### PR TITLE
fix(core): fix "repo" scan mode for remote actions

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -18,7 +18,7 @@ const extractedRoot = process.env.GARDEN_SEA_EXTRACTED_ROOT
 
 export const gitScanModes = ["repo", "subtree"] as const
 export type GitScanMode = (typeof gitScanModes)[number]
-export const defaultGitScanMode: GitScanMode = "subtree"
+export const defaultGitScanMode: GitScanMode = "repo"
 
 export const GARDEN_CORE_ROOT = !!extractedRoot
   ? resolve(extractedRoot, "src", "core")

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1573,7 +1573,7 @@ export class Garden {
   }
 
   /**
-   * Clones the project/module source if needed and returns the path (either from .garden/sources or from a local path)
+   * Clones the project/action/module source if needed and returns the path (either from .garden/sources or from a local path)
    */
   public async resolveExtSourcePath({
     name,

--- a/core/test/unit/src/graph/actions.ts
+++ b/core/test/unit/src/graph/actions.ts
@@ -48,6 +48,7 @@ describe("preprocessActionConfig", () => {
           garden,
           config,
           router,
+          linkedSources: {},
           mode: "default",
           log: garden.log,
         })
@@ -73,6 +74,7 @@ describe("preprocessActionConfig", () => {
           garden,
           config,
           router,
+          linkedSources: {},
           mode: "default",
           log: garden.log,
         })

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -155,11 +155,11 @@ scan:
   exclude:
 
   git:
-    # Choose how to perform scans of git repositories. Defaults to `subtree`. The `subtree` runs individual git scans
-    # on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching
-    # the paths, includes and excludes for each action/module. This can be considerably more efficient for large
-    # projects with many actions/modules.
-    mode: subtree
+    # Choose how to perform scans of git repositories. Defaults to `repo`. The `subtree` runs individual git scans on
+    # each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the
+    # paths, includes and excludes for each action/module. This can be considerably more efficient for large projects
+    # with many actions/modules.
+    mode: repo
 
 # A list of output values that the project should export. These are exported by the `garden get outputs` command, as
 # well as when referencing a project as a sub-project within another project.
@@ -576,11 +576,11 @@ scan:
 
 [scan](#scan) > [git](#scangit) > mode
 
-Choose how to perform scans of git repositories. Defaults to `subtree`. The `subtree` runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules.
+Choose how to perform scans of git repositories. Defaults to `repo`. The `subtree` runs individual git scans on each action/module path. The `repo` mode scans entire repositories and then filters down to files matching the paths, includes and excludes for each action/module. This can be considerably more efficient for large projects with many actions/modules.
 
-| Type     | Allowed Values    | Default     | Required |
-| -------- | ----------------- | ----------- | -------- |
-| `string` | "repo", "subtree" | `"subtree"` | Yes      |
+| Type     | Allowed Values    | Default  | Required |
+| -------- | ----------------- | -------- | -------- |
+| `string` | "repo", "subtree" | `"repo"` | Yes      |
 
 ### `outputs[]`
 

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -1,6 +1,9 @@
 apiVersion: garden.io/v1
 kind: Project
 name: remote-sources
+scan:
+  git:
+    mode: repo
 sources:
   - name: web-services
     # use #your-branch to specify a branch, #v0.3.0 for a tag or a full length commit SHA1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, remote actions (i.e. actions with `source.repository.url` set, not sources declared at the project level) didn't work correctly when using the new `repo` git scanning mode.

Also set the default git scanning mode back to `repo`, since this bug (which we've now fixed) was the reason we reverted to `subtree`.

The error arose because the base path wasn't being set to the locally cloned path of the remote source's repo early enough in the resolution process. This led to the repo scanning logic using the action's config directory instead of the cloned source directory as the repo root (thus ignoring the sources).

We've added a unit test that verifies that the base path is being set correctly when the action graph is initialized.

**Which issue(s) this PR fixes**:

Fixes #5625.