### PR TITLE
fix(module-conversion): always provide dummy build

### DIFF
--- a/core/src/plugin/handlers/Module/convert.ts
+++ b/core/src/plugin/handlers/Module/convert.ts
@@ -38,7 +38,7 @@ export interface ConvertModuleParams<T extends GardenModule = GardenModule> exte
   services: GardenService<T>[]
   tasks: GardenTask<T>[]
   tests: GardenTest<T>[]
-  dummyBuild: ExecBuildConfig | undefined
+  dummyBuild: ExecBuildConfig
   baseFields: {
     copyFrom: BuildCopyFrom[]
     disabled: boolean

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -761,15 +761,13 @@ export const convertModules = profileAsync(async function convertModules(
         return resolved
       }
 
-      let dummyBuild: ExecBuildConfig | undefined = undefined
-
-      if (copyFrom.length > 0) {
-        dummyBuild = makeDummyBuild({
-          module,
-          copyFrom,
-          dependencies: module.build.dependencies.map(convertBuildDependency),
-        })
-      }
+      // We always include a dummy build, since not all conversions generate a build action but other modules
+      // may still depend on it.
+      const dummyBuild = makeDummyBuild({
+        module,
+        copyFrom: copyFrom.length > 0 ? copyFrom : undefined,
+        dependencies: module.build.dependencies.map(convertBuildDependency),
+      })
 
       log.debug(`Converting ${module.type} module ${module.name} to actions`)
 

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -49,6 +49,7 @@ import type { GardenService } from "../../../../../src/types/service.js"
 import { serviceFromConfig } from "../../../../../src/types/service.js"
 import type { GardenTest } from "../../../../../src/types/test.js"
 import { testFromConfig } from "../../../../../src/types/test.js"
+import { makeDummyBuild } from "../../../../../src/resolve-module.js"
 
 describe("plugins.container", () => {
   const projectRoot = getDataDir("test-project-container")
@@ -122,7 +123,11 @@ describe("plugins.container", () => {
       convertRuntimeDependencies: () => [{ kind: "Deploy", name: "runtimeDep" }],
       convertTestName: () => "testName",
       ctx,
-      dummyBuild: undefined,
+      dummyBuild: makeDummyBuild({
+        module,
+        copyFrom: [],
+        dependencies: [],
+      }),
       log,
       module,
       prepareRuntimeDependencies: prepareRuntimeDependencies

--- a/core/test/unit/src/plugins/kubernetes/container/module-conversion.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/module-conversion.ts
@@ -36,7 +36,7 @@ describe("kubernetes container module conversion", () => {
     tmpDir.cleanup()
   })
 
-  it("should ", async () => {
+  it("should include build dependencies among converted runtime actions' dependencies", async () => {
     garden.setModuleConfigs([
       makeModuleConfig<ContainerModuleConfig>(garden.projectRoot, {
         name: "test-image",

--- a/core/test/unit/src/resolve-module.ts
+++ b/core/test/unit/src/resolve-module.ts
@@ -9,10 +9,12 @@
 import { expect } from "chai"
 import { join, dirname } from "path"
 import type { TestGarden } from "../../helpers.js"
-import { getDataDir, makeTestGarden, makeTestGardenA } from "../../helpers.js"
+import { customizedTestPlugin, getDataDir, makeTestGarden, makeTestGardenA, projectRootA } from "../../helpers.js"
 import { DEFAULT_BUILD_TIMEOUT_SEC } from "../../../src/constants.js"
 import type { ConfigGraph } from "../../../src/graph/config-graph.js"
 import { loadYamlFile } from "../../../src/util/serialization.js"
+import type { DeployActionConfig } from "../../../src/actions/deploy.js"
+import type { BaseActionConfig } from "../../../src/actions/types.js"
 
 describe("ModuleResolver", () => {
   // Note: We test the ModuleResolver via the TestGarden.resolveModule method, for convenience.
@@ -158,5 +160,100 @@ describe("ModuleResolver", () => {
         })
       })
     })
+  })
+})
+
+describe("convertModules", () => {
+  it("should always include a dummy build, even when the convert handler doesn't doesn't return a build", async () => {
+    const testPlugin = customizedTestPlugin({
+      name: "test-plugin",
+      createModuleTypes: [
+        {
+          name: "test",
+          docs: "I are documentation, yes",
+          needsBuild: false,
+          handlers: {
+            convert: async (params) => {
+              const { module, services, dummyBuild } = params
+              const actions: BaseActionConfig[] = []
+              for (const service of services) {
+                const deployAction: DeployActionConfig = {
+                  kind: "Deploy",
+                  type: "test",
+                  name: service.name,
+                  ...params.baseFields,
+
+                  dependencies: params.prepareRuntimeDependencies(service.spec.dependencies, dummyBuild),
+                  timeout: service.spec.timeout,
+
+                  spec: {},
+                }
+                actions.push(deployAction)
+              }
+              dummyBuild && actions.push(dummyBuild)
+              return {
+                group: {
+                  kind: <const>"Group",
+                  name: module.name,
+                  path: module.path,
+                  actions,
+                },
+              }
+            },
+          },
+        },
+      ],
+    })
+    const garden = await makeTestGarden(projectRootA, { plugins: [testPlugin] })
+    const log = garden.log
+
+    garden.setModuleConfigs([
+      {
+        name: "module-a",
+        type: "test",
+        path: join(garden.projectRoot, "module-a"),
+        spec: {
+          services: [{ name: "service-a", deployCommand: ["echo", "ok"], dependencies: [] }],
+          tests: [],
+          tasks: [],
+          build: { dependencies: [], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+        },
+        build: { dependencies: [], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+      },
+      {
+        name: "module-b",
+        type: "test",
+        path: join(garden.projectRoot, "module-b"),
+        spec: {
+          services: [{ name: "service-b", deployCommand: ["echo", "ok"], dependencies: ["service-a"] }],
+          tests: [],
+          tasks: [],
+          build: { dependencies: ["module-a"], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+        },
+        build: { dependencies: [{ name: "module-a", copy: [] }], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+      },
+    ])
+
+    const graph = await garden.getConfigGraph({ log, emit: false })
+
+    const dummyBuildA = graph.getBuild("module-a")
+    const dummyBuildB = graph.getBuild("module-b")
+
+    const buildActionDeps = graph
+      .getBuild("module-b")
+      .getDependencies()
+      .map((dep) => dep.key())
+      .sort()
+
+    const deployActionDeps = graph
+      .getDeploy("service-b")
+      .getDependencies()
+      .map((dep) => dep.key())
+      .sort()
+
+    expect(dummyBuildA).to.exist
+    expect(dummyBuildB).to.exist
+    expect(buildActionDeps).to.eql(["build.module-a"])
+    expect(deployActionDeps).to.eql(["build.module-a", "build.module-b", "deploy.service-a"])
   })
 })

--- a/core/test/unit/src/router/_helpers.ts
+++ b/core/test/unit/src/router/_helpers.ts
@@ -282,12 +282,11 @@ function getRouterUnitTestPlugins() {
             const actions: (BuildActionConfig | BaseRuntimeActionConfig)[] = []
 
             const buildAction: BuildActionConfig = {
+              ...params.baseFields,
+              ...dummyBuild,
               kind: "Build",
               type: "test",
               name: module.name,
-
-              ...params.baseFields,
-              ...dummyBuild,
 
               dependencies: module.build.dependencies.map(convertBuildDependency),
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

In 0.12, many users had build dependencies on modules with no-op build steps (e.g. `terraform`, `kubernetes` and `helm` modules)

While this was harmless in 0.12, this now results in noisy errors. We fix this in a simple way here by always providing a no-op dummy build to conversion handlers.