### PR TITLE
fix(core): don't execute disabled dependencies

### DIFF
--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -275,7 +275,7 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
         }
         return [this.getExecuteTask(action)]
       } else if (dep.explicit) {
-        if (this.skipRuntimeDependencies && dep.kind !== "Build") {
+        if ((this.skipRuntimeDependencies || disabled) && dep.kind !== "Build") {
           if (dep.needsStaticOutputs) {
             return [this.getResolveTask(action)]
           } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

When executing an action that depends on a disabled dependency, the disabled dependency should be skipped (unless it's a build).

This is fixed here (in accordance with the docstring for the `disabled` field on action configs).