### PR TITLE
fix(ci): macos cross build error

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -313,6 +313,11 @@ commands:
           e.g. when creating unstable releases. The script defaults to using the version from core/package.json.
         type: string
         default: ""
+      cargocommand:
+        description: |
+          Use Cross for cross-platform builds, or Cargo directly. Useful for macos which is not supported by cross.
+        type: string
+        default: "cross"
       context:
         description: Set this to the operating system, to avoid conflicting caches with the docker runs
         type: string
@@ -331,7 +336,7 @@ commands:
       - run:
           name: Run dist script
           command: |
-            npm run dist -- --version "<<parameters.version>>" <<parameters.targets>>
+            npm run dist -- --version "<<parameters.version>>" --cargocommand "<<parameters.cargocommand>>" <<parameters.targets>>
 
       # We cache the node archives because the NodeJS download mirror is unreliable
       - save_cache:
@@ -429,6 +434,7 @@ jobs:
       - run_npm_dist:
           version: <<parameters.version>>
           targets: "macos-amd64 macos-arm64"
+          cargocommand: cargo
           context: vm-macos
       - fail_fast
 
@@ -450,6 +456,7 @@ jobs:
       - run_npm_dist:
           version: <<parameters.version>>
           targets: "linux-amd64 linux-arm64 alpine-amd64 windows-amd64"
+          cargocommand: cross
           context: vm-ubuntu
       - fail_fast
 

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -218,6 +218,12 @@ async function buildBinaries(args: string[]) {
     versionInFilename = versionInBinary
   }
 
+  let cargoCommand = "cargo"
+
+  if (argv.cargocommand) {
+    cargoCommand = argv.cargocommand
+  }
+
   const selected = argv._.length > 0 ? pick(targets, argv._) : targets
 
   if (Object.keys(selected).length === 0) {
@@ -427,10 +433,10 @@ async function buildBinaries(args: string[]) {
     const rustTarget = getRustTarget(target.spec)
 
     // Run Garden SEA smoke tests. Windows tests run in a wine environment.
-    await exec("cross", ["test", "--target", rustTarget], { cwd: gardenSeaDir, stdio: "inherit" })
+    await exec(cargoCommand, ["test", "--target", rustTarget], { cwd: gardenSeaDir, stdio: "inherit" })
 
     // Build the release binary
-    await exec("cross", ["build", "--target", rustTarget, "--release"], { cwd: gardenSeaDir, stdio: "inherit" })
+    await exec(cargoCommand, ["build", "--target", rustTarget, "--release"], { cwd: gardenSeaDir, stdio: "inherit" })
 
     const executableFilename = target.spec.os === "win" ? "garden.exe" : "garden"
     const executablePath = resolve(distTargetDir, executableFilename)

--- a/docs/contributing/developing-garden.md
+++ b/docs/contributing/developing-garden.md
@@ -38,8 +38,9 @@ You can build the release binaries using the command
 
 ```shell
 npm run dist [target] # Valid targets are currently `windows-amd64`, `linux-arm64`, `linux-amd64`, `macos-arm64` and `macos-amd64`.
-
 ```
+
+Use the option ` --cargocommand=cross` for cross-platform builds, otherwise cargo build will be the default.
 
 You can then find the release binaries and archives under `dist/`.
 

--- a/garden-sea/README.md
+++ b/garden-sea/README.md
@@ -14,6 +14,9 @@ You can build the release binaries using the command
 ```shell
 npm run dist [target] # Valid targets are currently `windows-amd64`, `linux-arm64`, `linux-amd64`, `macos-arm64` and `macos-amd64`.
 ```
+
+Use the option ` --cargocommand=cross` for cross-platform builds, otherwise cargo build will be the default.
+
 You can then find the release binaries and archives under `dist/`.
 
 After you ran `npm run dist` for the first time the artifacts we reference using the `include_bytes!` macro in `artifacts.rs` have been generated in the appropriate location. From then on you can also build and test the application using cargo commands, like any other Rust application:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

On macos we should use cargo directly, as cross needs custom docker images.

A recent version of cross does not automatically fall back to just cargo anymore, so we need to introduce a cargo command flag for npm run dist.


**Special notes for your reviewer**:
