### PR TITLE
docs: stop using build field in docs and examples

### DIFF
--- a/docs/getting-started/next-steps.md
+++ b/docs/getting-started/next-steps.md
@@ -174,8 +174,10 @@ kind: Test
 name: api-integ
 type: container
 description: A Test action for integration testing the api after its been deployed
-build: api # <--- Use the api image to run the test
-dependencies: [deploy.api]
+dependencies: [build.api, deploy.api]
+spec:
+  image: ${actions.build.api.outputs.deploymentImageId}
+  command: [./integ-tests.sh]
 ```
 
 Depending on the size of your project, you may want to add a handful of actions to get started and then gradually add more as needed.

--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -27,8 +27,10 @@ To configure a service for sync mode, add `sync` to your Deploy configuration to
 kind: Deploy
 name: node-service
 type: container
-build: node-service-build
+dependencies:
+  - build.node-service-build
 spec:
+  image: ${actions.build.node-service-build.outputs.deploymentImageId}
   args: [npm, run, serve]
   sync:
     paths:
@@ -146,8 +148,10 @@ Exclusion rules can be specified on individual sync configs:
 kind: Deploy
 name: node-service
 type: container
-build: node-service-build
+dependencies:
+  - build.node-service-build
 spec:
+  image: ${actions.build.node-service-build.outputs.deploymentImageId}
   args: [npm, run, serve]
   sync:
     paths:
@@ -189,8 +193,10 @@ To do this, you can set a few options on each sync:
 kind: Deploy
 name: node-service
 type: container
-build: node-service-build
+dependencies:
+  - build.node-service-build
 spec:
+  image: ${actions.build.node-service-build.outputs.deploymentImageId}
   sync:
     paths:
       - target: /app/src
@@ -236,8 +242,10 @@ type: container
 description: |
   Here, we sync source code into the remote, and sync back the `test-artifacts` directory
   (populated when we run tests) back to the local machine.
-build: node-service-build
+dependencies:
+  - build.node-service-build
 spec:
+  image: ${actions.build.node-service-build.outputs.deploymentImageId}
   args: [npm, start]
   sync:
     # Overrides the container's default when the service is deployed in sync mode.

--- a/docs/guides/migrating-from-docker-compose.md
+++ b/docs/guides/migrating-from-docker-compose.md
@@ -70,10 +70,11 @@ apiVersion: garden.io/v1
 name: backend
 description: The backend server container
 type: container
-build: backend
 dependencies:
+  - build.backend
   - deploy.mongo
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   sync:
     paths:
       - source: ./
@@ -124,10 +125,11 @@ apiVersion: garden.io/v1
 name: frontend
 description: The frontend server and UI components container
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   env:
     DANGEROUSLY_DISABLE_HOST_CHECK: true
   sync:

--- a/docs/guides/running-service-in-local-mode.md
+++ b/docs/guides/running-service-in-local-mode.md
@@ -161,9 +161,11 @@ type: container
 kind: Deploy
 name: node-app
 type: container
-build: node-app
+dependencies:
+  - build.node-app
 ...
 spec:
+  image: ${actions.build.node-app.outputs.deploymentImageId}
   localMode:
     ports:
       - local: 8090 # The port of the local app, will be used for port-forward setup.
@@ -195,6 +197,8 @@ kind: Deploy
 name: backend
 type: kubernetes # this example looks the same for helm actions (i.e. with `type: helm`)
 build: backend
+dependencies:
+  - build.backend
 localMode:
   ports:
     - local: 8090

--- a/docs/k8s-plugins/ephemeral-k8s/ingress.md
+++ b/docs/k8s-plugins/ephemeral-k8s/ingress.md
@@ -29,10 +29,12 @@ kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-build: frontend
+dependencies:
+ - build.frontend
 variables:
   base-hostname: "${environment.name == 'ephemeral' ? providers.ephemeral-kubernetes.outputs.default-hostname : local.demo.garden}"
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080

--- a/docs/other-plugins/container.md
+++ b/docs/other-plugins/container.md
@@ -154,8 +154,10 @@ Here is a configuration example for two different test suites:
 kind: Test
 name: my-app-unit
 type: container
-build: my-app
+dependencies:
+  - build.my-app
 spec:
+  image: ${actions.build.my-app.outputs.deploymentImageId}
   args: [ npm, test ]
 
 ---
@@ -163,10 +165,11 @@ spec:
 kind: Test
 name: my-app-integ
 type: container
-build: my-app
 dependencies:
+  - build.my-app
   - deploy.my-app
 spec:
+  image: ${actions.build.my-app.outputs.deploymentImageId}
   args: [ npm, run, integ ]
 
 ```

--- a/docs/using-garden/tests.md
+++ b/docs/using-garden/tests.md
@@ -12,10 +12,11 @@ You add Tests when you want Garden to run your test suites for you. A minimalist
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
+  - build.frontend # <- we depend on the build because the image is used when running the test
   - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId} # <- use the output from the corresponding image build
   args: [npm, run, integ]
 ```
 
@@ -40,10 +41,11 @@ Below is an example of a `frontend-integ` Test that checks whether the frontend 
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
+  - build.frontend # <- we depend on the build because the image is used when running the test
   - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId} # <- use the output from the corresponding image build
   args: [npm, run, integ]
 ```
 

--- a/e2e/projects/open-telemetry/otlp-server/garden.yml
+++ b/e2e/projects/open-telemetry/otlp-server/garden.yml
@@ -7,9 +7,10 @@ type: container
 kind: Deploy
 name: otlp-http
 description: OTLP HTTP service container
+dependencies: [build.otlp-http]
 type: container
-build: otlp-http
 spec:
+  image: ${actions.build.otlp-http.outputs.deploymentImageId}
   ports:
     - name: http-otlp
       containerPort: 8080

--- a/examples/base-image/backend/backend.garden.yml
+++ b/examples/base-image/backend/backend.garden.yml
@@ -12,15 +12,14 @@ spec:
     BASE_IMAGE_VERSION: ${actions.build.base-image.version}
 
 ---
-
 kind: Deploy
 name: backend
 description: Backend service
 type: container
-
-build: backend
-
+dependencies:
+  - build.backend
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080

--- a/examples/build-dependencies/backend/garden.yml
+++ b/examples/build-dependencies/backend/garden.yml
@@ -16,10 +16,10 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: container
-
-build: backend
-
+dependencies:
+  - build.backend
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -34,7 +34,8 @@ kind: Run
 name: backend
 description: Simple run task
 type: container
-build: backend
-
+dependencies:
+  - build.backend
 spec:
   command: ["sh", "-c", "echo task output"]
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/build-dependencies/frontend/garden.yml
+++ b/examples/build-dependencies/frontend/garden.yml
@@ -12,28 +12,25 @@ copyFrom:
     targetPath: "config/"
 
 ---
-
 kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
-
 dependencies:
+  - build.frontend
   - deploy.backend
-
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   sync:
-    command: [ npm, run, dev ]
+    command: [npm, run, dev]
     paths:
       - source: .
         target: /app
-        exclude: [ node_modules ]
-        mode: one-way # do not set to one-way-replica, otherwise it will remove the /config dir
+        exclude: [node_modules]
+        mode: one-way
       - source: ../shared-config/
         target: /app/config/
-        exclude: [ garden.yml ]
+        exclude: [garden.yml]
         mode: one-way-replica
   ports:
     - name: http
@@ -52,16 +49,19 @@ spec:
 kind: Test
 name: frontend-unit
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 spec:
-  args: [ npm, test ]
+  args: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
-  - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
+  - build.frontend
+  - deploy.frontend
 spec:
-  args: [ npm, run, integ ]
+  args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/cert-manager-ext-dns/frontend/garden.yml
+++ b/examples/cert-manager-ext-dns/frontend/garden.yml
@@ -4,13 +4,14 @@ type: container
 name: frontend
 description: React App Build for TLS and DNS example
 ---
-# Deploys the frontend React App
 kind: Deploy
 type: container
 name: frontend
 description: React App Deploy for TLS and DNS example
-build: frontend
+dependencies:
+  - build.frontend
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       protocol: TCP
@@ -19,13 +20,14 @@ spec:
     - path: /
       hostname: "react.${var.base-hostname}"
       port: http
+
 ---
-# Setup tests for the frontend React App
 kind: Test
 name: react-unit
 type: container
-build: frontend
+dependencies:
+  - build.frontend
+  - deploy.frontend
 spec:
   args: [npm, test]
-dependencies:
-  - deploy.frontend
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/code-synchronization/node-service/garden.yml
+++ b/examples/code-synchronization/node-service/garden.yml
@@ -7,8 +7,10 @@ kind: Deploy
 description: Node greeting service
 name: node-service
 type: container
-build: node-service
+dependencies:
+  - build.node-service
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   args: [npm, start]
   sync:
     command: [npm, run, dev] # Overrides the container's default when the service is deployed in dev mode

--- a/examples/demo-project/backend/backend.garden.yml
+++ b/examples/demo-project/backend/backend.garden.yml
@@ -4,19 +4,16 @@ description: Backend service container image
 type: container
 
 ---
-
 kind: Deploy
 name: backend
 description: Backend service container
 type: container
-
-build: backend
-
-# You can specify variables here at the action level
+dependencies:
+  - build.backend
 variables:
   ingressPath: /hello-backend
-
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   healthCheck:
     httpGet:
       path: /hello-backend
@@ -35,6 +32,8 @@ spec:
 kind: Run
 name: backend-run-task
 type: container
-build: backend
+dependencies:
+  - build.backend
 spec:
   command: ["sh", "-c", "echo task output"]
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/demo-project/frontend/frontend.garden.yml
+++ b/examples/demo-project/frontend/frontend.garden.yml
@@ -4,17 +4,15 @@ description: Frontend service container image
 type: container
 
 ---
-
 kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
-
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -29,21 +27,22 @@ spec:
       port: http
 
 ---
-
 kind: Test
 name: frontend-unit
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 spec:
   args: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
-
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
-  - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
+  - build.frontend
+  - deploy.frontend
 spec:
   args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -2,6 +2,9 @@ apiVersion: garden.io/v1
 kind: Project
 name: demo-project
 # defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.
+
+dotIgnoreFile: "foo"
+
 environments:
   - name: local
   - name: remote
@@ -26,3 +29,4 @@ providers:
         namespace: default
 variables:
   userId: ${kebabCase(local.username)}
+

--- a/examples/disabled-configs/backend/garden.yml
+++ b/examples/disabled-configs/backend/garden.yml
@@ -10,11 +10,11 @@ kind: Deploy
 name: backend
 description: Backend service container image
 type: container
-
-build: backend
+dependencies:
+  - build.backend
 disabled: ${environment.name == "local"}
-
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -28,9 +28,9 @@ spec:
 kind: Run
 name: backend
 type: container
-
-build: backend
+dependencies:
+  - build.backend
 disabled: ${environment.name == "local"}
-
 spec:
-  command: [ "sh", "-c", "echo task output" ]
+  command: ["sh", "-c", "echo task output"]
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/disabled-configs/frontend/garden.yml
+++ b/examples/disabled-configs/frontend/garden.yml
@@ -8,12 +8,11 @@ kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
-
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -32,22 +31,21 @@ kind: Test
 name: frontend-unit
 description: Frontend service unit tests
 type: container
-
-build: frontend
-
+dependencies:
+  - build.frontend
 spec:
-  command: [ npm, test ]
+  command: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
 description: Frontend service integration tests
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend
 disabled: ${environment.name == "local"}
-
 spec:
-  command: [ npm, run, integ ]
+  command: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/ephemeral-cluster-demo/backend/backend.garden.yml
+++ b/examples/ephemeral-cluster-demo/backend/backend.garden.yml
@@ -10,13 +10,15 @@ name: backend
 description: Backend service container
 type: container
 
-build: backend
+dependencies:
+  - build.backend
 
 # You can specify variables here at the action level
 variables:
   ingressPath: /hello-backend
 
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   healthCheck:
     httpGet:
       path: /hello-backend
@@ -35,6 +37,9 @@ spec:
 kind: Run
 name: backend-run-task
 type: container
-build: backend
+dependencies:
+  - build.backend
+
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   command: ["sh", "-c", "echo task output"]

--- a/examples/ephemeral-cluster-demo/frontend/frontend.garden.yml
+++ b/examples/ephemeral-cluster-demo/frontend/frontend.garden.yml
@@ -10,11 +10,12 @@ name: frontend
 description: Frontend service container
 type: container
 
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
 
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -31,8 +32,11 @@ spec:
 kind: Test
 name: frontend-unit
 type: container
-build: frontend
+
+dependencies:
+  - build.frontend
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   args: [npm, test]
 
 ---
@@ -40,8 +44,9 @@ spec:
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   args: [npm, run, integ]

--- a/examples/gatsby-code-sync/garden.yml
+++ b/examples/gatsby-code-sync/garden.yml
@@ -16,13 +16,13 @@ kind: Deploy
 description: Minimal Gatsby example
 name: website
 type: container
-build: website
+dependencies:
+  - build.website
 spec:
   sync:
     paths:
       - source: src
         target: /app/src
-        # Make sure to specify any paths that should not be synced!
         exclude: [node_modules]
         mode: one-way
   args: [npm, run, dev]
@@ -34,3 +34,4 @@ spec:
   ingresses:
     - path: /
       port: http
+  image: ${actions.build.website.outputs.deploymentImageId}

--- a/examples/gke/backend/garden.yml
+++ b/examples/gke/backend/garden.yml
@@ -8,8 +8,10 @@ kind: Deploy
 name: backend
 description: Backend service
 type: container
-build: backend
+dependencies:
+  - build.backend
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080

--- a/examples/gke/frontend/garden.yml
+++ b/examples/gke/frontend/garden.yml
@@ -8,8 +8,8 @@ kind: Deploy
 name: frontend
 description: Frontend service
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
 spec:
   ports:
@@ -24,21 +24,25 @@ spec:
       port: http
     - path: /call-backend
       port: http
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: unit
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 spec:
   args: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: integ
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend
 spec:
   args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/hadolint/backend/garden.yml
+++ b/examples/hadolint/backend/garden.yml
@@ -8,7 +8,8 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: container
-build: backend
+dependencies:
+  - build.backend
 spec:
   ports:
     - name: http
@@ -18,3 +19,4 @@ spec:
   ingresses:
     - path: /hello-backend
       port: http
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/hadolint/frontend/garden.yml
+++ b/examples/hadolint/frontend/garden.yml
@@ -8,8 +8,8 @@ kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
 spec:
   ports:
@@ -24,23 +24,27 @@ spec:
       port: http
     - path: /call-backend
       port: http
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-unit
 description: Frontend service container unit tests
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 spec:
-  command: [ npm, test ]
+  command: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
 description: Frontend service container integration tests
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend
 spec:
-  command: [ npm, run, integ ]
+  command: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/k8s-deploy-patch-resources/api/garden.yml
+++ b/examples/k8s-deploy-patch-resources/api/garden.yml
@@ -61,11 +61,10 @@ spec:
 kind: Test
 name: api-unit
 type: container
-build: api
-timeout: 200
-
 dependencies:
+  - build.api
   - deploy.api
-
+timeout: 200
 spec:
   args: [echo, ok]
+  image: ${actions.build.api.outputs.deploymentImageId}

--- a/examples/k8s-deploy-patch-resources/web/garden.yml
+++ b/examples/k8s-deploy-patch-resources/web/garden.yml
@@ -55,15 +55,19 @@ spec:
 kind: Test
 name: web-unit
 type: container
-build: web
+dependencies:
+  - build.web
 spec:
   args: [npm, run, test:unit]
+  image: ${actions.build.web.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: e2e-runner
 type: container
-build: web
-dependencies: [deploy.api]
+dependencies:
+  - build.web
+  - deploy.api
 spec:
   args: [npm, run, test:integ]
+  image: ${actions.build.web.outputs.deploymentImageId}

--- a/examples/k8s-deploy-shared-manifests/api/garden.yml
+++ b/examples/k8s-deploy-shared-manifests/api/garden.yml
@@ -76,11 +76,10 @@ variables:
 kind: Test
 name: api-unit
 type: container
-build: api
-timeout: 200
-
 dependencies:
+  - build.api
   - deploy.api
-
+timeout: 200
 spec:
   args: [echo, ok]
+  image: ${actions.build.api.outputs.deploymentImageId}

--- a/examples/k8s-deploy-shared-manifests/web/garden.yml
+++ b/examples/k8s-deploy-shared-manifests/web/garden.yml
@@ -72,17 +72,20 @@ variables:
 kind: Test
 name: web-unit
 type: container
-build: web
+dependencies:
+  - build.web
 spec:
   args: [npm, run, test:unit]
+  image: ${actions.build.web.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: e2e-runner
 type: container
-build: web
 dependencies:
+  - build.web
   - deploy.api
   - deploy.web
 spec:
   args: [npm, run, test:integ]
+  image: ${actions.build.web.outputs.deploymentImageId}

--- a/examples/kaniko/backend/garden.yml
+++ b/examples/kaniko/backend/garden.yml
@@ -7,7 +7,8 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: container
-build: backend
+dependencies:
+  - build.backend
 spec:
   ports:
     - name: http
@@ -17,3 +18,4 @@ spec:
   ingresses:
     - path: /hello-backend
       port: http
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/kaniko/frontend/garden.yml
+++ b/examples/kaniko/frontend/garden.yml
@@ -8,8 +8,8 @@ name: frontend
 description: Frontend service container
 type: container
 dependencies:
+  - build.frontend
   - deploy.backend
-build: frontend
 spec:
   ports:
     - name: http
@@ -23,21 +23,25 @@ spec:
       port: http
     - path: /call-backend
       port: http
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 name: frontend-unit
 spec:
   command: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 type: container
-build: frontend
-name: frontend-integ
 dependencies:
+  - build.frontend
   - deploy.frontend
+name: frontend-integ
 spec:
   command: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/kubernetes-secrets/backend/garden.yml
+++ b/examples/kubernetes-secrets/backend/garden.yml
@@ -8,18 +8,20 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: container
-build: backend
+dependencies:
+  - build.backend
 spec:
-    ports:
-      - name: http
-        containerPort: 8080
-        # Maps service:80 -> container:8080
-        servicePort: 80
-    ingresses:
-      - path: /hello-backend
-        port: http
-    env:
-      SECRET_VAR:
-        secretRef:
-          name: my-secret
-          key: my-key
+  image: ${actions.build.backend.outputs.deploymentImageId}
+  ports:
+    - name: http
+      containerPort: 8080
+      # Maps service:80 -> container:8080
+      servicePort: 80
+  ingresses:
+    - path: /hello-backend
+      port: http
+  env:
+    SECRET_VAR:
+      secretRef:
+        name: my-secret
+        key: my-key

--- a/examples/kubernetes-secrets/frontend/garden.yml
+++ b/examples/kubernetes-secrets/frontend/garden.yml
@@ -8,10 +8,11 @@ kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -30,17 +31,20 @@ kind: Test
 name: frontend-unit
 description: Frontend service container unit tests
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 spec:
-  command: [ npm, test ]
+  command: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
 description: Frontend service container integration tests
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend
 spec:
-  command: [ npm, run, integ ]
+  command: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/local-exec/backend/backend.garden.yml
+++ b/examples/local-exec/backend/backend.garden.yml
@@ -29,14 +29,13 @@ copyFrom:
     targetPath: .
 
 ---
-# This action's Dockerfile expects the Go binary to already be built
 kind: Deploy
 type: container
 name: backend
-
-build: backend
-
+dependencies:
+  - build.backend
 spec:
+  image: ${actions.build.backend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080

--- a/examples/local-mode-helm/frontend/garden.yml
+++ b/examples/local-mode-helm/frontend/garden.yml
@@ -4,17 +4,15 @@ description: Frontend service container image
 type: container
 
 ---
-
 kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
-
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -33,8 +31,9 @@ spec:
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
-  - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
+  - build.frontend
+  - deploy.frontend
 spec:
-  args: [ npm, run, integ ]
+  args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/local-mode-k8s/backend/garden.yml
+++ b/examples/local-mode-k8s/backend/garden.yml
@@ -2,22 +2,20 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: kubernetes
-
-build: backend-image
-dependencies: "${this.mode == 'local' ? ['run.build-backend-local'] : []}"
-
+dependencies:
+  - build.backend-image
+  - "${this.mode == 'local' ? ['run.build-backend-local'] : []}"
 spec:
+  image: ${actions.build.backend-image.outputs.deployment-image-id}
   localMode:
     ports:
       - local: 8090
         remote: 8080
-    # starts the local application
-    command: [ "../backend-local/main" ]
+    command: ["../backend-local/main"]
     target:
       kind: Deployment
       name: backend-deployment
       containerName: backend
-
   manifests:
     - apiVersion: v1
       kind: Service

--- a/examples/local-mode-k8s/frontend/garden.yml
+++ b/examples/local-mode-k8s/frontend/garden.yml
@@ -4,17 +4,15 @@ description: Frontend service container image
 type: container
 
 ---
-
 kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
-
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -33,8 +31,9 @@ spec:
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
-  - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
+  - build.frontend
+  - deploy.frontend
 spec:
-  args: [ npm, run, integ ]
+  args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/local-mode/backend-1/garden.yml
+++ b/examples/local-mode/backend-1/garden.yml
@@ -10,14 +10,14 @@ name: backend-1
 description: Backend 1 service container
 type: container
 
-build: backend-1
-dependencies: "${this.mode == 'local' ? ['run.build-backend-local-1'] : []}"
+dependencies: "${this.mode == 'local' ? ['run.build-backend-local-1'] : ['build.backend-1']}"
 
 # You can specify variables here at the action level
 variables:
   ingressPath: /hello-backend-1
 
 spec:
+  image: ${actions.build.backend-1.outputs.deploymentImageId}
   localMode:
     ports:
       - remote: 8080

--- a/examples/local-mode/backend-2/garden.yml
+++ b/examples/local-mode/backend-2/garden.yml
@@ -4,26 +4,21 @@ description: Backend 2 service container image
 type: container
 
 ---
-
 kind: Deploy
 name: backend-2
 description: Backend 2 service container
 type: container
-
-build: backend-2
-dependencies: "${this.mode == 'local' ? ['run.build-backend-local-2'] : []}"
-
-# You can specify variables here at the action level
+dependencies:
+  - build.backend-2
+  - "${this.mode == 'local' ? ['run.build-backend-local-2'] : []}"
 variables:
   ingressPath: /hello-backend-2
-
 spec:
   localMode:
     ports:
       - remote: 8081
         local: 8091
-    # starts the local application
-    command: [ "../backend-local-2/main" ]
+    command: ["../backend-local-2/main"]
   healthCheck:
     httpGet:
       path: ${var.ingressPath}
@@ -31,8 +26,8 @@ spec:
   ports:
     - name: http
       containerPort: 8081
-      # Maps service:80 -> container:8081
       servicePort: 80
   ingresses:
     - path: ${var.ingressPath}
       port: http
+  image: ${actions.build.backend-2.outputs.deploymentImageId}

--- a/examples/local-mode/frontend/garden.yml
+++ b/examples/local-mode/frontend/garden.yml
@@ -4,17 +4,14 @@ description: Frontend service container image
 type: container
 
 ---
-
 kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend-1
   - deploy.backend-2
-
 spec:
   ports:
     - name: http
@@ -30,14 +27,17 @@ spec:
       port: http
     - path: /call-backend-2
       port: http
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
 dependencies:
-  - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
+  - build.frontend
+  - deploy.frontend
 spec:
-  args: [ npm, run, integ ]
+  args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
+

--- a/examples/local-service/backend/garden.yml
+++ b/examples/local-service/backend/garden.yml
@@ -8,13 +8,10 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: container
-
-build: backend
-
-# You can specify variables here at the action level
+dependencies:
+  - build.backend
 variables:
   ingressPath: /hello-backend
-
 spec:
   healthCheck:
     httpGet:
@@ -28,12 +25,14 @@ spec:
   ingresses:
     - path: ${var.ingressPath}
       port: http
+  image: ${actions.build.backend.outputs.deploymentImageId}
 
 ---
 kind: Run
 name: backend
 type: container
-build: backend
-
+dependencies:
+  - build.backend
 spec:
   command: ["sh", "-c", "echo task output"]
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/local-service/frontend/garden.yml
+++ b/examples/local-service/frontend/garden.yml
@@ -9,17 +9,14 @@ kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-
-build: frontend
-
 dependencies:
+  - build.frontend
   - deploy.backend
-
 variables:
   env:
     PORT: 8080
-
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -39,28 +36,26 @@ kind: Test
 name: frontend-unit
 description: Frontend service unit tests
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend
-
 spec:
   args: [npm, test]
   env: ${actions.deploy.frontend.var.env}
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
 description: Frontend service integration tests
 type: container
-
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.frontend
-
 spec:
   args: [npm, run, integ]
   env: ${actions.deploy.frontend.var.env}
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Build
@@ -73,11 +68,10 @@ include: []
 kind: Deploy
 name: frontend-local
 type: exec
-
-build: frontend-local
-
+dependencies:
+  - build.frontend-local
 spec:
   persistent: true
   deployCommand: ["yarn", "run", "dev"]
-  statusCommand: [./check-local-status.sh]
+  statusCommand: ["./check-local-status.sh"]
   env: ${actions.deploy.frontend.var.env}

--- a/examples/local-tls/services/go-service/garden.yml
+++ b/examples/local-tls/services/go-service/garden.yml
@@ -8,10 +8,10 @@ kind: Deploy
 name: go-service
 description: Go service container
 type: container
-
-build: go-service
-
+dependencies:
+  - build.go-service
 spec:
+  image: ${actions.build.go-service.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 80

--- a/examples/local-tls/services/node-service/garden.yml
+++ b/examples/local-tls/services/node-service/garden.yml
@@ -9,11 +9,12 @@ name: node-service
 description: Node service container
 type: container
 
-build: node-service
 dependencies:
+  - build.node-service
   - deploy.go-service
 
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   args: [ npm, start ]
   ports:
     - name: http
@@ -30,9 +31,11 @@ name: node-service-unit
 description: Node service container unit tests
 type: container
 
-build: node-service
+dependencies:
+  - build.node-service
 
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   command: [ npm, test ]
 
 ---
@@ -41,10 +44,11 @@ name: node-service-integ
 description: Node service container integration tests
 type: container
 
-build: node-service
 dependencies:
+  - build.node-service
   - deploy.go-service
 
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   command: [ npm, run, integ ]
 

--- a/examples/modules-to-actions/node-service/garden.yml
+++ b/examples/modules-to-actions/node-service/garden.yml
@@ -8,10 +8,12 @@ spec:
 ---
 kind: Deploy
 name: a
-build: a
 description: Node service A
 type: container
+dependencies:
+  - build.a
 spec:
+  image: ${actions.build.a.outputs.deploymentImageId}
   command: [npm, start]
   ports:
     - name: http
@@ -23,10 +25,12 @@ spec:
 ---
 kind: Test
 name: a-unit
-build: a
 type: container
+dependencies:
+  - build.a
 spec:
   args: [npm, test]
+  image: ${actions.build.a.outputs.deploymentImageId}
 
 ---
 kind: Build
@@ -39,10 +43,12 @@ spec:
 ---
 kind: Deploy
 name: b
-build: b
 description: Node service B
 type: container
+dependencies:
+  - build.b
 spec:
+  image: ${actions.build.b.outputs.deploymentImageId}
   command: [npm, start]
   ports:
     - name: http
@@ -54,7 +60,9 @@ spec:
 ---
 kind: Test
 name: b-unit
-build: b
 type: container
+dependencies:
+  - build.b
 spec:
   args: [npm, test]
+  image: ${actions.build.b.outputs.deploymentImageId}

--- a/examples/remote-k8s/services/go-service/garden.yml
+++ b/examples/remote-k8s/services/go-service/garden.yml
@@ -8,8 +8,10 @@ kind: Deploy
 name: go-service
 type: container
 description: Go service container
-build: go-service
+dependencies:
+  - build.go-service
 spec:
+  image: ${actions.build.go-service.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 80

--- a/examples/remote-k8s/services/node-service/garden.yml
+++ b/examples/remote-k8s/services/node-service/garden.yml
@@ -8,10 +8,11 @@ kind: Deploy
 name: node-service
 type: container
 description: Node service
-build: node-service
 dependencies:
+  - build.node-service
   - deploy.go-service
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   args: [npm, start]
   ports:
     - name: http
@@ -26,16 +27,19 @@ spec:
 kind: Test
 name: node-service-unit
 type: container
-build: node-service
+dependencies:
+  - build.node-service
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   args: [npm, test]
 
 ---
 kind: Test
 name: node-service-integ
 type: container
-build: node-service
 dependencies:
+  - build.node-service
   - deploy.node-service
 spec:
+  image: ${actions.build.node-service.outputs.deploymentImageId}
   args: [npm, run, integ]

--- a/examples/remote-sources/worker/garden.yml
+++ b/examples/remote-sources/worker/garden.yml
@@ -10,8 +10,8 @@ kind: Deploy
 description: The worker that collects votes and stores results in a postgres table
 type: container
 name: worker
-build: worker
 dependencies:
+  - build.worker
   - deploy.redis
   - run.db-init
 spec:
@@ -19,3 +19,4 @@ spec:
     PGDATABASE: ${var.postgres-database}
     PGUSER: ${var.postgres-username}
     PGPASSWORD: ${var.postgres-password}
+  image: ${actions.build.worker.outputs.deploymentImageId}

--- a/examples/run-actions/hello/garden.yml
+++ b/examples/run-actions/hello/garden.yml
@@ -7,8 +7,8 @@ kind: Deploy
 name: hello
 description: Greeting service
 type: container
-build: hello
 dependencies:
+  - build.hello
   - run.node-migration
 spec:
   args: [npm, start]
@@ -18,25 +18,26 @@ spec:
   ingresses:
     - path: /hello
       port: http
+  image: ${actions.build.hello.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: hello-unit
 type: container
-build: hello
+dependencies:
+  - build.hello
 spec:
   args: [npm, test]
+  image: ${actions.build.hello.outputs.deploymentImageId}
 
 ---
 kind: Run
 name: node-migration
 type: container
-build: hello
-description: Creates the users table.
 dependencies:
+  - build.hello
   - deploy.postgres
+description: Creates the users table.
 spec:
-  # The postgres health check appears to go through before the server accepts remote connections,
-  # so we set a long initial delay.
-  # https://github.com/CrunchyData/crunchy-containers/issues/653
   args: [/bin/sh, -c, "sleep 15 && knex migrate:latest"]
+  image: ${actions.build.hello.outputs.deploymentImageId}

--- a/examples/run-actions/user/garden.yml
+++ b/examples/run-actions/user/garden.yml
@@ -7,10 +7,11 @@ kind: Deploy
 name: user
 description: User-listing service written in Ruby
 type: container
-build: user
 dependencies:
+  - build.user
   - run.ruby-migration
 spec:
+  image: ${actions.build.user.outputs.deploymentImageId}
   args: [ruby, app.rb]
   ports:
     - name: http
@@ -20,22 +21,24 @@ spec:
 kind: Run
 name: ruby-migration
 type: container
-build: user
 description: Populates the users table with a few records.
 dependencies:
+  - build.user
   # node-migration creates the users table, which has to exist before we use
   # ruby-migration to insert records into it.
   - run.node-migration
 spec:
+  image: ${actions.build.user.outputs.deploymentImageId}
   args: [rake, db:migrate]
 
 ---
 kind: Run
 name: db-clear
 type: container
-build: user
 description: Deletes all records from the users table.
 dependencies:
+  - build.user
   - run.node-migration
 spec:
+  image: ${actions.build.user.outputs.deploymentImageId}
   args: [rake, db:rollback]

--- a/examples/rust/backend/backend.garden.yml
+++ b/examples/rust/backend/backend.garden.yml
@@ -10,9 +10,8 @@ kind: Deploy
 name: backend
 description: Backend service
 type: container
-
-build: backend
-
+dependencies:
+  - build.backend
 spec:
   sync:
     paths:
@@ -32,3 +31,4 @@ spec:
     - path: /
       port: http
       hostname: backend.${var.base-hostname}
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/terraform-gke/backend/garden.yml
+++ b/examples/terraform-gke/backend/garden.yml
@@ -3,12 +3,12 @@ name: backend
 type: container
 
 ---
-
 kind: Deploy
 name: backend
-build: backend
 description: Backend service container
 type: container
+dependencies:
+  - build.backend
 spec:
   ports:
     - name: http
@@ -17,3 +17,4 @@ spec:
   ingresses:
     - path: /hello-backend
       port: http
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/terraform-gke/frontend/garden.yml
+++ b/examples/terraform-gke/frontend/garden.yml
@@ -5,10 +5,13 @@ type: container
 ---
 kind: Deploy
 name: frontend
-build: frontend
 description: Frontend service container
 type: container
+dependencies:
+  - build.frontend
+  - deploy.backend
 spec:
+  image: ${actions.build.frontend.outputs.deploymentImageId}
   ports:
     - name: http
       containerPort: 8080
@@ -21,23 +24,24 @@ spec:
       port: http
     - path: /call-backend
       port: http
-dependencies:
-  - deploy.backend
 
 ---
 kind: Test
 name: frontend-unit
-build: frontend
 type: container
+dependencies:
+  - build.frontend
 spec:
   args: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
-build: frontend
 type: container
+dependencies:
+  - build.frontend
+  - deploy.backend
 spec:
   args: [npm, run, integ]
-dependencies:
-  - deploy.backend
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/variables/backend/garden.yml
+++ b/examples/variables/backend/garden.yml
@@ -7,7 +7,8 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: container
-build: backend
+dependencies:
+  - build.backend
 
 variables:
   httpPort:
@@ -20,8 +21,9 @@ variables:
     localPort: 12345
 
 spec:
-  replicas: ${var.service-replicas} # <- Refers to the variable set in the project config
+  replicas: ${var.service-replicas}
   ports: "${this.mode == 'sync' ? [var.httpPort, var.debugPort] : [var.httpPort] }"
   ingresses:
     - path: /hello-backend
       port: http
+  image: ${actions.build.backend.outputs.deploymentImageId}

--- a/examples/variables/frontend/garden.yml
+++ b/examples/variables/frontend/garden.yml
@@ -7,11 +7,11 @@ kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-build: frontend
 dependencies:
+  - build.frontend
   - deploy.backend
 spec:
-  replicas: ${var.service-replicas} # <- Refers to the variable set in the project config
+  replicas: ${var.service-replicas}
   ports:
     - name: http
       containerPort: 8080
@@ -24,20 +24,25 @@ spec:
       port: http
     - path: /call-backend
       port: http
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-unit
 type: container
-build: frontend
+dependencies:
+  - build.frontend
 spec:
   args: [npm, test]
+  image: ${actions.build.frontend.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: frontend-integ
 type: container
-build: frontend
-dependencies: [deploy.backend]
+dependencies:
+  - build.frontend
+  - deploy.backend
 spec:
   args: [npm, run, integ]
+  image: ${actions.build.frontend.outputs.deploymentImageId}

--- a/examples/vote-helm/api-image/garden.yml
+++ b/examples/vote-helm/api-image/garden.yml
@@ -7,9 +7,10 @@ name: api-image
 kind: Test
 name: api-integ
 type: container
-build: api-image
 timeout: 60
 dependencies:
+  - build.api-image
   - deploy.api
 spec:
+  image: ${actions.build.api-image.outputs.deploymentImageId}
   args: [python, /app/test.py]

--- a/examples/vote-helm/vote-image/garden.yml
+++ b/examples/vote-helm/vote-image/garden.yml
@@ -7,6 +7,8 @@ type: container
 kind: Test
 name: vote-unit
 type: container
-build: vote-image
+dependencies:
+  - build.vote-image
 spec:
+  image: ${actions.build.vote-image.outputs.deploymentImageId}
   args: [npm, run, test:unit]

--- a/examples/vote/api/garden.yml
+++ b/examples/vote/api/garden.yml
@@ -7,8 +7,8 @@ kind: Deploy
 description: The backend for the voting UI
 name: api
 type: container
-build: api
 dependencies:
+  - build.api
   - deploy.redis
 spec:
   args: [python, app.py]
@@ -24,14 +24,16 @@ spec:
     - path: /
       hostname: "api.${var.baseHostname}"
       port: http
+  image: ${actions.build.api.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: api-integ
 type: container
-build: api
 dependencies:
+  - build.api
   - deploy.api
 timeout: 200
 spec:
   args: [python, /app/test.py]
+  image: ${actions.build.api.outputs.deploymentImageId}

--- a/examples/vote/result/garden.yml
+++ b/examples/vote/result/garden.yml
@@ -7,8 +7,8 @@ kind: Deploy
 description: Results UI service
 type: container
 name: result
-build: result
 dependencies:
+  - build.result
   - run.db-init
 spec:
   args: [nodemon, server.js]
@@ -24,12 +24,15 @@ spec:
     PGDATABASE: ${var.postgres-database}
     PGUSER: ${var.postgres-username}
     PGPASSWORD: ${var.postgres-password}
+  image: ${actions.build.result.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: results-integ
 type: container
-build: result
-dependencies: [run.db-init]
+dependencies:
+  - build.result
+  - run.db-init
 spec:
   args: [echo, ok]
+  image: ${actions.build.result.outputs.deploymentImageId}

--- a/examples/vote/vote/garden.yml
+++ b/examples/vote/vote/garden.yml
@@ -8,11 +8,12 @@ description: The voting UI
 name: vote
 # repositoryUrl: http://github.com/garden-io/garden...
 type: container
-build: vote
 dependencies:
+  - build.vote
   - deploy.api
 spec:
   args: [npm, run, serve]
+  image: ${actions.build.vote.outputs.deploymentImageId}
   sync:
     paths:
       - target: /app/src
@@ -36,17 +37,20 @@ spec:
 kind: Test
 name: vote-unit
 type: container
-build: vote
+dependencies:
+  - build.vote
 spec:
   args: [npm, run, test:unit]
+  image: ${actions.build.vote.outputs.deploymentImageId}
 
 ---
 kind: Test
 name: vote-integ
 type: container
-build: vote
 dependencies:
+  - build.vote
   - deploy.vote
 timeout: 60
 spec:
   args: [npm, run, test:integ]
+  image: ${actions.build.vote.outputs.deploymentImageId}

--- a/examples/vote/worker/garden.yml
+++ b/examples/vote/worker/garden.yml
@@ -7,11 +7,12 @@ kind: Deploy
 description: The worker that collects votes and stores results in a postgres table
 type: container
 name: worker
-build: worker
 dependencies:
+  - build.worker
   - deploy.redis
   - run.db-init
 spec:
+  image: ${actions.build.worker.outputs.deploymentImageId}
   env:
     PGDATABASE: ${var.postgres-database}
     PGUSER: ${var.postgres-username}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
When we released Bonsai we introduced the following short hand
for referencing container Build actions in container Deploy actions
via the `build` field:

```yaml
kind: Deploy
name: api
build: api
spec:
```

The longer version would be:

```yaml
kind: Deploy
name: api
dependencies: [build.api]
spec:
  image: ${actions.build.api.outputs.deploymentImageId}
  # ...
```

The short hand works for `container` Deploy actions but not for `helm`
or `kubernetes` Deploy actions. In fact using the `build` field there
sets the build context to the `.garden/build` dir of the corresponding
`build`.

This has caused a lot of confusion for users as they copy examples
containing the `build` field to `kubernetes` and `helm` Deploy actions.

A common symptom is that a Garden command will fail because it can't
find the files belonging to the Deploy action.

Furthermore, the `build` field has in general caused confusion and we
_may_ end up deprecating it.

In the meantime, this commit removes any unneeded/false usage of it in our
examples and docs.

The result is that `container` Deploy actions are slightly more
verbose but in turn we've removed a big footgun that users keep bumping
into as they copy/paste example config.

There are still legit use cases for the `build` field and I've left
those examples alone.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Most of the updates were done with the help of ChatGPT and it looks a couple of comments got lost along the way but I think we can skip those anyway. 
