### PR TITLE
fix(git): fix file list caching bug for repo mode

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -200,13 +200,12 @@ export class GitHandler extends VcsHandler {
     }
 
     const { log, path, pathDescription = "directory", filter, failOnPrompt = false } = params
-    const { exclude, hasIncludes, include } = await getIncludeExcludeFiles(params)
 
     const gitLog = log
       .createLog({ name: "git" })
       .debug(
-        `Scanning ${pathDescription} at ${path}\n  → Includes: ${include || "(none)"}\n  → Excludes: ${
-          exclude || "(none)"
+        `Scanning ${pathDescription} at ${path}\n  → Includes: ${params.include || "(none)"}\n  → Excludes: ${
+          params.exclude || "(none)"
         }`
       )
 
@@ -225,6 +224,7 @@ export class GitHandler extends VcsHandler {
         throw err
       }
     }
+    const { exclude, hasIncludes, include } = await getIncludeExcludeFiles(params)
 
     let files: VcsFile[] = []
 

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -199,7 +199,7 @@ describe("VcsHandler", () => {
       expect(result.files).to.eql(["foo"])
     })
 
-    it("should not call getFiles is include: [] is set on the module", async () => {
+    it("should not call getFiles if include: [] is set on the module", async () => {
       td.replace(handlerA, "getFiles", async () => {
         throw new Error("Nope!")
       })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This fixes an error that would come up e.g. when an action config in the project root excluded a subdirectory containing another action config.

In that setup, the file list for the action in the subdirectory would be empty because the file list had been cached using the exclude config applied when computing the file list for the action config at the root level (which included no files for the excluded subdirectory).

This was fixed by adding another level of caching to `GitRepoHandler` that accounts for different includes/excludes and filter functions for the same path.

**Special notes for your reviewer**:

Note the slightly awkward clarification section about the difference between the exclude behavior of `subtree` and `repo` when no includes are configured.

In a follow-up to this, we really should address https://github.com/garden-io/garden/issues/5582.

I think bringing our include/exclude behavior completely in line with Git's would make things easier to reason about for our users.