### PR TITLE
improvement(cloud): log 'not logged in' msg at info level for community

### DIFF
--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -635,7 +635,7 @@ describe("Garden", () => {
         expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
         expect(garden.projectId).to.eql(undefined)
       })
-      it("should log a warning by default", async () => {
+      it("should log an informational message about not being logged in for community edition", async () => {
         log.root["entries"] = []
         const projectName = "test"
         const envName = "default"
@@ -650,6 +650,32 @@ describe("Garden", () => {
           log,
         })
         const distroName = getCloudDistributionName(garden.cloudDomain || DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+        const expectedLog = log.root.getLogEntries().filter((l) => resolveMsg(l)?.includes(`You are not logged in`))
+
+        expect(expectedLog.length).to.eql(1)
+        expect(expectedLog[0].level).to.eql(LogLevel.info)
+        expect(expectedLog[0].msg).to.eql(
+          `You are not logged in. To use ${distroName}, log in with the ${styles.command("garden login")} command.`
+        )
+      })
+      it("should log a warning message about not being logged in for commercial edition", async () => {
+        log.root["entries"] = []
+        const fakeCloudDomain = "https://example.com"
+        const projectName = "test"
+        const envName = "default"
+        const config: ProjectConfig = createProjectConfig({
+          name: projectName,
+          path: pathFoo,
+          domain: fakeCloudDomain,
+        })
+
+        await TestGarden.factory(pathFoo, {
+          config,
+          environmentString: envName,
+          log,
+        })
+        const distroName = getCloudDistributionName(fakeCloudDomain)
 
         const expectedLog = log.root.getLogEntries().filter((l) => resolveMsg(l)?.includes(`You are not logged in`))
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

A previous commit (see #5538) logged this at the warning level which is relevant for the commercial edition but the community. This fixes that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
