### PR TITLE
fix(git): revert default Git scan mode to `subtree`

### DIFF
--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -269,7 +269,7 @@ const projectScanSchema = createSchema({
         .only()
         .default(defaultGitScanMode)
         .description(
-          "Choose how to perform scans of git repositories. The default (`subtree`) runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules."
+          `Choose how to perform scans of git repositories. Defaults to \`${defaultGitScanMode}\`. The \`subtree\` runs individual git scans on each action/module path. The \`repo\` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules.`
         ),
     }),
   }),

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -18,7 +18,7 @@ const extractedRoot = process.env.GARDEN_SEA_EXTRACTED_ROOT
 
 export const gitScanModes = ["repo", "subtree"] as const
 export type GitScanMode = (typeof gitScanModes)[number]
-export const defaultGitScanMode: GitScanMode = "repo"
+export const defaultGitScanMode: GitScanMode = "subtree"
 
 export const GARDEN_CORE_ROOT = !!extractedRoot
   ? resolve(extractedRoot, "src", "core")

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -155,11 +155,11 @@ scan:
   exclude:
 
   git:
-    # Choose how to perform scans of git repositories. The default (`subtree`) runs individual git scans on each
-    # action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths,
-    # includes and excludes for each action/module. This can be considerably more efficient for large projects with
-    # many actions/modules.
-    mode: repo
+    # Choose how to perform scans of git repositories. Defaults to `subtree`. The `subtree` runs individual git scans
+    # on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching
+    # the paths, includes and excludes for each action/module. This can be considerably more efficient for large
+    # projects with many actions/modules.
+    mode: subtree
 
 # A list of output values that the project should export. These are exported by the `garden get outputs` command, as
 # well as when referencing a project as a sub-project within another project.
@@ -576,11 +576,11 @@ scan:
 
 [scan](#scan) > [git](#scangit) > mode
 
-Choose how to perform scans of git repositories. The default (`subtree`) runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules.
+Choose how to perform scans of git repositories. Defaults to `subtree`. The `subtree` runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules.
 
-| Type     | Allowed Values    | Default  | Required |
-| -------- | ----------------- | -------- | -------- |
-| `string` | "repo", "subtree" | `"repo"` | Yes      |
+| Type     | Allowed Values    | Default     | Required |
+| -------- | ----------------- | ----------- | -------- |
+| `string` | "repo", "subtree" | `"subtree"` | Yes      |
 
 ### `outputs[]`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
The quick-fix to revert the [regression](https://github.com/garden-io/garden/pull/5399) introduced in [0.13.20](https://github.com/garden-io/garden/releases/tag/0.13.20).

**Which issue(s) this PR fixes**:

Fixes #5624
Fixes #5625

**Special notes for your reviewer**:
