### PR TITLE
fix(k8s): remove k8s manifest logs on apply

### DIFF
--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -118,9 +118,6 @@ export async function apply({
 
   const input = Buffer.from(encodeYamlMulti(manifests))
 
-  const manifestLogLevel = "debug" as const
-  log[manifestLogLevel](`Applying Kubernetes manifests:\n${input.toString()}`)
-
   const args = ["apply"]
   dryRun && args.push("--dry-run")
   args.push("--output=json", "-f", "-")
@@ -146,10 +143,7 @@ export async function apply({
         message: dedent`
           Failed to apply Kubernetes manifests. This is the output of the kubectl command:
 
-          ${e.details.output}
-
-          Use the option "--log-level ${manifestLogLevel}" to see the kubernetes manifests that we attempted to apply through "kubectl apply".
-          `,
+          ${e.details.output}`,
       })
     }
     throw e


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Kubernetes manifests often contain sensitive values, and Garden at the
moment does not offer sufficient facilities to filter them reliably
enough.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
