### PR TITLE
improvement(mutagen): use faux SSH command to use original Mutagen

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -55,6 +55,8 @@ export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://app.garden.io"
 
 export const DEFAULT_BROWSER_DIVIDER_WIDTH = 80
 
+export const GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME = "GARDEN_ENABLE_NEW_SYNC"
+
 /**
  * Environment variables, with defaults where appropriate.
  *
@@ -100,5 +102,5 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  GARDEN_ENABLE_NEW_SYNC: env.get("GARDEN_ENABLE_NEW_SYNC").required(false).default("false").asBool(),
+  GARDEN_ENABLE_NEW_SYNC: env.get(GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME).required(false).default("false").asBool(),
 }

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -100,5 +100,5 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  GARDEN_ENABLE_LEGACY_SYNC: env.get("GARDEN_ENABLE_LEGACY_SYNC").required(false).default("true").asBool(),
+  GARDEN_ENABLE_LEGACY_SYNC: env.get("GARDEN_ENABLE_LEGACY_SYNC").required(false).default("false").asBool(),
 }

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -100,5 +100,5 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  GARDEN_ENABLE_LEGACY_SYNC: env.get("GARDEN_ENABLE_LEGACY_SYNC").required(false).default("false").asBool(),
+  GARDEN_ENABLE_NEW_SYNC: env.get("GARDEN_ENABLE_NEW_SYNC").required(false).default("false").asBool(),
 }

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -55,8 +55,6 @@ export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://app.garden.io"
 
 export const DEFAULT_BROWSER_DIVIDER_WIDTH = 80
 
-export const GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME = "GARDEN_ENABLE_NEW_SYNC"
-
 /**
  * Environment variables, with defaults where appropriate.
  *
@@ -102,5 +100,5 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  GARDEN_ENABLE_NEW_SYNC: env.get(GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME).required(false).default("false").asBool(),
+  GARDEN_ENABLE_NEW_SYNC: env.get("GARDEN_ENABLE_NEW_SYNC").required(false).default("false").asBool(),
 }

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -100,5 +100,5 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  MUTAGEN_SSH_PATH: env.get("MUTAGEN_SSH_PATH").required(false).asString(),
+  GARDEN_ENABLE_LEGACY_SYNC: env.get("GARDEN_ENABLE_LEGACY_SYNC").required(false).default("true").asBool(),
 }

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -100,4 +100,5 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
+  MUTAGEN_SSH_PATH: env.get("MUTAGEN_SSH_PATH").required(false).asString(),
 }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -866,20 +866,25 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
   return parsed
 }
 
-export const mutagenVersion = "0.15.0"
+export const isNativeMutagenEnabled = () => !!gardenEnv.MUTAGEN_SSH_PATH
+
+const mutagenVersionLegacy = "0.15.0"
+const mutagenVersionNative = "0.15.0"
+
+export const mutagenVersion = isNativeMutagenEnabled() ? mutagenVersionNative : mutagenVersionLegacy
 
 export function mutagenCliSpecLegacy(): PluginToolSpec {
   return {
     name: "mutagen",
-    version: mutagenVersion,
-    description: `The mutagen synchronization tool, v${mutagenVersion}`,
+    version: mutagenVersionLegacy,
+    description: `The mutagen synchronization tool, v${mutagenVersionLegacy}`,
     type: "binary",
     _includeInGardenImage: false,
     builds: [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
         sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
         extract: {
           format: "tar",
@@ -889,7 +894,7 @@ export function mutagenCliSpecLegacy(): PluginToolSpec {
       {
         platform: "darwin",
         architecture: "arm64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_darwin_arm64_v${mutagenVersionLegacy}.tar.gz`,
         sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
         extract: {
           format: "tar",
@@ -899,7 +904,7 @@ export function mutagenCliSpecLegacy(): PluginToolSpec {
       {
         platform: "linux",
         architecture: "amd64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_linux_amd64_v${mutagenVersionLegacy}.tar.gz`,
         sha256: "e8c0708258ddd6d574f1b8f514fb214f9ab5d82aed38dd8db49ec10956e5063a",
         extract: {
           format: "tar",
@@ -909,7 +914,7 @@ export function mutagenCliSpecLegacy(): PluginToolSpec {
       {
         platform: "linux",
         architecture: "arm64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_linux_arm64_v${mutagenVersionLegacy}.tar.gz`,
         sha256: "80f108fc316223d8c3d1a48def18192e666b33a334b75aa3ebcc95938b774e64",
         extract: {
           format: "tar",
@@ -919,7 +924,7 @@ export function mutagenCliSpecLegacy(): PluginToolSpec {
       {
         platform: "windows",
         architecture: "amd64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_windows_amd64_v${mutagenVersion}.zip`,
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_windows_amd64_v${mutagenVersionLegacy}.zip`,
         sha256: "fdae26b43cc418b2525a937a1613bba36e74ea3dde4dbec3512a9abd004def95",
         extract: {
           format: "zip",
@@ -933,15 +938,15 @@ export function mutagenCliSpecLegacy(): PluginToolSpec {
 export function mutagenCliSpecNative(): PluginToolSpec {
   return {
     name: "mutagen",
-    version: mutagenVersion,
-    description: `The mutagen synchronization tool, v${mutagenVersion}`,
+    version: mutagenVersionNative,
+    description: `The mutagen synchronization tool, v${mutagenVersionNative}`,
     type: "binary",
     _includeInGardenImage: false,
     builds: [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_darwin_amd64_v${mutagenVersionNative}.tar.gz`,
         sha256: "7ff3fae37c90f050db283f557d4370546691e4d5ec2f6dd10fbcbe6a20ba0154",
         extract: {
           format: "tar",
@@ -951,7 +956,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "darwin",
         architecture: "arm64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_darwin_arm64_v${mutagenVersionNative}.tar.gz`,
         sha256: "2ab938830c9a1a7d5b3289826f9765654ca465b7a089b74df407071bc5f8b7b0",
         extract: {
           format: "tar",
@@ -961,7 +966,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "linux",
         architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_linux_amd64_v${mutagenVersionNative}.tar.gz`,
         sha256: "dd4a0b6fa8b36232108075d2c740d563ec945d8e872c749ad027fa1b241a8b07",
         extract: {
           format: "tar",
@@ -971,7 +976,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "linux",
         architecture: "arm64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_linux_arm64_v${mutagenVersionNative}.tar.gz`,
         sha256: "137274f443aaf6bfb9c9170cdfa91d9ea88c5903e8c79b445870881ef678b4e8",
         extract: {
           format: "tar",
@@ -981,7 +986,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "windows",
         architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_windows_amd64_v${mutagenVersionNative}.zip`,
         sha256: "8b502693add563a7dd7973f043301b25ef34bd3846619dffce3ba47f64c15a0a",
         extract: {
           format: "zip",
@@ -992,7 +997,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
   }
 }
 
-export const mutagenCliSpec = !!gardenEnv.MUTAGEN_SSH_PATH ? mutagenCliSpecNative() : mutagenCliSpecLegacy()
+export const mutagenCliSpec = isNativeMutagenEnabled() ? mutagenCliSpecNative() : mutagenCliSpecLegacy()
 
 export const mutagenCli = new PluginTool(mutagenCliSpec)
 

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -542,6 +542,7 @@ export class Mutagen {
                   "ps -ef | grep 'mutagen daemon run'"
                 )}`
               )
+              throw err
             }
           }
         },

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -30,6 +30,7 @@ import { registerCleanupFunction, sleep } from "./util/util.js"
 import type { OctalPermissionMask } from "./plugins/kubernetes/types.js"
 import { styles } from "./logger/styles.js"
 import { dirname } from "node:path"
+import { emitNonRepeatableWarning } from "./warnings.js"
 
 const { mkdirp, pathExists } = fsExtra
 
@@ -1076,6 +1077,12 @@ async function getMutagenSshPath(log: Log): Promise<string | undefined> {
     return undefined
   }
 
+  const warnMessage = `This version of Garden uses a new file syncing machinery.
+  All running Mutagen processes (syncs, Garden sync monitors and Mutagen daemon) must be stopped before using the new machinery!!!
+  Please, stop all the Mutagen processes and try again if you get any issues.
+  In case of other issues, use GARDEN_ENABLE_LEGACY_SYNC=true env variable to fallback to the old machinery.`
+
+  emitNonRepeatableWarning(log, warnMessage)
   const fauxSshToolPath = await mutagenFauxSsh.ensurePath(log)
   // This must be the dir containing the faux SSH binary,
   // not the full path that includes the binary name

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -1078,9 +1078,8 @@ async function getMutagenSshPath(log: Log): Promise<string | undefined> {
   }
 
   const warnMessage = `This version of Garden uses a new file syncing machinery.
-  All running Mutagen processes (syncs, Garden sync monitors and Mutagen daemon) must be stopped before using the new machinery!!!
-  Please, stop all the Mutagen processes and try again if you get any issues.
-  In case of other issues, use GARDEN_ENABLE_LEGACY_SYNC=true env variable to fallback to the old machinery.`
+  All running syncs must be stopped before using the new machinery.
+  Use GARDEN_ENABLE_LEGACY_SYNC=true env variable to fallback to the old machinery.`
 
   emitNonRepeatableWarning(log, warnMessage)
   const fauxSshToolPath = await mutagenFauxSsh.ensurePath(log)

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -1079,8 +1079,9 @@ async function getMutagenSshPath(log: Log): Promise<string | undefined> {
     return undefined
   }
 
-  const warnMessage = `This version of Garden uses a new file syncing machinery.
-  All running syncs must be stopped before using the new machinery.
+  const warnMessage = `Starting from version 0.13.25, Garden uses a new file syncing machinery.
+  A reboot is required to make the syncing work properly.
+  Please, reboot you machine if you have updated from version 0.13.24 or earlier.
   Use GARDEN_ENABLE_LEGACY_SYNC=true env variable to fallback to the old machinery.`
 
   emitNonRepeatableWarning(log, warnMessage)

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -213,6 +213,7 @@ class _MutagenMonitor extends TypedEventEmitter<MonitorEvents> {
       const proc = respawn(mutagenOpts, {
         cwd: dataDir,
         name: "mutagen",
+        // TODO: Add MUTAGEN_SSH_PATH with Garden-provided faux SSH
         env: getMutagenEnv({ dataDir, logLevel: "debug" }),
         maxRestarts,
         sleep: 3000,
@@ -872,8 +873,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
-      sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
+      sha256: "7ff3fae37c90f050db283f557d4370546691e4d5ec2f6dd10fbcbe6a20ba0154",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -882,8 +883,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "arm64",
-      url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
-      sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
+      sha256: "2ab938830c9a1a7d5b3289826f9765654ca465b7a089b74df407071bc5f8b7b0",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -892,8 +893,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
-      sha256: "e8c0708258ddd6d574f1b8f514fb214f9ab5d82aed38dd8db49ec10956e5063a",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
+      sha256: "dd4a0b6fa8b36232108075d2c740d563ec945d8e872c749ad027fa1b241a8b07",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -902,8 +903,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "arm64",
-      url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
-      sha256: "80f108fc316223d8c3d1a48def18192e666b33a334b75aa3ebcc95938b774e64",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
+      sha256: "137274f443aaf6bfb9c9170cdfa91d9ea88c5903e8c79b445870881ef678b4e8",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -912,8 +913,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_windows_amd64_v${mutagenVersion}.zip`,
-      sha256: "fdae26b43cc418b2525a937a1613bba36e74ea3dde4dbec3512a9abd004def95",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
+      sha256: "8b502693add563a7dd7973f043301b25ef34bd3846619dffce3ba47f64c15a0a",
       extract: {
         format: "zip",
         targetPath: "mutagen.exe",

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -16,7 +16,7 @@ import pRetry from "p-retry"
 import { join } from "path"
 import respawn from "respawn"
 import split2 from "split2"
-import { GARDEN_GLOBAL_PATH, MUTAGEN_DIR_NAME } from "./constants.js"
+import { GARDEN_GLOBAL_PATH, gardenEnv, MUTAGEN_DIR_NAME } from "./constants.js"
 import { ChildProcessError, GardenError } from "./exceptions.js"
 import pMemoize from "./lib/p-memoize.js"
 import type { Log } from "./logger/log-entry.js"
@@ -213,8 +213,7 @@ class _MutagenMonitor extends TypedEventEmitter<MonitorEvents> {
       const proc = respawn(mutagenOpts, {
         cwd: dataDir,
         name: "mutagen",
-        // TODO: Add MUTAGEN_SSH_PATH with Garden-provided faux SSH
-        env: getMutagenEnv({ dataDir, logLevel: "debug" }),
+        env: getMutagenEnv({ dataDir, logLevel: "debug", sshPath: gardenEnv.MUTAGEN_SSH_PATH }),
         maxRestarts,
         sleep: 3000,
         kill: 500,
@@ -816,18 +815,24 @@ export function getMutagenDataDir({ ctx, log }: MutagenDaemonParams) {
 type MutagenEnv = {
   MUTAGEN_DATA_DIRECTORY: string
   MUTAGEN_LOG_LEVEL?: string
+  MUTAGEN_SSH_PATH?: string
 }
 
 type MutagenEnvValues = {
   dataDir: string
   logLevel?: string
+  sshPath?: string
 }
 
-export function getMutagenEnv({ dataDir, logLevel }: MutagenEnvValues): MutagenEnv {
-  const requiredEnv = { MUTAGEN_DATA_DIRECTORY: dataDir }
-  const optionalEnv = !!logLevel ? { MUTAGEN_LOG_LEVEL: logLevel } : {}
-
-  return { ...requiredEnv, ...optionalEnv }
+export function getMutagenEnv({ dataDir, logLevel, sshPath }: MutagenEnvValues): MutagenEnv {
+  const env: MutagenEnv = { MUTAGEN_DATA_DIRECTORY: dataDir }
+  if (!!logLevel) {
+    env.MUTAGEN_LOG_LEVEL = logLevel
+  }
+  if (!!sshPath) {
+    env.MUTAGEN_SSH_PATH = sshPath
+  }
+  return env
 }
 
 export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
@@ -863,65 +868,131 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
 
 export const mutagenVersion = "0.15.0"
 
-export const mutagenCliSpec: PluginToolSpec = {
-  name: "mutagen",
-  version: mutagenVersion,
-  description: `The mutagen synchronization tool, v${mutagenVersion}`,
-  type: "binary",
-  _includeInGardenImage: false,
-  builds: [
-    {
-      platform: "darwin",
-      architecture: "amd64",
-      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
-      sha256: "7ff3fae37c90f050db283f557d4370546691e4d5ec2f6dd10fbcbe6a20ba0154",
-      extract: {
-        format: "tar",
-        targetPath: "mutagen",
+export function mutagenCliSpecLegacy(): PluginToolSpec {
+  return {
+    name: "mutagen",
+    version: mutagenVersion,
+    description: `The mutagen synchronization tool, v${mutagenVersion}`,
+    type: "binary",
+    _includeInGardenImage: false,
+    builds: [
+      {
+        platform: "darwin",
+        architecture: "amd64",
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
+        sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
       },
-    },
-    {
-      platform: "darwin",
-      architecture: "arm64",
-      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
-      sha256: "2ab938830c9a1a7d5b3289826f9765654ca465b7a089b74df407071bc5f8b7b0",
-      extract: {
-        format: "tar",
-        targetPath: "mutagen",
+      {
+        platform: "darwin",
+        architecture: "arm64",
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
+        sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
       },
-    },
-    {
-      platform: "linux",
-      architecture: "amd64",
-      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
-      sha256: "dd4a0b6fa8b36232108075d2c740d563ec945d8e872c749ad027fa1b241a8b07",
-      extract: {
-        format: "tar",
-        targetPath: "mutagen",
+      {
+        platform: "linux",
+        architecture: "amd64",
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
+        sha256: "e8c0708258ddd6d574f1b8f514fb214f9ab5d82aed38dd8db49ec10956e5063a",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
       },
-    },
-    {
-      platform: "linux",
-      architecture: "arm64",
-      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
-      sha256: "137274f443aaf6bfb9c9170cdfa91d9ea88c5903e8c79b445870881ef678b4e8",
-      extract: {
-        format: "tar",
-        targetPath: "mutagen",
+      {
+        platform: "linux",
+        architecture: "arm64",
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
+        sha256: "80f108fc316223d8c3d1a48def18192e666b33a334b75aa3ebcc95938b774e64",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
       },
-    },
-    {
-      platform: "windows",
-      architecture: "amd64",
-      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
-      sha256: "8b502693add563a7dd7973f043301b25ef34bd3846619dffce3ba47f64c15a0a",
-      extract: {
-        format: "zip",
-        targetPath: "mutagen.exe",
+      {
+        platform: "windows",
+        architecture: "amd64",
+        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersion}-garden-1/mutagen_windows_amd64_v${mutagenVersion}.zip`,
+        sha256: "fdae26b43cc418b2525a937a1613bba36e74ea3dde4dbec3512a9abd004def95",
+        extract: {
+          format: "zip",
+          targetPath: "mutagen.exe",
+        },
       },
-    },
-  ],
+    ],
+  }
 }
+
+export function mutagenCliSpecNative(): PluginToolSpec {
+  return {
+    name: "mutagen",
+    version: mutagenVersion,
+    description: `The mutagen synchronization tool, v${mutagenVersion}`,
+    type: "binary",
+    _includeInGardenImage: false,
+    builds: [
+      {
+        platform: "darwin",
+        architecture: "amd64",
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
+        sha256: "7ff3fae37c90f050db283f557d4370546691e4d5ec2f6dd10fbcbe6a20ba0154",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
+      },
+      {
+        platform: "darwin",
+        architecture: "arm64",
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
+        sha256: "2ab938830c9a1a7d5b3289826f9765654ca465b7a089b74df407071bc5f8b7b0",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "amd64",
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
+        sha256: "dd4a0b6fa8b36232108075d2c740d563ec945d8e872c749ad027fa1b241a8b07",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "arm64",
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
+        sha256: "137274f443aaf6bfb9c9170cdfa91d9ea88c5903e8c79b445870881ef678b4e8",
+        extract: {
+          format: "tar",
+          targetPath: "mutagen",
+        },
+      },
+      {
+        platform: "windows",
+        architecture: "amd64",
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
+        sha256: "8b502693add563a7dd7973f043301b25ef34bd3846619dffce3ba47f64c15a0a",
+        extract: {
+          format: "zip",
+          targetPath: "mutagen.exe",
+        },
+      },
+    ],
+  }
+}
+
+export const mutagenCliSpec = !!gardenEnv.MUTAGEN_SSH_PATH ? mutagenCliSpecNative() : mutagenCliSpecLegacy()
 
 export const mutagenCli = new PluginTool(mutagenCliSpec)
 

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -872,12 +872,10 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
   return parsed
 }
 
-export const isNativeMutagenEnabled = () => !gardenEnv.GARDEN_ENABLE_LEGACY_SYNC
-
 const mutagenVersionLegacy = "0.15.0"
 const mutagenVersionNative = "0.15.0"
 
-export const mutagenVersion = isNativeMutagenEnabled() ? mutagenVersionNative : mutagenVersionLegacy
+export const mutagenVersion = gardenEnv.GARDEN_ENABLE_LEGACY_SYNC ? mutagenVersionLegacy : mutagenVersionNative
 
 export function mutagenCliSpecLegacy(): PluginToolSpec {
   return {
@@ -1003,7 +1001,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
   }
 }
 
-export const mutagenCliSpec = isNativeMutagenEnabled() ? mutagenCliSpecNative() : mutagenCliSpecLegacy()
+export const mutagenCliSpec = gardenEnv.GARDEN_ENABLE_LEGACY_SYNC ? mutagenCliSpecLegacy() : mutagenCliSpecNative()
 
 export const mutagenCli = new PluginTool(mutagenCliSpec)
 
@@ -1077,7 +1075,7 @@ export const mutagenFauxSsh = new PluginTool(mutagenFauxSshSpec)
  * (i.e. if {@code GARDEN_ENABLE_LEGACY_SYNC=true}) or {@code undefined} otherwise.
  */
 async function getMutagenSshPath(log: Log): Promise<string | undefined> {
-  if (!isNativeMutagenEnabled()) {
+  if (gardenEnv.GARDEN_ENABLE_LEGACY_SYNC) {
     return undefined
   }
 

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -35,6 +35,7 @@ import { registerCleanupFunction, sleep } from "./util/util.js"
 import type { OctalPermissionMask } from "./plugins/kubernetes/types.js"
 import { styles } from "./logger/styles.js"
 import { dirname } from "node:path"
+import { makeDocsLink } from "./docs/common.js"
 
 const { mkdirp, pathExists } = fsExtra
 
@@ -538,9 +539,11 @@ export class Mutagen {
 
             if (isMutagenForkError(err)) {
               log.warn(
-                `It looks like the syncing machinery was switched via the ${GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME} env variable. Please stop the currently running Mutagen daemons. Use this command to find the daemons: ${styles.command(
-                  "ps -ef | grep 'mutagen daemon run'"
-                )}`
+                dedent`
+                It looks like the underlying syncing machinery was switched via the ${GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME} env variable and the sync daemon needs to be restarted.
+                Please see our Troubleshooting docs for instructions on how to restart the daemon for your platform: ${styles.link(
+                  makeDocsLink("misc/troubleshooting#restarting-sync-daemon")
+                )}}`
               )
               throw err
             }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -16,12 +16,7 @@ import pRetry, { type FailedAttemptError } from "p-retry"
 import { join } from "path"
 import respawn from "respawn"
 import split2 from "split2"
-import {
-  GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME,
-  GARDEN_GLOBAL_PATH,
-  gardenEnv,
-  MUTAGEN_DIR_NAME,
-} from "./constants.js"
+import { GARDEN_GLOBAL_PATH, gardenEnv, MUTAGEN_DIR_NAME } from "./constants.js"
 import { ChildProcessError, GardenError } from "./exceptions.js"
 import pMemoize from "./lib/p-memoize.js"
 import type { Log } from "./logger/log-entry.js"
@@ -540,9 +535,9 @@ export class Mutagen {
             if (isMutagenForkError(err)) {
               log.warn(
                 dedent`
-                It looks like the underlying syncing machinery was switched via the ${GARDEN_ENABLE_NEW_SYNC_FEATURE_FLAG_NAME} env variable and the sync daemon needs to be restarted.
+                It looks like you've changed to a different version of the sync daemon and therefore the sync daemon needs to be restarted.
                 Please see our Troubleshooting docs for instructions on how to restart the daemon for your platform: ${styles.link(
-                  makeDocsLink("misc/troubleshooting#restarting-sync-daemon")
+                  makeDocsLink("guides/code-synchronization#restarting-sync-daemon")
                 )}}`
               )
               throw err

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -1001,6 +1001,69 @@ export const mutagenCliSpec = isNativeMutagenEnabled() ? mutagenCliSpecNative() 
 
 export const mutagenCli = new PluginTool(mutagenCliSpec)
 
+const mutagenFauxSshVersion = "v0.0.1"
+const mutagenFauxSshReleaseBaseUrl = "https://github.com/garden-io/mutagen-faux-ssh/releases/download/"
+
+export const mutagenFauxSshSpec: PluginToolSpec = {
+  name: "mutagen-faux-ssh",
+  version: mutagenFauxSshVersion,
+  description: "The faux SSH implementation to be used as SSH transport for Mutagen.",
+  type: "binary",
+  _includeInGardenImage: false,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url: `${mutagenFauxSshReleaseBaseUrl}/${mutagenFauxSshVersion}/mutagen-faux-ssh-${mutagenFauxSshVersion}-darwin-amd64.tar.gz`,
+      sha256: "2613c82c843ac5123c0fe380422781db9306862341ba94b76aa3c5c6268acf50",
+      extract: {
+        format: "tar",
+        targetPath: "ssh",
+      },
+    },
+    {
+      platform: "darwin",
+      architecture: "arm64",
+      url: `${mutagenFauxSshReleaseBaseUrl}/${mutagenFauxSshVersion}/mutagen-faux-ssh-${mutagenFauxSshVersion}-darwin-arm64.tar.gz`,
+      sha256: "914db58ebaf093e7494c83ea0c21156a23216c1ce08ccab27f9973f6aa4d5c4d",
+      extract: {
+        format: "tar",
+        targetPath: "ssh",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url: `${mutagenFauxSshReleaseBaseUrl}/${mutagenFauxSshVersion}/mutagen-faux-ssh-${mutagenFauxSshVersion}-linux-amd64.tar.gz`,
+      sha256: "16588f55e614d9ccb77c933463207cd023101bd7234b5d0eecff0e57a98dd7b0",
+      extract: {
+        format: "tar",
+        targetPath: "ssh",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "arm64",
+      url: `${mutagenFauxSshReleaseBaseUrl}/${mutagenFauxSshVersion}/mutagen-faux-ssh-${mutagenFauxSshVersion}-linux-arm64.tar.gz`,
+      sha256: "c7645e615efc9e5139f8a281abb9acae61ea2ce2084ea25aa438438da3481167",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
+      },
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `${mutagenFauxSshReleaseBaseUrl}/${mutagenFauxSshVersion}/mutagen-faux-ssh-${mutagenFauxSshVersion}-windows-amd64.zip`,
+      sha256: "f548d81eea994c0b21dbcfa77b671ea8cc897b66598303396a214ef0b0c53f08",
+      extract: {
+        format: "zip",
+        targetPath: "ssh.exe",
+      },
+    },
+  ],
+}
+
 /**
  * Returns true if the given sync point is a filesystem path that exists.
  */

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -1072,6 +1072,10 @@ export const mutagenFauxSshSpec: PluginToolSpec = {
 
 export const mutagenFauxSsh = new PluginTool(mutagenFauxSshSpec)
 
+/**
+ * Returns the path to the location of the faux SSH Mutagen transport if the original Mutagen is used
+ * (i.e. if {@code GARDEN_ENABLE_LEGACY_SYNC=true}) or {@code undefined} otherwise.
+ */
 async function getMutagenSshPath(log: Log): Promise<string | undefined> {
   if (!isNativeMutagenEnabled()) {
     return undefined
@@ -1084,7 +1088,7 @@ async function getMutagenSshPath(log: Log): Promise<string | undefined> {
   emitNonRepeatableWarning(log, warnMessage)
   const fauxSshToolPath = await mutagenFauxSsh.ensurePath(log)
   // This must be the dir containing the faux SSH binary,
-  // not the full path that includes the binary name
+  // not the full path that includes the binary name.
   return dirname(fauxSshToolPath)
 }
 

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -437,7 +437,7 @@ export class Mutagen {
     }
   }
 
-  async ensureDaemon() {
+  async ensureDaemonProc() {
     await this.execCommand(["daemon", "start"])
   }
 
@@ -684,7 +684,7 @@ export class Mutagen {
           this.log.warn(
             styles.primary(`Could not connect to sync daemon, retrying (attempt ${loops}/${maxRetries})...`)
           )
-          await this.ensureDaemon()
+          await this.ensureDaemonProc()
           await sleep(2000 + loops * 500)
         } else {
           throw err
@@ -704,7 +704,7 @@ export class Mutagen {
 
   async restartDaemonProc() {
     await this.stopDaemonProc()
-    await this.ensureDaemon()
+    await this.ensureDaemonProc()
   }
 
   async startMonitoring() {

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -989,20 +989,27 @@ export async function getKubectlExecDestination({
     namespace,
   })
 
-  const command = [
+  const parameters = {
     kubectlPath,
-    "exec",
-    "-i",
-    ...connectionOpts,
-    "--container",
-    containerName,
-    resourceName,
-    "--",
-    mutagenAgentPath,
-    "synchronizer",
-  ]
+    kubectlArgs: [
+      "exec",
+      "-i",
+      ...connectionOpts,
+      "--container",
+      containerName,
+      resourceName,
+      "--",
+      mutagenAgentPath,
+      "synchronizer",
+    ],
+  }
 
-  return `exec:'${command.join(" ")}':${targetPath}`
+  // We replace the standard Base64 '/' character with '_' in this encoding
+  // because the presence of a forward slash will cause Mutagen to treat this as
+  // a local path, in which case it won't be dispatched to our faux SSH command.
+  const hostname = Buffer.from(JSON.stringify(parameters)).toString("base64").replace(/\//g, "_")
+
+  return `${hostname}:${targetPath}`
 }
 
 const isReverseMode = (mode: string) => mode === "one-way-reverse" || mode === "one-way-replica-reverse"

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -57,11 +57,16 @@ import { targetResourceSpecSchema } from "./config.js"
 import { isConfiguredForSyncMode } from "./status/status.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { SyncConfig, SyncSession } from "../../mutagen.js"
-import { mutagenAgentPath, Mutagen, haltedStatuses, mutagenStatusDescriptions } from "../../mutagen.js"
+import {
+  haltedStatuses,
+  isNativeMutagenEnabled,
+  Mutagen,
+  mutagenAgentPath,
+  mutagenStatusDescriptions,
+} from "../../mutagen.js"
 import { k8sSyncUtilImageName } from "./constants.js"
-import { relative, resolve } from "path"
+import { isAbsolute, relative, resolve } from "path"
 import type { Resolved } from "../../actions/types.js"
-import { isAbsolute } from "path"
 import { joinWithPosix } from "../../util/fs.js"
 import type { KubernetesModule, KubernetesService } from "./kubernetes-type/module-config.js"
 import type { HelmModule, HelmService } from "./helm/module-config.js"
@@ -69,7 +74,7 @@ import { convertServiceResource } from "./kubernetes-type/common.js"
 import { prepareConnectionOpts } from "./kubectl.js"
 import type { GetSyncStatusResult, SyncState, SyncStatus } from "../../plugin/handlers/Deploy/get-sync-status.js"
 import { ConfigurationError } from "../../exceptions.js"
-import { DOCS_BASE_URL, gardenEnv } from "../../constants.js"
+import { DOCS_BASE_URL } from "../../constants.js"
 import { styles } from "../../logger/styles.js"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
@@ -1055,7 +1060,7 @@ async function getKubectlExecDestinationNative({
   return `${hostname}:${targetPath}`
 }
 
-export const getKubectlExecDestination = !!gardenEnv.MUTAGEN_SSH_PATH
+export const getKubectlExecDestination = isNativeMutagenEnabled()
   ? getKubectlExecDestinationNative
   : getKubectlExecDestinationLegacy
 

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -1054,8 +1054,8 @@ async function getKubectlExecDestinationNative({
   return `${hostname}:${targetPath}`
 }
 
-export const getKubectlExecDestination = gardenEnv.GARDEN_ENABLE_LEGACY_SYNC
-  ? getKubectlExecDestinationLegacy
-  : getKubectlExecDestinationNative
+export const getKubectlExecDestination = gardenEnv.GARDEN_ENABLE_NEW_SYNC
+  ? getKubectlExecDestinationNative
+  : getKubectlExecDestinationLegacy
 
 const isReverseMode = (mode: string) => mode === "one-way-reverse" || mode === "one-way-replica-reverse"

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -57,13 +57,7 @@ import { targetResourceSpecSchema } from "./config.js"
 import { isConfiguredForSyncMode } from "./status/status.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { SyncConfig, SyncSession } from "../../mutagen.js"
-import {
-  haltedStatuses,
-  isNativeMutagenEnabled,
-  Mutagen,
-  mutagenAgentPath,
-  mutagenStatusDescriptions,
-} from "../../mutagen.js"
+import { haltedStatuses, Mutagen, mutagenAgentPath, mutagenStatusDescriptions } from "../../mutagen.js"
 import { k8sSyncUtilImageName } from "./constants.js"
 import { isAbsolute, relative, resolve } from "path"
 import type { Resolved } from "../../actions/types.js"
@@ -74,7 +68,7 @@ import { convertServiceResource } from "./kubernetes-type/common.js"
 import { prepareConnectionOpts } from "./kubectl.js"
 import type { GetSyncStatusResult, SyncState, SyncStatus } from "../../plugin/handlers/Deploy/get-sync-status.js"
 import { ConfigurationError } from "../../exceptions.js"
-import { DOCS_BASE_URL } from "../../constants.js"
+import { DOCS_BASE_URL, gardenEnv } from "../../constants.js"
 import { styles } from "../../logger/styles.js"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
@@ -1060,8 +1054,8 @@ async function getKubectlExecDestinationNative({
   return `${hostname}:${targetPath}`
 }
 
-export const getKubectlExecDestination = isNativeMutagenEnabled()
-  ? getKubectlExecDestinationNative
-  : getKubectlExecDestinationLegacy
+export const getKubectlExecDestination = gardenEnv.GARDEN_ENABLE_LEGACY_SYNC
+  ? getKubectlExecDestinationLegacy
+  : getKubectlExecDestinationNative
 
 const isReverseMode = (mode: string) => mode === "one-way-reverse" || mode === "one-way-replica-reverse"

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -269,7 +269,7 @@ export class PluginTool extends CliWrapper {
       const tmpPath = join(this.toolPath, this.versionDirname + "." + uuidv4().substr(0, 8))
       const targetAbsPath = join(tmpPath, ...this.targetSubpath.split(posix.sep))
 
-      const downloadLog = log.createLog().info(`Fetching ${this.name}...`)
+      const downloadLog = log.createLog().info(`Fetching ${this.name} ${this.spec.version}...`)
       const debug = downloadLog
         .createLog({
           fixLevel: LogLevel.debug,

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { mutagenCliSpecLegacy, mutagenCliSpecNative } from "../../../src/mutagen.js"
+import { mutagenCliSpecLegacy, mutagenCliSpecNative, mutagenFauxSshSpec } from "../../../src/mutagen.js"
 import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
 import { kustomizeSpec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helm3Spec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
@@ -19,6 +19,10 @@ describe("Docker binaries", () => {
 
 describe("Mutagen binaries", () => {
   downloadBinariesAndVerifyHashes([mutagenCliSpecNative(), mutagenCliSpecLegacy()])
+})
+
+describe("Mutagen faux SSH binaries", () => {
+  downloadBinariesAndVerifyHashes([mutagenFauxSshSpec])
 })
 
 describe("Kubectl binaries", () => {

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { mutagenCliSpec } from "../../../src/mutagen.js"
+import { mutagenCliSpecLegacy, mutagenCliSpecNative } from "../../../src/mutagen.js"
 import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
 import { kustomizeSpec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helm3Spec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
@@ -18,7 +18,7 @@ describe("Docker binaries", () => {
 })
 
 describe("Mutagen binaries", () => {
-  downloadBinariesAndVerifyHashes([mutagenCliSpec])
+  downloadBinariesAndVerifyHashes([mutagenCliSpecNative(), mutagenCliSpecLegacy()])
 })
 
 describe("Kubectl binaries", () => {

--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -275,8 +275,31 @@ Every so often something comes up in the underlying Mutagen synchronization proc
 
 Because Garden creates a temporary data directory for Mutagen for every Garden CLI instance, you can't use the `mutagen` CLI without additional context. However, to make this easier, a symlink to the temporary directory is automatically created under `<project root>/.garden/mutagen/<random ID>`, as well as a `mutagen.sh` helper script within that directory that sets the appropriate context and links to the automatically installed Mutagen CLI. We also create a `<project root>/.garden/mutagen/latest` symlink for convenience.
 
-To, for example, get the current list of active syncs in an active Garden process, you could run the following from the project root directory:
+### Get list of active syncs
+
+To get the current list of active syncs in an active Garden process, you could run the following from the project root directory:
 
 ```sh
 garden util mutagen sync list
 ```
+
+### Restarting sync daemon
+
+Starting from the version `0.13.26`, Garden offer a new file synchronization machinery.
+It is available via the environment variable `GARDEN_ENABLE_NEW_SYNC` and it disabled by default.
+
+It is important to stop all syncs and the sync daemon before changing the value of `GARDEN_ENABLE_NEW_SYNC`.
+Otherwise, the syncs will fail. In order to do that, just run the following commands from the project root directory:
+```
+garden util mutagen daemon stop
+GARDEN_ENABLE_NEW_SYNC=true garden util mutagen daemon stop
+```
+
+It will stop both old and new sync daemons.
+If one of the daemons is not running, then the command will report an error message like this:
+```
+Error: unable to connect to daemon: connection timed out (is the daemon running?)
+```
+That is fine, please ignore it.
+
+Once you have stopped the sync daemons, please try again to start the syncs.


### PR DESCRIPTION
**What this PR does / why we need it**:
Garden currently uses a custom fork of Mutagen for its `kubectl exec` transport. This is the last remaining blocker to get Garden back on the official Mutagen releases.

At the moment, Mutagen doesn't support custom transports, but it does allow a custom ssh executable to be specified, which presents an opportunity for using a faux SSH command that calls down to `kubectl exec` using parameters smuggled through the SSH hostname specification. In this case, they are smuggled in a Base64-encoded JSON object (with some slight encoding tweaks to pass through Mutagen's local path detection heuristic).

The faux SSH implementation added in the original PR #3102 will almost certainly be useable (with minor tweaks) as a custom transport implementation once support exists in Mutagen.

The faux SSH implementation has been hosted in its own repo at https://github.com/garden-io/mutagen-faux-ssh.

**Which issue(s) this PR fixes**:

This is the rebased version of #3102 and it allows to move away from the Mutagen fork.

Fixes #5420

**Special notes for your reviewer**:

Some questions from the original PR (#3102):

> This PR is fairly close to complete, but there are a few remaining questions:
> 
> 1. Is this approach satisfactory overall?
> 2. Should the faux `ssh` command be rewritten in TypeScript?
> 3. How should the faux `ssh` command be source-controlled and distributed?
> 4. Are there any transition considerations for active `garden dev` commands?
> 
> Regarding (1), I think this is the best approach because it gets Garden back on the official Mutagen releases with the minimal amount of effort and the implementation strategy is very similar to what custom transports will eventually look like in Mutagen, meaning that the faux SSH command will probably be convertible to a `mutagen-transport-garden` (name TBD) command later on.
>
> Regarding (2), that's a policy decision I'd leave to Garden.  The critical aspect is just the proper signal and standard input closure forwarding.
> 
> Regarding (3), that's probably a good point for discussion.  I would imagine it would be distributed/downloaded in a similar manner to the `mutagen` executable, but I don't know the best location to perform its build or serve its binaries.  There's also the consideration of its versioning w.r.t. Garden, especially if the format of the JSON changes, but that's likely to see very little churn once implemented, so manually managing its versioning as some external project might be suitable.  Once this is decided and implemented, the `MUTAGEN_SSH_PATH` environment variable will need to be set for `mutagen daemon run`; a TODO has been indicated for this in the code.
> 
> Regarding (4), the simple answer is that the project would probably just need to be restarted entirely.  If the same `MUTAGEN_DATA_DIRECTORY` is used, then the standard Mutagen daemon will just reject and ignore the prior `exec`-based sessions, but testing of this would be good before shipping.

Comments from @vvagaytsev:
1. Yes, that approach was good and simple.
2. No, the original implementation in Go worked fine.
3. It's now hosted at https://github.com/garden-io/mutagen-faux-ssh.
4. Agree, all running Mutagen processes must be killed before using the new transport and original Mutagen:
4.1. All sync must be stopped.
4.2. All sync monitors must be terminated.
4.3. Mutagen daemon must be stopped.