### PR TITLE
fix(core): fix config error when using project.modules

### DIFF
--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -348,6 +348,20 @@ function handleProjectModules(log: Log, projectSpec: ProjectConfig): ProjectConf
       log,
       "Project configuration field `modules` is deprecated in 0.13 and will be removed in 0.14. Please use the `scan` field instead."
     )
+    const scanConfig = projectSpec.scan || {}
+    for (const key of ["include", "exclude"]) {
+      if (projectSpec["modules"][key]) {
+        if (!scanConfig[key]) {
+          scanConfig[key] = projectSpec["modules"][key]
+        } else {
+          log.warn(
+            `Project-level \`${key}\` is set both in \`modules.${key}\` and \`scan.${key}\`. The value from \`scan.${key}\` will be used (and the value from \`modules.${key}\` will not have any effect).`
+          )
+        }
+      }
+    }
+    projectSpec.scan = scanConfig
+    delete projectSpec["modules"]
   }
 
   return projectSpec

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -31,7 +31,7 @@ import { memoize } from "lodash-es"
 import type { GenericProviderConfig } from "./provider.js"
 import { providerConfigBaseSchema } from "./provider.js"
 import type { GitScanMode } from "../constants.js"
-import { DOCS_BASE_URL, GardenApiVersion, gitScanModes } from "../constants.js"
+import { DOCS_BASE_URL, GardenApiVersion, defaultGitScanMode, gitScanModes } from "../constants.js"
 import { defaultDotIgnoreFile } from "../util/fs.js"
 import type { CommandInfo } from "../plugin-context.js"
 import type { VcsInfo } from "../vcs/vcs.js"
@@ -267,7 +267,7 @@ const projectScanSchema = createSchema({
         .string()
         .allow(...gitScanModes)
         .only()
-        .default("subtree")
+        .default(defaultGitScanMode)
         .description(
           "Choose how to perform scans of git repositories. The default (`subtree`) runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules."
         ),
@@ -424,7 +424,6 @@ export const projectSchema = createSchema({
       "Key/value map of variables to configure for all environments. " + joiVariablesDescription
     ),
   }),
-  rename: [["modules", "scan"]],
 })
 
 export function getDefaultEnvironmentName(defaultName: string, config: ProjectConfig): string {

--- a/core/test/data/test-projects/project-include-exclude/garden.yml
+++ b/core/test/data/test-projects/project-include-exclude/garden.yml
@@ -5,7 +5,12 @@ environments:
   - name: local
 providers:
   - name: test-plugin
+# We use the old `modules.<include|exclude>` fields to test the renaming/moving of the fields to
+# `scan.<include|exclude>` during project config preprocessing (see the `prepareProjectResource` helper).
 scan:
+  git:
+    mode: repo
+modules:
   include:
     - module*/**/*
   exclude:

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -159,7 +159,7 @@ scan:
     # action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths,
     # includes and excludes for each action/module. This can be considerably more efficient for large projects with
     # many actions/modules.
-    mode: subtree
+    mode: repo
 
 # A list of output values that the project should export. These are exported by the `garden get outputs` command, as
 # well as when referencing a project as a sub-project within another project.
@@ -578,9 +578,9 @@ scan:
 
 Choose how to perform scans of git repositories. The default (`subtree`) runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules.
 
-| Type     | Allowed Values    | Default     | Required |
-| -------- | ----------------- | ----------- | -------- |
-| `string` | "repo", "subtree" | `"subtree"` | Yes      |
+| Type     | Allowed Values    | Default  | Required |
+| -------- | ----------------- | -------- | -------- |
+| `string` | "repo", "subtree" | `"repo"` | Yes      |
 
 ### `outputs[]`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, an error would be thrown if using `scan.git.mode` and `module.include` or `module.exclude` together (since the Joi helper for renaming fields fails if there's already a value at the destination).