### PR TITLE
fix(helm): fix `sha256` hash for `linux-arm64` binary

### DIFF
--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -57,7 +57,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "linux",
       architecture: "arm64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-linux-arm64.tar.gz`,
-      sha256: "658839fed8f9be2169f5df68e55cb2f0aa731a50df454caf183186766800bbd0",
+      sha256: "cfafbae85c31afde88c69f0e5053610c8c455826081c1b2d665d9b44c31b3759",
       extract: {
         format: "tar",
         targetPath: "linux-arm64/helm",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Patches #5497

**Special notes for your reviewer**:
The issue was found by the test script implemented in #5556.
Nothing to back-port to `0.12`, because it does not support `linux-arm64` binaries for Helm.
