### PR TITLE
improvement(dashboard): better warning logs

### DIFF
--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -23,7 +23,7 @@ import { globalDisplayOptions } from "./params.js"
 import { GardenError, ParameterError, RuntimeError, toGardenError } from "../exceptions.js"
 import { getPackageVersion, removeSlice } from "../util/util.js"
 import type { Log } from "../logger/log-entry.js"
-import { STATIC_DIR, gardenEnv, ERROR_LOG_FILENAME } from "../constants.js"
+import { STATIC_DIR, gardenEnv, ERROR_LOG_FILENAME, DOCS_BASE_URL } from "../constants.js"
 import { printWarningMessage } from "../logger/util.js"
 import type { GlobalConfigStore } from "../config-store/global.js"
 import { got } from "../util/http.js"
@@ -562,4 +562,14 @@ export function renderCommandErrors(logger: Logger, errors: Error[], log?: Log) 
   if (logger.getWriters().file.length > 0) {
     errorLog.info(`\nSee .garden/${ERROR_LOG_FILENAME} for detailed error message`)
   }
+}
+
+export function getDashboardInfoMsg() {
+  return styles.success(deline`
+    🌿 Log in with ${styles.command(
+      "garden login"
+    )} to explore logs, past commands, and your dependency graph in the Garden dashboard.
+
+    Learn more at: ${styles.underline(`${DOCS_BASE_URL}/using-garden/dashboard`)}\n
+  `)
 }

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -24,6 +24,8 @@ import type { Garden } from "../garden.js"
 import type { GardenPluginReference } from "../plugin/plugin.js"
 import { CommandError, ParameterError, isEAddrInUseException, isErrnoException } from "../exceptions.js"
 import { styles } from "../logger/styles.js"
+import { getDashboardInfoMsg } from "../cli/helpers.js"
+import { DEFAULT_GARDEN_CLOUD_DOMAIN } from "../constants.js"
 
 export const defaultServerPort = 9777
 
@@ -156,16 +158,14 @@ export class ServeCommand<
 
     try {
       const cloudApi = await manager.getCloudApi({ log, cloudDomain, globalConfigStore: garden.globalConfigStore })
+      const isLoggedIn = !!cloudApi
+      const isCommunityEdition = cloudDomain === DEFAULT_GARDEN_CLOUD_DOMAIN
 
-      if (!cloudApi) {
+      if (!isLoggedIn && isCommunityEdition) {
         await garden.emitWarning({
           key: "web-app",
           log,
-          message: styles.success(
-            `🌿 Explore logs, past commands, and your dependency graph in the Garden dashboard. Log in with ${styles.command(
-              "garden login"
-            )}.`
-          ),
+          message: getDashboardInfoMsg(),
         })
       }
 
@@ -192,7 +192,7 @@ export class ServeCommand<
           if (session?.shortId) {
             const distroName = getCloudDistributionName(cloudDomain)
             const livePageUrl = cloudApi.getLivePageUrl({ shortId: session.shortId }).toString()
-            const msg = dedent`${printEmoji("🌸", log)}Connected to ${distroName} ${printEmoji("🌸", log)}
+            const msg = dedent`\n${printEmoji("🌸", log)}Connected to ${distroName} ${printEmoji("🌸", log)}
               Follow the link below to stream logs, run commands, and more from the Garden dashboard ${printEmoji(
                 "👇",
                 log

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -238,7 +238,7 @@ export class GardenServer extends EventEmitter {
         }
       } while (!serverStarted)
     }
-    this.log.info(`Garden server has successfully started at port ${styles.highlight(this.port.toString())}.\n`)
+    this.log.info(`Garden server has successfully started at port ${styles.highlight(this.port.toString())}\n`)
 
     const processRecord = await this.globalConfigStore.get("activeProcesses", String(process.pid))
 

--- a/core/src/util/cloud.ts
+++ b/core/src/util/cloud.ts
@@ -7,7 +7,7 @@
  */
 import { DEFAULT_GARDEN_CLOUD_DOMAIN } from "../constants.js"
 
-export type CloudDistroName = "Garden Dashboard" | "Garden Enterprise" | "Garden Cloud"
+export type CloudDistroName = "the Garden dashboard" | "Garden Enterprise" | "Garden Cloud"
 
 /**
  * Returns "Garden Cloud" if domain matches https://<some-subdomain>.app.garden,
@@ -17,7 +17,7 @@ export type CloudDistroName = "Garden Dashboard" | "Garden Enterprise" | "Garden
  */
 export function getCloudDistributionName(domain: string): CloudDistroName {
   if (domain === DEFAULT_GARDEN_CLOUD_DOMAIN) {
-    return "Garden Dashboard"
+    return "the Garden dashboard"
   }
 
   // TODO: consider using URL object instead.
@@ -31,7 +31,7 @@ export function getCloudDistributionName(domain: string): CloudDistroName {
 export type CloudLogSectionName = "garden-dashboard" | "garden-cloud" | "garden-enterprise"
 
 export function getCloudLogSectionName(distroName: CloudDistroName): CloudLogSectionName {
-  if (distroName === "Garden Dashboard") {
+  if (distroName === "the Garden dashboard") {
     return "garden-dashboard"
   } else if (distroName === "Garden Cloud") {
     return "garden-cloud"

--- a/core/test/unit/src/commands/login.ts
+++ b/core/test/unit/src/commands/login.ts
@@ -62,7 +62,7 @@ describe("LoginCommand", () => {
     }
     const command = new LoginCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -88,7 +88,7 @@ describe("LoginCommand", () => {
     }
     const command = new LoginCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -115,7 +115,7 @@ describe("LoginCommand", () => {
 
     const command = new LoginCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -146,7 +146,7 @@ describe("LoginCommand", () => {
     // NOTE: if we don't use makeDummyGarden it would try to fully resolve the
     // secrets which are not available unless we mock the cloud API instance.
     const garden = await makeDummyGarden(getDataDir("test-projects", "login", "secret-in-project-variables"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -205,7 +205,7 @@ describe("LoginCommand", () => {
 
     const command = new LoginCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -236,7 +236,7 @@ describe("LoginCommand", () => {
 
     const command = new LoginCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -301,7 +301,7 @@ describe("LoginCommand", () => {
 
     // this is a bit of a workaround to run outside of the garden root dir
     const garden = await makeDummyGarden(getDataDir("..", "..", "..", ".."), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -338,7 +338,7 @@ describe("LoginCommand", () => {
     it("should be a no-op if the user has a valid auth token in the environment", async () => {
       const command = new LoginCommand()
       const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-        noEnterprise: false,
+        skipCloudConnect: false,
         commandInfo: { name: "foo", args: {}, opts: {} },
         globalConfigStore,
       })
@@ -355,7 +355,7 @@ describe("LoginCommand", () => {
     it("should throw if the user has an invalid auth token in the environment", async () => {
       const command = new LoginCommand()
       const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-        noEnterprise: false,
+        skipCloudConnect: false,
         commandInfo: { name: "foo", args: {}, opts: {} },
         globalConfigStore,
       })
@@ -388,7 +388,7 @@ describe("LoginCommand", () => {
       }
       const command = new LoginCommand()
       const garden = await makeTestGarden(getDataDir("test-projects", "login", "missing-domain"), {
-        noEnterprise: false,
+        skipCloudConnect: false,
         commandInfo: { name: "foo", args: {}, opts: {} },
         globalConfigStore,
       })
@@ -418,7 +418,7 @@ describe("LoginCommand", () => {
       }
       const command = new LoginCommand()
       const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain"), {
-        noEnterprise: false,
+        skipCloudConnect: false,
         commandInfo: { name: "foo", args: {}, opts: {} },
         globalConfigStore,
       })

--- a/core/test/unit/src/commands/logout.ts
+++ b/core/test/unit/src/commands/logout.ts
@@ -56,7 +56,7 @@ describe("LogoutCommand", () => {
 
     const command = new LogOutCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -95,7 +95,7 @@ describe("LogoutCommand", () => {
 
     const command = new LogOutCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "missing-domain"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
     })
 
@@ -126,7 +126,7 @@ describe("LogoutCommand", () => {
   it("should be a no-op if the user is already logged out", async () => {
     const command = new LogOutCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -147,7 +147,7 @@ describe("LogoutCommand", () => {
 
     const command = new LogOutCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -187,7 +187,7 @@ describe("LogoutCommand", () => {
 
     const command = new LogOutCommand()
     const garden = await makeTestGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })
@@ -245,7 +245,7 @@ describe("LogoutCommand", () => {
 
     // this is a bit of a workaround to run outside of the garden root dir
     const garden = await makeDummyGarden(getDataDir("..", "..", "..", ".."), {
-      noEnterprise: false,
+      skipCloudConnect: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
       globalConfigStore,
     })

--- a/core/test/unit/src/commands/tools.ts
+++ b/core/test/unit/src/commands/tools.ts
@@ -221,7 +221,7 @@ describe("ToolsCommand", () => {
 
   it("should run a tool by name when run outside of a project", async () => {
     const _garden: any = await makeDummyGarden(tmpDir.path, {
-      noEnterprise: true,
+      skipCloudConnect: true,
       commandInfo: { name: "foo", args: {}, opts: {} },
     })
     _garden.registeredPlugins = [pluginA, pluginB]

--- a/core/test/unit/src/util/cloud.ts
+++ b/core/test/unit/src/util/cloud.ts
@@ -14,8 +14,8 @@ import { expect } from "chai"
 describe("garden-cloud", () => {
   describe("getCloudDistributionName", () => {
     context(`when domain name is ${DEFAULT_GARDEN_CLOUD_DOMAIN}`, () => {
-      it(`returns "Garden Dashboard" for ${DEFAULT_GARDEN_CLOUD_DOMAIN}`, () => {
-        expect(getCloudDistributionName(DEFAULT_GARDEN_CLOUD_DOMAIN)).to.eql("Garden Dashboard")
+      it(`returns "the Garden dashboard" for ${DEFAULT_GARDEN_CLOUD_DOMAIN}`, () => {
+        expect(getCloudDistributionName(DEFAULT_GARDEN_CLOUD_DOMAIN)).to.eql("the Garden dashboard")
       })
     })
 
@@ -41,8 +41,8 @@ describe("garden-cloud", () => {
   })
 
   describe("getCloudLogSectionName", () => {
-    it(`returns "garden-dashboard" for "Garden Dashboard"`, () => {
-      expect(getCloudLogSectionName("Garden Dashboard")).to.eql("garden-dashboard")
+    it(`returns "garden-dashboard" for "the Garden dashboard"`, () => {
+      expect(getCloudLogSectionName("the Garden dashboard")).to.eql("garden-dashboard")
     })
 
     it(`returns "garden-cloud" for "Garden Cloud"`, () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commit adds a message about the dashboard to all Garden commands. Previously we only showed it for the 'dev' command.

The message can be disabled.

It also consistently logs a warning if a user is logged in across all cloud distros.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
