### PR TITLE
docs: clean up Use Cases

### DIFF
--- a/docs/use-cases/jumpstart-idp.md
+++ b/docs/use-cases/jumpstart-idp.md
@@ -19,32 +19,26 @@ If you're already familiar with Garden and just want to get going, click any of 
 
 Navigate to [Examples](#examples) for a selection of pre-configured stacks you can use to quickly explore relevant features.
 
-## Prerequisites
+## Requirements
 
-Before you proceed, make sure you have gone through the following steps:
-
-- [Installing Garden](../getting-started/installation.md)
-- [Set up a local Kubernetes cluster](../k8s-plugins/local-k8s/configure-provider.md) _or_ use our [Ephemeral Clusters](../k8s-plugins/ephemeral-k8s/configure-provider.md)
-- If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../guides/migrating-from-docker-compose.md) guide
+- [Garden installed](../getting-started/installation.md)
+- [A local Kubernetes cluster](../k8s-plugins/local-k8s/configure-provider.md), [remote](../k8s-plugins/remote-k8s/configure-provider.md), _or_ [Ephemeral Cluster](../k8s-plugins/ephemeral-k8s/configure-provider.md) set up
 
 Setting up a remote Kubernetes environment for local development creates a developer namespace in a remote cluster. This namespace acts as a sandbox for your application, allowing you to test and develop without affecting other applications or services in the cluster.
 
-## Next steps
+## Resources
 
 Now that you've installed Garden and have a cluster configured, you'll progressively add features to make Garden the right fit for you.
 
 - Pull in any number of remote repositories to collaborate across teams by setting up [Remote Sources](../advanced/using-remote-sources.md)
 - Use [Config Templates](../using-garden/config-templates.md) to vend development environments to all your developers
-
-## Troubleshooting
-
-- Visit [Troubleshooting](../misc/troubleshooting.md)
+- If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../guides/migrating-from-docker-compose.md) guide
 
 {% hint style="info" %}
-If you encounter any issues or bugs 🐛 in this seed, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
+If you encounter any issues or bugs 🐛, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
 {% endhint %}
 
-## Additional resources
+## Further Reading
 
 - [How Garden Works](../overview/how-garden-works.md)
 - [Configuration Overview](../using-garden/configuration-overview.md)

--- a/docs/use-cases/jumpstart-idp.md
+++ b/docs/use-cases/jumpstart-idp.md
@@ -19,23 +19,14 @@ If you're already familiar with Garden and just want to get going, click any of 
 
 Navigate to [Examples](#examples) for a selection of pre-configured stacks you can use to quickly explore relevant features.
 
-## Requirements
-
-- [Garden installed](../getting-started/installation.md)
-- [A local Kubernetes cluster](../k8s-plugins/local-k8s/configure-provider.md), [remote](../k8s-plugins/remote-k8s/configure-provider.md), _or_ [Ephemeral Cluster](../k8s-plugins/ephemeral-k8s/configure-provider.md) set up
-
-Setting up a remote Kubernetes environment for local development creates a developer namespace in a remote cluster. This namespace acts as a sandbox for your application, allowing you to test and develop without affecting other applications or services in the cluster.
-
 ## Resources
-
-Now that you've installed Garden and have a cluster configured, you'll progressively add features to make Garden the right fit for you.
 
 - Pull in any number of remote repositories to collaborate across teams by setting up [Remote Sources](../advanced/using-remote-sources.md)
 - Use [Config Templates](../using-garden/config-templates.md) to vend development environments to all your developers
 - If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../guides/migrating-from-docker-compose.md) guide
 
 {% hint style="info" %}
-If you encounter any issues or bugs 🐛, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
+Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
 {% endhint %}
 
 ## Further Reading

--- a/docs/use-cases/local-development-remote-clusters.md
+++ b/docs/use-cases/local-development-remote-clusters.md
@@ -24,32 +24,27 @@ If you're already familiar with Garden and just want to get going, click any of 
 
 Navigate to [Examples](#examples) for a selection of pre-configured stacks you can use to quickly explore relevant features.
 
-## Prerequisites
+## Requirements
 
-Before you proceed, make sure you have gone through the following steps:
-
-- [Installing Garden](../getting-started/installation.md)
-- [Set up a local Kubernetes cluster](../k8s-plugins/local-k8s/configure-provider.md) _or_ use our [Ephemeral Clusters](../k8s-plugins/ephemeral-k8s/configure-provider.md)
-- If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../guides/migrating-from-docker-compose.md) guide
+- [Garden installed](../getting-started/installation.md)
+- [Remote Kubernetes cluster configured](../k8s-plugins/remote-k8s/configure-provider.md) _or_ use our [Ephemeral Clusters](../k8s-plugins/ephemeral-k8s/configure-provider.md)
 
 Setting up a remote Kubernetes environment for local development creates a developer namespace in a remote cluster. This namespace acts as a sandbox for your application, allowing you to test and develop without affecting other applications or services in the cluster.
 
-## Next steps
+## Resources
 
 Now that you've installed Garden and have a cluster configured, you'll progressively add features to make Garden the right fit for you.
 
 - Build inside a powerful Kubernetes cluster with [In-Cluster Building](../k8s-plugins/guides/in-cluster-building.md)
 - Set up hot reloading for a frustration-free inner loop with [Code Synchronization](../guides/code-synchronization.md)
-
-## Troubleshooting
-
-- Visit [Troubleshooting](../misc/troubleshooting.md)
+- If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../guides/migrating-from-docker-compose.md) guide
+- Go developers may be interested in our [pre-configured template](https://docs.garden.io/garden-seeds/languages/go) that makes use of the Helm package manager and Garden's Code  to spawn a ready-to-code environment
 
 {% hint style="info" %}
-If you encounter any issues or bugs 🐛 in this seed, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
+If you encounter any issues or bugs 🐛, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
 {% endhint %}
 
-## Additional resources
+## Further Reading
 
 - [How Garden Works](../overview/how-garden-works.md)
 - [Configuration Overview](../using-garden/configuration-overview.md)

--- a/docs/use-cases/local-development-remote-clusters.md
+++ b/docs/use-cases/local-development-remote-clusters.md
@@ -7,7 +7,7 @@ order: 1
 
 With other tools the complexity of replicating a production-like environment on your local machine is a developer experience that suffers from compromise. Setting up a remote Kubernetes cluster has meant a tangle of scripts, tools, and proxies that mock out the pains of running a remote cluster to make it feel like home.
 
-Garden's first-class support for remote clusters eliminates the setup cost of manually setting up remote image builders, developer namespaces, and hot reload with short stanzas of YAML you can reuse and share among teammates. Garden supports complex topologies across any number of local or remote Kubernetes clusters or environments. With Garden for local development you can:
+Garden's first-class support for remote clusters eliminates the setup cost of manually setting up remote image builders, developer namespaces, and hot reload with short stanzas of YAML you can reuse and share among teammates. Garden supports complex topologies across any number of local or remote Kubernetes clusters or environments.
 
 Garden creates a developer namespace inside a remote Kubernetes cluster that looks and feels just as if it was a local cluster. This means you can develop and test your applications in an environment that closely mimics your production environment, leading to fewer surprises when you deploy your application.
 
@@ -24,24 +24,14 @@ If you're already familiar with Garden and just want to get going, click any of 
 
 Navigate to [Examples](#examples) for a selection of pre-configured stacks you can use to quickly explore relevant features.
 
-## Requirements
-
-- [Garden installed](../getting-started/installation.md)
-- [Remote Kubernetes cluster configured](../k8s-plugins/remote-k8s/configure-provider.md) _or_ use our [Ephemeral Clusters](../k8s-plugins/ephemeral-k8s/configure-provider.md)
-
-Setting up a remote Kubernetes environment for local development creates a developer namespace in a remote cluster. This namespace acts as a sandbox for your application, allowing you to test and develop without affecting other applications or services in the cluster.
-
 ## Resources
-
-Now that you've installed Garden and have a cluster configured, you'll progressively add features to make Garden the right fit for you.
 
 - Build inside a powerful Kubernetes cluster with [In-Cluster Building](../k8s-plugins/guides/in-cluster-building.md)
 - Set up hot reloading for a frustration-free inner loop with [Code Synchronization](../guides/code-synchronization.md)
 - If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../guides/migrating-from-docker-compose.md) guide
-- Go developers may be interested in our [pre-configured template](https://docs.garden.io/garden-seeds/languages/go) that makes use of the Helm package manager and Garden's Code  to spawn a ready-to-code environment
 
 {% hint style="info" %}
-If you encounter any issues or bugs 🐛, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
+Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
 {% endhint %}
 
 ## Further Reading

--- a/docs/use-cases/portable-ci-pipelines.md
+++ b/docs/use-cases/portable-ci-pipelines.md
@@ -24,17 +24,14 @@ Simply by adding extra environments to your [Garden project](../using-garden/pro
 
 If you're already familiar with Garden and just want to get going, click any of the links above to set up your features.
 
-## Requirements
-
-- Your CI provider should be configured to run Garden. If you're using GitHub, you may be interested in our [Garden GitHub Action](https://github.com/marketplace/actions/garden-action).
-
 ## Resources
 
 - Garden's [Quickstart](../getting-started/quickstart.md)
 - [Using Garden in CircleCI](../guides/using-garden-in-circleci.md)
+- Garden's official [GitHub Action](https://github.com/marketplace/actions/garden-action).
 
 {% hint style="info" %}
-If you encounter any issues or bugs 🐛, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
+Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
 {% endhint %}
 
 ## Further Reading

--- a/docs/use-cases/portable-ci-pipelines.md
+++ b/docs/use-cases/portable-ci-pipelines.md
@@ -24,15 +24,20 @@ Simply by adding extra environments to your [Garden project](../using-garden/pro
 
 If you're already familiar with Garden and just want to get going, click any of the links above to set up your features.
 
-## Next Steps
+## Requirements
 
-- Visit our [quickstart](../getting-started/quickstart.md)
+- Your CI provider should be configured to run Garden. If you're using GitHub, you may be interested in our [Garden GitHub Action](https://github.com/marketplace/actions/garden-action).
+
+## Resources
+
+- Garden's [Quickstart](../getting-started/quickstart.md)
+- [Using Garden in CircleCI](../guides/using-garden-in-circleci.md)
 
 {% hint style="info" %}
-If you encounter any issues or bugs 🐛 in this seed, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
+If you encounter any issues or bugs 🐛, don't hesitate to join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
 {% endhint %}
 
-## Additional resources
+## Further Reading
 
 - [How Garden Works](../overview/how-garden-works.md)
 - [Configuration Overview](../using-garden/configuration-overview.md)


### PR DESCRIPTION
Until we build out learning paths centered around use cases, it's best the docs are somewhat hermetic in their approach. This changes the docs to be less tutorial and more resource page for people looking to make use of them.