### PR TITLE
fix(module-conversion): more fixes to PVC type

### DIFF
--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -108,7 +108,6 @@ export async function configureContainerModule({ log, moduleConfig }: ConfigureM
   moduleConfig.testConfigs = moduleConfig.spec.tests.map((t) => {
     for (const volume of t.volumes) {
       if (volume.module) {
-        moduleConfig.build.dependencies.push({ name: volume.module, copy: [] })
         t.dependencies.push(volume.module)
       }
     }
@@ -125,7 +124,6 @@ export async function configureContainerModule({ log, moduleConfig }: ConfigureM
   moduleConfig.taskConfigs = moduleConfig.spec.tasks.map((t) => {
     for (const volume of t.volumes) {
       if (volume.module) {
-        moduleConfig.build.dependencies.push({ name: volume.module, copy: [] })
         t.dependencies.push(volume.module)
       }
     }

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -712,7 +712,7 @@ describe("plugins.container", () => {
 
       const result = await configureContainerModule({ ctx, moduleConfig, log })
 
-      expect(result.moduleConfig.build.dependencies).to.eql([{ name: "volume-module", copy: [] }])
+      expect(result.moduleConfig.build.dependencies).to.eql([])
       expect(result.moduleConfig.taskConfigs[0].dependencies).to.eql(["volume-module"])
     })
 
@@ -763,7 +763,7 @@ describe("plugins.container", () => {
 
       const result = await configureContainerModule({ ctx, moduleConfig, log })
 
-      expect(result.moduleConfig.build.dependencies).to.eql([{ name: "volume-module", copy: [] }])
+      expect(result.moduleConfig.build.dependencies).to.eql([])
       expect(result.moduleConfig.testConfigs[0].dependencies).to.eql(["volume-module"])
     })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This is a follow-up to #5671 (see `47c24d5`). We also need to remove the added dependencies on the build steps of `persistentvolumeclaim` modules, since the converted actions there don't include a Build action.

Although this hasn't been reported yet, this would result in missing dependency errors when executing Runs or Tests that come from `container` modules which mount a `persistentvolumeclaim` module (using the `volumes` config field for `container` module services).