### PR TITLE
feat(config): add environments field on actions

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -75,6 +75,7 @@ export interface BaseActionConfig<K extends ActionKind = ActionKind, T = string,
   // -> Templating with ActionConfigContext allowed
   dependencies?: ActionReference[]
   disabled?: boolean
+  environments?: string[]
 
   // Version/file handling
   // -> Templating with ActionConfigContext allowed

--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -106,7 +106,12 @@ export class PluginsCommand extends Command<Args> {
     const provider = await garden.resolveProvider(log, args.plugin)
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
 
-    let graph = new ConfigGraph({ actions: [], moduleGraph: new ModuleGraph([], {}), groups: [] })
+    let graph = new ConfigGraph({
+      environmentName: garden.environmentName,
+      actions: [],
+      moduleGraph: new ModuleGraph([], {}),
+      groups: [],
+    })
 
     // Commands can optionally ask for all the modules in the project/environment
     if (command.resolveGraph) {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1063,7 +1063,6 @@ export class Garden {
       moduleGraph,
       actionModes,
       linkedSources,
-      environmentName: this.environmentName,
     })
 
     // TODO-0.13.1: detect overlap on Build actions
@@ -1190,6 +1189,7 @@ export class Garden {
     const graph = await this.getConfigGraph(params)
     const resolved = await this.resolveActions({ graph, actions: graph.getActions(), log: params.log })
     return new ResolvedConfigGraph({
+      environmentName: this.environmentName,
       actions: Object.values(resolved),
       moduleGraph: graph.moduleGraph,
       // TODO: perhaps groups should be resolved here

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -78,7 +78,6 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
   moduleGraph,
   actionModes,
   linkedSources,
-  environmentName,
 }: {
   garden: Garden
   log: Log
@@ -87,7 +86,6 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
   moduleGraph: ModuleGraph
   actionModes: ActionModeMap
   linkedSources: LinkedSourceMap
-  environmentName: string
 }): Promise<MutableConfigGraph> {
   const configsByKey: ActionConfigsByKey = {}
 
@@ -100,10 +98,10 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
     const existing = configsByKey[key]
 
     if (existing) {
-      if (actionIsDisabled(config, environmentName)) {
+      if (actionIsDisabled(config, garden.environmentName)) {
         log.silly(() => `Skipping disabled action ${key} in favor of other action with same key`)
         return
-      } else if (actionIsDisabled(existing, environmentName)) {
+      } else if (actionIsDisabled(existing, garden.environmentName)) {
         log.silly(() => `Skipping disabled action ${key} in favor of other action with same key`)
         configsByKey[key] = config
         return
@@ -205,7 +203,12 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
   const minimalRoots = await garden.vcs.getMinimalRoots(log, allPaths)
 
   // TODO: Maybe we could optimize resolving tree versions, avoid parallel scanning of the same directory etc.
-  const graph = new MutableConfigGraph({ actions: [], moduleGraph, groups: groupConfigs })
+  const graph = new MutableConfigGraph({
+    environmentName: garden.environmentName,
+    actions: [],
+    moduleGraph,
+    groups: groupConfigs,
+  })
 
   await Promise.all(
     Object.entries(preprocessResults).map(async ([key, res]) => {

--- a/core/src/graph/config-graph.ts
+++ b/core/src/graph/config-graph.ts
@@ -91,16 +91,20 @@ export abstract class BaseConfigGraph<
   }
 
   readonly moduleGraph: ModuleGraph
+  readonly environmentName: string
 
   constructor({
+    environmentName,
     actions,
     moduleGraph,
     groups,
   }: {
+    environmentName: string
     actions: Action[]
     moduleGraph: ModuleGraph
     groups: GroupConfig[]
   }) {
+    this.environmentName = environmentName
     this.dependencyGraph = {}
     this.actions = {
       Build: {},
@@ -132,7 +136,12 @@ export abstract class BaseConfigGraph<
   }
 
   clone() {
-    const clone = new ConfigGraph({ actions: [], moduleGraph: this.moduleGraph, groups: Object.values(this.groups) })
+    const clone = new ConfigGraph({
+      environmentName: this.environmentName,
+      actions: [],
+      moduleGraph: this.moduleGraph,
+      groups: Object.values(this.groups),
+    })
     for (const key of Object.getOwnPropertyNames(this)) {
       clone[key] = cloneDeep(this[key])
     }
@@ -455,6 +464,7 @@ export abstract class BaseConfigGraph<
 
   toMutableGraph() {
     return new MutableConfigGraph({
+      environmentName: this.environmentName,
       actions: this.getActions(),
       moduleGraph: this.moduleGraph,
       groups: Object.values(this.groups),

--- a/core/src/tasks/resolve-action.ts
+++ b/core/src/tasks/resolve-action.ts
@@ -201,6 +201,7 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
 
     // Resolve action without outputs
     const resolvedGraph = new ResolvedConfigGraph({
+      environmentName: this.graph.environmentName,
       actions: [...resolvedDependencies, ...executedDependencies],
       moduleGraph: this.graph.moduleGraph,
       groups: this.graph.getGroups(),

--- a/core/test/data/test-projects/config-action-environments/project.garden.yml
+++ b/core/test/data/test-projects/config-action-environments/project.garden.yml
@@ -1,0 +1,17 @@
+kind: Project
+apiVersion: garden.io/v1
+name: config-action-environments
+environments:
+  - name: local
+  - name: remote
+providers:
+  - name: test-plugin
+---
+kind: Build
+type: test
+name: a
+---
+kind: Build
+type: test
+name: b
+environments: [local]

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -54,7 +54,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const actions = graph.getActions()
@@ -86,7 +85,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const actions = graph.getActions()
@@ -118,7 +116,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const actions = graph.getActions()
@@ -150,7 +147,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const actions = graph.getActions()
@@ -189,7 +185,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const actions = graph.getActions()
@@ -232,7 +227,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("bar")
@@ -280,7 +274,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("bar")
@@ -329,7 +322,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("bar")
@@ -379,7 +371,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("bar")
@@ -429,7 +420,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("bar")
@@ -467,7 +457,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("foo")
@@ -496,7 +485,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("bar")
@@ -527,7 +515,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("foo")
@@ -562,7 +549,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("foo")
@@ -602,7 +588,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("foo")
@@ -658,7 +643,6 @@ describe("actionConfigsToGraph", () => {
         moduleGraph: new ModuleGraph([], {}),
         actionModes: {},
         linkedSources: {},
-        environmentName: garden.environmentName,
       })
 
       const action = graph.getBuild("foo")
@@ -703,7 +687,6 @@ describe("actionConfigsToGraph", () => {
       actionModes: {
         sync: ["deploy.foo"],
       },
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("foo")
@@ -734,7 +717,6 @@ describe("actionConfigsToGraph", () => {
       actionModes: {
         local: ["deploy.foo"],
       },
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("foo")
@@ -771,7 +753,6 @@ describe("actionConfigsToGraph", () => {
         local: ["deploy.foo"],
         sync: ["deploy.foo"],
       },
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("foo")
@@ -802,7 +783,6 @@ describe("actionConfigsToGraph", () => {
       actionModes: {
         local: ["*"],
       },
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("foo")
@@ -833,7 +813,6 @@ describe("actionConfigsToGraph", () => {
       actionModes: {
         local: ["deploy.f*"],
       },
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getDeploy("foo")
@@ -876,7 +855,6 @@ describe("actionConfigsToGraph", () => {
       actionModes: {
         local: ["deploy.*"],
       },
-      environmentName: garden.environmentName,
     })
 
     const deploy = graph.getDeploy("foo")
@@ -908,7 +886,6 @@ describe("actionConfigsToGraph", () => {
           moduleGraph: new ModuleGraph([], {}),
           actionModes: {},
           linkedSources: {},
-          environmentName: garden.environmentName,
         }),
       (err) => expect(err.message).to.equal("Unknown action kind: Boop")
     )
@@ -946,7 +923,6 @@ describe("actionConfigsToGraph", () => {
           moduleGraph: new ModuleGraph([], {}),
           actionModes: {},
           linkedSources: {},
-          environmentName: garden.environmentName,
         }),
       {
         contains: ["Found two actions of the same name and kind"],
@@ -985,7 +961,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("foo")
@@ -1023,7 +998,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     const action = graph.getBuild("foo")
@@ -1055,7 +1029,6 @@ describe("actionConfigsToGraph", () => {
         moduleGraph: new ModuleGraph([], {}),
         actionModes: {},
         linkedSources: {},
-        environmentName: garden.environmentName,
       })
       const action = graph.getBuild("foo")
 
@@ -1092,7 +1065,6 @@ describe("actionConfigsToGraph", () => {
       moduleGraph: new ModuleGraph([], {}),
       actionModes: {},
       linkedSources: {},
-      environmentName: garden.environmentName,
     })
 
     it("sets include and exclude", async () => {

--- a/core/test/unit/src/actions/base.ts
+++ b/core/test/unit/src/actions/base.ts
@@ -10,7 +10,7 @@ import { expect } from "chai"
 import { DEFAULT_BUILD_TIMEOUT_SEC } from "../../../../src/constants.js"
 import type { ActionConfig, BaseActionConfig } from "../../../../src/actions/types.js"
 import type { NonVersionedActionConfigKey } from "../../../../src/actions/base.js"
-import { getActionConfigVersion } from "../../../../src/actions/base.js"
+import { actionIsDisabled, getActionConfigVersion } from "../../../../src/actions/base.js"
 
 describe("getActionConfigVersion", () => {
   function minimalActionConfig(): ActionConfig {
@@ -56,5 +56,85 @@ describe("getActionConfigVersion", () => {
         expect(version1).to.eql(version2)
       })
     }
+  })
+})
+
+describe("actionIsDisabled", () => {
+  it("returns true if the action is disabled", () => {
+    const config: ActionConfig = {
+      kind: "Build",
+      type: "test",
+      name: "foo",
+      timeout: DEFAULT_BUILD_TIMEOUT_SEC,
+      internal: {
+        basePath: ".",
+      },
+      spec: {},
+      disabled: true,
+    }
+    expect(actionIsDisabled(config, "foo")).to.eql(true)
+  })
+
+  it("returns false if the action is not disabled", () => {
+    const config: ActionConfig = {
+      kind: "Build",
+      type: "test",
+      name: "foo",
+      timeout: DEFAULT_BUILD_TIMEOUT_SEC,
+      internal: {
+        basePath: ".",
+      },
+      disabled: false,
+      spec: {},
+    }
+    expect(actionIsDisabled(config, "foo")).to.eql(false)
+  })
+
+  it("returns false if action environments field is undefined", () => {
+    const config: ActionConfig = {
+      kind: "Build",
+      type: "test",
+      name: "foo",
+      timeout: DEFAULT_BUILD_TIMEOUT_SEC,
+      internal: {
+        basePath: ".",
+      },
+      disabled: false,
+      environments: undefined,
+      spec: {},
+    }
+    expect(actionIsDisabled(config, "foo")).to.eql(false)
+  })
+
+  it("returns false if action environments field is set and contains the environment", () => {
+    const config: ActionConfig = {
+      kind: "Build",
+      type: "test",
+      name: "foo",
+      timeout: DEFAULT_BUILD_TIMEOUT_SEC,
+      internal: {
+        basePath: ".",
+      },
+      disabled: false,
+      environments: ["yes"],
+      spec: {},
+    }
+    expect(actionIsDisabled(config, "yes")).to.eql(false)
+  })
+
+  it("returns true if action environments field is set and does not contain the environment", () => {
+    const config: ActionConfig = {
+      kind: "Build",
+      type: "test",
+      name: "foo",
+      timeout: DEFAULT_BUILD_TIMEOUT_SEC,
+      internal: {
+        basePath: ".",
+      },
+      disabled: false,
+      environments: ["yes"],
+      spec: {},
+    }
+    expect(actionIsDisabled(config, "no")).to.eql(true)
   })
 })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4358,6 +4358,18 @@ describe("Garden", () => {
         ],
       })
     })
+
+    it("correctly picks up and handles the environments field on actions", async () => {
+      const projectRoot = getDataDir("test-projects", "config-action-environments")
+      const garden = await makeTestGarden(projectRoot, { environmentString: "remote" })
+
+      const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      const a = graph.getBuild("a", { includeDisabled: true })
+      const b = graph.getBuild("b", { includeDisabled: true })
+
+      expect(a.isDisabled()).to.be.false
+      expect(b.isDisabled()).to.be.true
+    })
   })
 
   context("module type has a base", () => {

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -128,6 +128,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `variables`
 
 A map of variables scoped to this particular action. These are resolved before any other parts of the action configuration and take precedence over group-scoped variables (if applicable) and project-scoped variables, in that order. They may reference group-scoped and project-scoped variables, and generally can use any template strings normally allowed when resolving the action.

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -128,6 +128,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `variables`
 
 A map of variables scoped to this particular action. These are resolved before any other parts of the action configuration and take precedence over group-scoped variables (if applicable) and project-scoped variables, in that order. They may reference group-scoped and project-scoped variables, and generally can use any template strings normally allowed when resolving the action.

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -140,6 +140,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `variables`
 
 A map of variables scoped to this particular action. These are resolved before any other parts of the action configuration and take precedence over group-scoped variables (if applicable) and project-scoped variables, in that order. They may reference group-scoped and project-scoped variables, and generally can use any template strings normally allowed when resolving the action.

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -128,6 +128,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -132,6 +132,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -134,6 +134,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -132,6 +132,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -136,6 +136,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -128,6 +128,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -134,6 +134,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -132,6 +132,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -128,6 +128,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -134,6 +134,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -130,6 +130,14 @@ For other action kinds, the action is skipped in all scenarios, and dependency d
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `environments[]`
+
+If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is equivalent to `disabled: ${environment.name != "prod"}`.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `include[]`
 
 Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus will affect the computed _version_ of the action.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1803,6 +1803,11 @@ actionConfigs:
       # conditional expressions.
       disabled:
 
+      # If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand
+      # for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is
+      # equivalent to `disabled: ${environment.name != "prod"}`.
+      environments:
+
       # A map of variables scoped to this particular action. These are resolved before any other parts of the action
       # configuration and take precedence over group-scoped variables (if applicable) and project-scoped variables, in
       # that order. They may reference group-scoped and project-scoped variables, and generally can use any template
@@ -1973,6 +1978,11 @@ actionConfigs:
       # conditional expressions.
       disabled:
 
+      # If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand
+      # for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is
+      # equivalent to `disabled: ${environment.name != "prod"}`.
+      environments:
+
       # Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus
       # will affect the computed _version_ of the action.
       #
@@ -2113,6 +2123,11 @@ actionConfigs:
       # conditional expressions.
       disabled:
 
+      # If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand
+      # for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is
+      # equivalent to `disabled: ${environment.name != "prod"}`.
+      environments:
+
       # Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus
       # will affect the computed _version_ of the action.
       #
@@ -2252,6 +2267,11 @@ actionConfigs:
       # action is disabled, so you need to make sure to provide alternate values for those if you're using them, using
       # conditional expressions.
       disabled:
+
+      # If set, the action is only enabled for the listed environment types. This is effectively a cleaner shorthand
+      # for the `disabled` field with an expression for environments. For example, `environments: ["prod"]` is
+      # equivalent to `disabled: ${environment.name != "prod"}`.
+      environments:
 
       # Specify a list of POSIX-style paths or globs that should be regarded as source files for this action, and thus
       # will affect the computed _version_ of the action.

--- a/examples/disabled-configs/README.md
+++ b/examples/disabled-configs/README.md
@@ -20,7 +20,7 @@ And the `frontend` config like this:
 kind: Test
 name: frontend-integ
 type: container
-disabled: ${environment.name == local}
+environments: [remote] # <- Here we use the environments field instead of the expression above
 # ...
 spec:
   command: [npm, run, integ]

--- a/examples/disabled-configs/frontend/garden.yml
+++ b/examples/disabled-configs/frontend/garden.yml
@@ -45,7 +45,7 @@ type: container
 dependencies:
   - build.frontend
   - deploy.frontend
-disabled: ${environment.name == "local"}
+environments: [remote] # <- enabling only for the "remote" environment
 spec:
   command: [npm, run, integ]
   image: ${actions.build.frontend.outputs.deploymentImageId}


### PR DESCRIPTION
This allows setting e.g. `environments: [dev]` on actions instead of the
more verbose `disabled: ${environment.name != "dev"}`.

Resolves #3221