### PR TITLE
fix(template): do not partially resolve function arg objects with special keys

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -17,7 +17,7 @@ import { validateSchema } from "../config/validation.js"
 import { load, loadAll } from "js-yaml"
 import { safeDumpYaml } from "../util/serialization.js"
 import indentString from "indent-string"
-import { maybeTemplateString } from "./template-string.js"
+import { mayContainTemplateString } from "./template-string.js"
 
 interface ExampleArgument {
   input: any[]
@@ -510,12 +510,12 @@ export function callHelperFunction({
       })
 
       // do not apply helper function for an unresolved template string
-      if (maybeTemplateString(value)) {
+      if (mayContainTemplateString(value)) {
         if (allowPartial) {
           return { resolved: "${" + text + "}" }
         } else {
           const _error = new TemplateStringError({
-            message: `Function '${functionName}' cannot be applied on unresolved string`,
+            message: `Function '${functionName}' cannot be applied on unresolved value`,
           })
           return { _error }
         }

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1191,8 +1191,7 @@ describe("resolveTemplateString", () => {
 
     it("throws if the function fails", () => {
       void expectError(() => resolveTemplateString({ string: "${jsonDecode('{]}')}", context: new TestContext({}) }), {
-        contains:
-          "Invalid template string (${jsonDecode('{]}')}): Error from helper function jsonDecode: SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)",
+        contains: "Invalid template string (${jsonDecode('{]}')}): Error from helper function jsonDecode: SyntaxError",
       })
     })
 
@@ -1205,6 +1204,17 @@ describe("resolveTemplateString", () => {
         },
       })
       expect(res).to.equal("${base64Encode('${environment.namespace}')}")
+    })
+
+    it("does not apply helper function on unresolved template object and returns string as-is, when allowPartial=true", () => {
+      const res = resolveTemplateString({
+        string: "${base64Encode(var.foo)}",
+        context: new TestContext({ foo: { $forEach: ["a", "b"], $return: "${item.value}" } }),
+        contextOpts: {
+          allowPartial: true,
+        },
+      })
+      expect(res).to.equal("${base64Encode(var.foo)}")
     })
 
     context("concat", () => {


### PR DESCRIPTION
This caused bad handling of e.g. $forEach objects in input variables for templated actions.