### PR TITLE
fix(cli): fallback to non-highlighted yaml if error occurs

### DIFF
--- a/core/src/util/serialization.ts
+++ b/core/src/util/serialization.ts
@@ -35,14 +35,21 @@ export function encodeYamlMulti(objects: object[]) {
 }
 
 export function highlightYaml(s: string) {
-  return highlight(s, {
-    language: "yaml",
-    theme: {
-      keyword: styles.accent.italic,
-      literal: styles.accent.italic,
-      string: styles.accent,
-    },
-  })
+  try {
+    return highlight(s, {
+      language: "yaml",
+      theme: {
+        keyword: styles.accent.italic,
+        literal: styles.accent.italic,
+        string: styles.accent,
+      },
+    })
+  } catch (err) {
+    // FIXME: this is a quickfix for https://github.com/garden-io/garden/issues/5442
+    //  The issue needs to be fixed properly, by fixing Garden single app binary construction.
+    // Fallback to non-highlighted yaml if an error occurs.
+    return s
+  }
 }
 
 /**


### PR DESCRIPTION
This is a quickfix for #5442 to avoid Garden crashes on yaml highlighting. The proper fix still needs to be implemented.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

A quickfix for #5442

**Special notes for your reviewer**:
