### PR TITLE
fix(core): inherit Build action mode from dependant Deploy action

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -137,6 +137,11 @@ export interface ActionModes {
   local?: boolean
 }
 
+export const ALL_ACTION_MODES_SUPPORTED: ActionModes = {
+  sync: true,
+  local: true,
+}
+
 export type ActionMode = keyof ActionModes | "default"
 
 export type ActionModeMap = {

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -194,8 +194,8 @@ export class DeployCommand extends Command<Args, Opts> {
 
     const actionModes: ActionModeMap = {
       // Support a single empty value (which comes across as an empty list) as equivalent to '*'
-      local: opts["local-mode"]?.length === 0 ? ["*"] : opts["local-mode"]?.map((s) => "deploy." + s),
-      sync: opts.sync?.length === 0 ? ["*"] : opts.sync?.map((s) => "deploy." + s),
+      local: opts["local-mode"]?.length === 0 ? ["deploy.*"] : opts["local-mode"]?.map((s) => "deploy." + s),
+      sync: opts.sync?.length === 0 ? ["deploy.*"] : opts.sync?.map((s) => "deploy." + s),
     }
 
     const graph = await garden.getConfigGraph({ log, emit: true, actionModes })

--- a/core/src/config/template-contexts/actions.ts
+++ b/core/src/config/template-contexts/actions.ts
@@ -11,7 +11,7 @@ import type { ActionConfig, Action, ExecutedAction, ResolvedAction } from "../..
 import type { ActionMode } from "../../actions/types.js"
 import type { Garden } from "../../garden.js"
 import type { GardenModule } from "../../types/module.js"
-import { deline } from "../../util/string.js"
+import { dedent, deline } from "../../util/string.js"
 import type { DeepPrimitiveMap, PrimitiveMap } from "../common.js"
 import { joi, joiIdentifier, joiIdentifierMap, joiPrimitive, joiVariables } from "../common.js"
 import type { ProviderMap } from "../provider.js"
@@ -40,7 +40,11 @@ const actionModeSchema = joi
   .default("default")
   .allow("default", "sync", "local")
   .description(
-    "The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used."
+    dedent`
+      The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+      Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+    `
   )
   .example("sync")
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -59,7 +59,7 @@ import { mergeVariables } from "./common.js"
 import type { ConfigGraph } from "./config-graph.js"
 import { MutableConfigGraph } from "./config-graph.js"
 import type { ModuleGraph } from "./modules.js"
-import type { MaybeUndefined } from "../util/util.js"
+import { isTruthy, type MaybeUndefined } from "../util/util.js"
 import minimatch from "minimatch"
 import type { ConfigContext } from "../config/template-contexts/base.js"
 import type { LinkedSource, LinkedSourceMap } from "../config-store/local.js"
@@ -138,24 +138,82 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
   // Doing this in two steps makes the code a bit less readable, but it's worth it for the performance boost.
   const preprocessResults: { [key: string]: PreprocessActionResult } = {}
   const computedActionModes: { [key: string]: { mode: ActionMode; explicitMode: boolean } } = {}
-  await Promise.all(
-    Object.entries(configsByKey).map(async ([key, config]) => {
-      const { mode, explicitMode } = getActionMode(config, actionModes, log)
-      computedActionModes[key] = { mode, explicitMode }
-      preprocessResults[key] = await preprocessActionConfig({
-        garden,
-        config,
-        router,
-        log,
-        mode,
+
+  const preprocessActions = async (predicate: (config: ActionConfig) => boolean = () => true) => {
+    return await Promise.all(
+      Object.entries(configsByKey).map(async ([key, config]) => {
+        if (!predicate(config)) {
+          return
+        }
+
+        const { mode, explicitMode } = getActionMode(config, actionModes, log)
+        computedActionModes[key] = { mode, explicitMode }
+        preprocessResults[key] = await preprocessActionConfig({
+          garden,
+          config,
+          router,
+          log,
+          mode,
+        })
       })
-    })
-  )
+    )
+  }
+
+  // First preprocess only the Deploy actions, so we can infer the mode of Build actions that are used by them.
+  await preprocessActions((config) => config.kind === "Deploy")
+
+  // This enables users to use `this.mode` in Build action configs, such that `this.mode == "sync"`
+  // when a Deploy action that uses the Build action is in sync mode.
+  //
+  // The proper solution to this would involve e.g. parametrized actions, or injecting a separate Build action
+  // with `this.mode` set to the Deploy action's mode before resolution (both would need to be thought out carefully).
+  const actionTypes = await garden.getActionTypes()
+  const buildModeOverrides: Record<string, { mode: ActionMode; overriddenByDeploy: string }> = {}
+  for (const [key, res] of Object.entries(preprocessResults)) {
+    const config = res.config
+    const { mode } = computedActionModes[key]
+    if (config.kind === "Deploy" && mode !== "default") {
+      const definition = actionTypes[config.kind][config.type]?.spec
+      const buildDeps = dependenciesFromActionConfig(
+        log,
+        config,
+        configsByKey,
+        definition,
+        res.templateContext,
+        actionTypes
+      )
+      const referencedBuildNames = [config.build, ...buildDeps.map((d) => d.name)].filter(isTruthy)
+      for (const buildName of referencedBuildNames) {
+        const buildKey = actionReferenceToString({ kind: "Build", name: buildName })
+        if (buildModeOverrides[buildKey]) {
+          const prev = buildModeOverrides[buildKey]
+          log.warn(dedent`
+            Using mode ${styles.highlight(prev.mode)} for Build ${styles.highlight(buildName)} as requested by\
+            the Deploy ${styles.highlight(prev.overriddenByDeploy)}.
+
+            Ignoring request by Deploy ${styles.highlight(config.name)} to use mode ${styles.highlight(mode)}.
+          `)
+        }
+        actionModes[mode] = [buildKey, ...(actionModes[mode] || [])]
+        buildModeOverrides[buildKey] = {
+          mode,
+          overriddenByDeploy: config.name,
+        }
+      }
+    }
+  }
+
+  // Preprocess all remaining actions (Deploy actions are preprocessed above)
+  // We are preprocessing actions in two batches so we can infer the mode of Build actions that are used by Deploy actions. See the comments above.
+  await preprocessActions((config) => config.kind !== "Deploy")
 
   // Optimize file scanning by avoiding unnecessarily broad scans when project is not in repo root.
   const preprocessedConfigs = Object.values(preprocessResults).map((r) => r.config)
   const allPaths = preprocessedConfigs.map((c) => getSourcePath(c))
   const minimalRoots = await garden.vcs.getMinimalRoots(log, allPaths)
+
+  // If a Build uses this.mode and is used as a build or dependency of a Deploy action that has a non-default mode,
+  // inject a build with the mode set to that non-default mode to the graph (and re-resolve it).
 
   // TODO: Maybe we could optimize resolving tree versions, avoid parallel scanning of the same directory etc.
   const graph = new MutableConfigGraph({ actions: [], moduleGraph, groups: groupConfigs })

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -22,7 +22,7 @@ import type {
   Executed,
   Resolved,
 } from "../actions/types.js"
-import { actionKinds } from "../actions/types.js"
+import { ALL_ACTION_MODES_SUPPORTED, actionKinds } from "../actions/types.js"
 import {
   actionReferenceToString,
   addActionDependency,
@@ -772,7 +772,13 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
 
   resolveTemplates()
 
-  const { config: updatedConfig, supportedModes } = await router.configureAction({ config, log })
+  const configureActionResult = await router.configureAction({ config, log })
+
+  const { config: updatedConfig } = configureActionResult
+
+  // NOTE: Build actions inherit the supported modes of the Deploy actions that use them
+  const supportedModes: ActionModes =
+    config.kind === "Build" ? ALL_ACTION_MODES_SUPPORTED : configureActionResult.supportedModes
 
   // -> Throw if trying to modify no-template fields
   for (const field of noTemplateFields) {

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -212,9 +212,6 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
   const allPaths = preprocessedConfigs.map((c) => getSourcePath(c))
   const minimalRoots = await garden.vcs.getMinimalRoots(log, allPaths)
 
-  // If a Build uses this.mode and is used as a build or dependency of a Deploy action that has a non-default mode,
-  // inject a build with the mode set to that non-default mode to the graph (and re-resolve it).
-
   // TODO: Maybe we could optimize resolving tree versions, avoid parallel scanning of the same directory etc.
   const graph = new MutableConfigGraph({ actions: [], moduleGraph, groups: groupConfigs })
 

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -840,7 +840,7 @@ describe("actionConfigsToGraph", () => {
     expect(action.mode()).to.equal("local")
   })
 
-  it("deploy action mode overrides the build action mode, if deploy action depends on build action", async () => {
+  it("deploy action mode overrides the mode of a dependency build action", async () => {
     const graph = await actionConfigsToGraph({
       garden,
       log,

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -410,6 +410,8 @@ my-variable: ${actions.build.my-build.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -392,6 +392,8 @@ my-variable: ${actions.build.my-build.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -569,6 +569,8 @@ my-variable: ${actions.build.my-build.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -321,6 +321,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -1191,6 +1191,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -391,6 +391,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -1045,6 +1045,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -1082,6 +1082,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -491,6 +491,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -467,6 +467,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -378,6 +378,8 @@ my-variable: ${actions.deploy.my-deploy.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -618,6 +618,8 @@ my-variable: ${actions.run.my-run.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -371,6 +371,8 @@ my-variable: ${actions.run.my-run.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -642,6 +642,8 @@ my-variable: ${actions.run.my-run.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -414,6 +414,8 @@ my-variable: ${actions.run.my-run.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -707,6 +707,8 @@ my-variable: ${actions.run.my-run.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -368,6 +368,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -356,6 +356,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -608,6 +608,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -371,6 +371,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -315,6 +315,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -642,6 +642,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -414,6 +414,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -707,6 +707,8 @@ my-variable: ${actions.test.my-test.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/template-strings/action-all-fields.md
+++ b/docs/reference/template-strings/action-all-fields.md
@@ -447,6 +447,8 @@ The name of the action.
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -581,6 +581,8 @@ my-variable: ${runtime.build.<action-name>.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |
@@ -696,6 +698,8 @@ my-variable: ${runtime.deploy.<action-name>.sourcePath}
 ### `${runtime.deploy.<action-name>.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |
@@ -813,6 +817,8 @@ my-variable: ${runtime.run.<action-name>.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |
@@ -928,6 +934,8 @@ my-variable: ${runtime.test.<action-name>.sourcePath}
 ### `${runtime.test.<action-name>.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |
@@ -1045,6 +1053,8 @@ my-variable: ${runtime.services.<action-name>.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |
@@ -1160,6 +1170,8 @@ my-variable: ${runtime.tasks.<action-name>.sourcePath}
 ### `${runtime.tasks.<action-name>.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |
@@ -1285,6 +1297,8 @@ my-variable: ${actions.build.<action-name>.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |
@@ -1400,6 +1414,8 @@ my-variable: ${actions.deploy.<action-name>.sourcePath}
 ### `${actions.deploy.<action-name>.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |
@@ -1517,6 +1533,8 @@ my-variable: ${actions.run.<action-name>.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |
@@ -1632,6 +1650,8 @@ my-variable: ${actions.test.<action-name>.sourcePath}
 ### `${actions.test.<action-name>.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |
@@ -1749,6 +1769,8 @@ my-variable: ${actions.services.<action-name>.sourcePath}
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
 
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
+
 | Type     | Default     |
 | -------- | ----------- |
 | `string` | `"default"` |
@@ -1864,6 +1886,8 @@ my-variable: ${actions.tasks.<action-name>.sourcePath}
 ### `${actions.tasks.<action-name>.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |
@@ -2026,6 +2050,8 @@ my-variable: ${this.sourcePath}
 ### `${this.mode}`
 
 The mode that the action should be executed in (e.g. 'sync' or 'local' for Deploy actions). Set to 'default' if no special mode is being used.
+
+Build actions inherit the mode from Deploy actions that depend on them. E.g. If a Deploy action is in 'sync' mode and depends on a Build action, the Build action will inherit the 'sync' mode setting from the Deploy action. This enables installing different tools that may be necessary for different development modes.
 
 | Type     | Default     |
 | -------- | ----------- |

--- a/examples/vote/vote/Dockerfile
+++ b/examples/vote/vote/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.1-alpine as default
+FROM node:16.18.1-alpine
 
 WORKDIR /app
 
@@ -8,12 +8,4 @@ RUN npm install
 RUN mkdir node_modules/.cache && chmod -R 777 node_modules/.cache
 ADD . /app
 
-RUN echo "default" > /.mode
-RUN echo "default"
-
 CMD ["npm", "run", "serve"]
-
-FROM default as sync
-
-RUN echo "sync" > /.mode
-RUN echo "sync"

--- a/examples/vote/vote/Dockerfile
+++ b/examples/vote/vote/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.1-alpine
+FROM node:16.18.1-alpine as default
 
 WORKDIR /app
 
@@ -8,4 +8,12 @@ RUN npm install
 RUN mkdir node_modules/.cache && chmod -R 777 node_modules/.cache
 ADD . /app
 
+RUN echo "default" > /.mode
+RUN echo "default"
+
 CMD ["npm", "run", "serve"]
+
+FROM default as sync
+
+RUN echo "sync" > /.mode
+RUN echo "sync"

--- a/examples/vote/vote/garden.yml
+++ b/examples/vote/vote/garden.yml
@@ -1,6 +1,21 @@
 kind: Build
 name: vote
 type: container
+spec:
+  targetStage:
+    $if: "${this.mode == 'sync'}"
+    $then: sync
+    $else: default
+
+
+---
+kind: Run
+name: prepare-db
+build: vote
+type: container
+spec:
+  args: ["cat", "/.mode"]
+
 
 ---
 kind: Deploy
@@ -10,6 +25,7 @@ name: vote
 type: container
 build: vote
 dependencies:
+  - run.prepare-db
   - deploy.api
 spec:
   args: [npm, run, serve]
@@ -50,3 +66,16 @@ dependencies:
 timeout: 60
 spec:
   args: [npm, run, test:integ]
+
+---
+kind: Run
+type: exec
+name: echo-vars
+spec:
+  command:
+    - /bin/sh
+    - "-c"
+    - |
+      echo "actions.build.vote.mode: ${actions.build.vote.mode}"
+      echo "actions.deploy.vote.mode: ${actions.deploy.vote.mode}"
+      echo "actions.test.vote-unit.mode: ${actions.test.vote-unit.mode}"

--- a/examples/vote/vote/garden.yml
+++ b/examples/vote/vote/garden.yml
@@ -1,21 +1,6 @@
 kind: Build
 name: vote
 type: container
-spec:
-  targetStage:
-    $if: "${this.mode == 'sync'}"
-    $then: sync
-    $else: default
-
-
----
-kind: Run
-name: prepare-db
-build: vote
-type: container
-spec:
-  args: ["cat", "/.mode"]
-
 
 ---
 kind: Deploy
@@ -25,7 +10,6 @@ name: vote
 type: container
 build: vote
 dependencies:
-  - run.prepare-db
   - deploy.api
 spec:
   args: [npm, run, serve]
@@ -66,16 +50,3 @@ dependencies:
 timeout: 60
 spec:
   args: [npm, run, test:integ]
-
----
-kind: Run
-type: exec
-name: echo-vars
-spec:
-  command:
-    - /bin/sh
-    - "-c"
-    - |
-      echo "actions.build.vote.mode: ${actions.build.vote.mode}"
-      echo "actions.deploy.vote.mode: ${actions.deploy.vote.mode}"
-      echo "actions.test.vote-unit.mode: ${actions.test.vote-unit.mode}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Override the Build action mode with the Deploy action mode, if it depends on the build.

This enables using ${this.mode} in the build action as a proxy to the
Deploy action mode, simplifying configuration for many users.

In previous versions of Garden all actions went into `sync` Mode when
users ran the command `garden deploy --sync` without explicitly listing
Deploy actions due to the fact that we defaulted to the `*` Minimatch
pattern that also matched build actions.

This commit ensures that if you depend on a Build from a Deploy action,
and that Deploy action is in `sync` mode, the Build action inherits the
mode.

If multiple Deploy actions depend on the same build, and have different
modes, the non-default mode wins. If multiple Deploy actions use
different non-default modes, we print a warning.

In the future, we can make this even more reliable by injecting
different invariants of build actions into the stack graph for each
Deploy action, if the build action is used by multiple Deploy actions
and they are in different modes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
