### PR TITLE
docs: fix docstring for allowPublish for modules

### DIFF
--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -234,7 +234,7 @@ export const baseModuleSpecKeys = memoize(() => ({
   allowPublish: joi
     .boolean()
     .default(true)
-    .description("When false, disables pushing this module to remote registries."),
+    .description("When false, disables pushing this module to remote registries via the publish command."),
   generateFiles: joiSparseArray(generatedFileSchema()).description(dedent`
     A list of files to write to the module directory when resolving this module. This is useful to automatically generate (and template) any supporting files needed for the module.
   `),

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1534,7 +1534,7 @@ providers:
         # garden.yml file.
         repositoryUrl:
 
-        # When false, disables pushing this module to remote registries.
+        # When false, disables pushing this module to remote registries via the publish command.
         allowPublish:
 
         # A map of variables scoped to this particular module. These are resolved before any other parts of the module
@@ -2413,7 +2413,7 @@ moduleConfigs:
     # garden.yml file.
     repositoryUrl:
 
-    # When false, disables pushing this module to remote registries.
+    # When false, disables pushing this module to remote registries via the publish command.
     allowPublish:
 
     # A map of variables scoped to this particular module. These are resolved before any other parts of the module
@@ -2971,7 +2971,7 @@ modules:
     # garden.yml file.
     repositoryUrl:
 
-    # When false, disables pushing this module to remote registries.
+    # When false, disables pushing this module to remote registries via the publish command.
     allowPublish:
 
     # A map of variables scoped to this particular module. These are resolved before any other parts of the module

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -121,7 +121,7 @@ modules:
     # garden.yml file.
     repositoryUrl:
 
-    # When false, disables pushing this module to remote registries.
+    # When false, disables pushing this module to remote registries via the publish command.
     allowPublish: true
 
     # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -458,7 +458,7 @@ modules:
 
 [modules](#modules) > allowPublish
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -104,7 +104,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -357,7 +357,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -107,7 +107,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -365,7 +365,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -119,7 +119,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -934,7 +934,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -116,7 +116,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -554,7 +554,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -110,7 +110,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -356,7 +356,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -112,7 +112,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -816,7 +816,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -187,7 +187,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -1149,7 +1149,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -111,7 +111,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -794,7 +794,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -104,7 +104,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -420,7 +420,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -106,7 +106,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -436,7 +436,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -98,7 +98,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -349,7 +349,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -110,7 +110,7 @@ exclude:
 # garden.yml file.
 repositoryUrl:
 
-# When false, disables pushing this module to remote registries.
+# When false, disables pushing this module to remote registries via the publish command.
 allowPublish: true
 
 # A list of files to write to the module directory when resolving this module. This is useful to automatically
@@ -382,7 +382,7 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 ### `allowPublish`
 
-When false, disables pushing this module to remote registries.
+When false, disables pushing this module to remote registries via the publish command.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |


### PR DESCRIPTION
**What this PR does / why we need it**:

The docstring for the `allowPublish` field for modules was ambiguous (some users interpreted it as applying to the `build` command as well).