### PR TITLE
fix(jib): fix OpenJDK `sha256` hashes for `linux-arm64` binaries

### DIFF
--- a/plugins/jib/src/openjdk.ts
+++ b/plugins/jib/src/openjdk.ts
@@ -65,7 +65,7 @@ const jdk11Version: JdkVersion = {
   },
   linux_arm64: {
     filename: "OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.9.1_1.tar.gz",
-    sha256: "e96d665a39800b160f8ed4de03eada2969c650752faaf7cc83fa643e28dce337",
+    sha256: "e9cea040cdf5d9b0a2986feaf87662e1aef68e876f4d66664cb2be36e26db412",
   },
   windows: {
     filename: "OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.zip",
@@ -88,7 +88,7 @@ const jdk13Version: JdkVersion = {
   },
   linux_arm64: {
     filename: "OpenJDK13U-jdk_aarch64_linux_hotspot_13_33.tar.gz",
-    sha256: "2365b7fbba8d9125fb091933aad9f38f8cc1fbb0217cdec9ec75d2000f6d451a",
+    sha256: "74f4110333ac4239564ed864b1d7d69b7af32af39efcfbde9816e1486cb5ae07",
   },
   windows: {
     filename: "OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
@@ -115,7 +115,7 @@ const jdk17Version: JdkVersion = {
   },
   linux_arm64: {
     filename: "OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.4.1_1.tar.gz",
-    sha256: "2e4137529319cd7935f74e1289025b7b4c794c0fb47a3d138adffbd1bbc0ea58",
+    sha256: "3c7460de77421284b38b4e57cb1bd584a6cef55c34fc51a12270620544de2b8a",
   },
   windows: {
     filename: "OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The issue was found by the test script implemented in #5556.
Nothing to back-port to `0.12`, because it does not support `linux-arm64` binaries for OpenJDK.