### PR TITLE
fix(k8s): don't throw when log fetching fails

### DIFF
--- a/core/src/plugins/kubernetes/retry.ts
+++ b/core/src/plugins/kubernetes/retry.ts
@@ -123,7 +123,7 @@ export function toKubernetesError(err: unknown, context: string): KubernetesErro
     // The ErrorEvent does not expose the status code other than as part of the error.message
   } else {
     // In all other cases, we don't know what this is, so let's just throw an InternalError
-    throw InternalError.wrapError(err, `toKubernetesError encountered an unknown error unexpectedly during ${context}`)
+    throw InternalError.wrapError(err, `toKubernetesError encountered an unknown error during ${context}`)
   }
 
   let message = `Error while performing Kubernetes API operation ${context}: ${errorType}\n`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This should fix an intermittent class of errors reported by users, where unhealthy pods result in Garden failing to fetch logs for these same pods (for the purposes of error reporting) and throwing a noisy error that obscures the underlying problem.

See https://github.com/garden-io/garden/issues/5559, for example.

Here, we catch errors thrown during the diagnostic pod log error fetching, and simply log a warning message that the log fetching failed.

**Which issue(s) this PR fixes**:

Fixes #5559 (hopefully).

**Special notes for your reviewer**:

It's kind of hard to write tests for this, but at least we're explicitly only catching an exception we weren't catching before, so this should be eminently safe.