### PR TITLE
improvement(ext-tools): always print versions in `garden tools` output

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -865,7 +865,7 @@ export const mutagenVersion = "0.15.0"
 export const mutagenCliSpec: PluginToolSpec = {
   name: "mutagen",
   version: mutagenVersion,
-  description: "The mutagen synchronization tool.",
+  description: `The mutagen synchronization tool, v${mutagenVersion}`,
   type: "binary",
   _includeInGardenImage: false,
   builds: [

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -509,7 +509,7 @@ export const gardenPlugin = () =>
       {
         name: "docker",
         version: "24.0.4",
-        description: "The official Docker CLI.",
+        description: "The official Docker CLI, v24.0.4",
         type: "binary",
         _includeInGardenImage: true,
         builds: [

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -49,6 +49,8 @@ export type ContainerProviderConfig = GenericProviderConfig
 
 export type ContainerProvider = Provider<ContainerProviderConfig>
 
+const dockerVersion = "24.0.4"
+
 // TODO: remove in 0.14. validation should be in the action validation handler.
 export async function configureContainerModule({ log, moduleConfig }: ConfigureModuleParams<ContainerModule>) {
   // validate services
@@ -508,15 +510,15 @@ export const gardenPlugin = () =>
     tools: [
       {
         name: "docker",
-        version: "24.0.4",
-        description: "The official Docker CLI, v24.0.4",
+        version: dockerVersion,
+        description: `The official Docker CLI, v${dockerVersion}`,
         type: "binary",
         _includeInGardenImage: true,
         builds: [
           {
             platform: "darwin",
             architecture: "amd64",
-            url: "https://download.docker.com/mac/static/stable/x86_64/docker-24.0.4.tgz",
+            url: `https://download.docker.com/mac/static/stable/x86_64/docker-${dockerVersion}.tgz`,
             sha256: "a1016b319d8fb5b92e6a4f9ae4082b0fe934bcec4a18f4ddba9b6a5778af230c",
             extract: {
               format: "tar",
@@ -526,7 +528,7 @@ export const gardenPlugin = () =>
           {
             platform: "darwin",
             architecture: "arm64",
-            url: "https://download.docker.com/mac/static/stable/aarch64/docker-24.0.4.tgz",
+            url: `https://download.docker.com/mac/static/stable/aarch64/docker-${dockerVersion}.tgz`,
             sha256: "d99ce023f984b07a57621d804f226bfeedea513ce708aba480a62f5b63631367",
             extract: {
               format: "tar",
@@ -536,7 +538,7 @@ export const gardenPlugin = () =>
           {
             platform: "linux",
             architecture: "amd64",
-            url: "https://download.docker.com/linux/static/stable/x86_64/docker-24.0.4.tgz",
+            url: `https://download.docker.com/linux/static/stable/x86_64/docker-${dockerVersion}.tgz`,
             sha256: "0ab79ae5f19e2ef5bdc3c3009c8b770dea6189e0f1e0ef4935d78fd30519b11d",
             extract: {
               format: "tar",
@@ -546,7 +548,7 @@ export const gardenPlugin = () =>
           {
             platform: "linux",
             architecture: "arm64",
-            url: "https://download.docker.com/linux/static/stable/aarch64/docker-24.0.4.tgz",
+            url: `https://download.docker.com/linux/static/stable/aarch64/docker-${dockerVersion}.tgz`,
             sha256: "193a8e1f051adce6a30a4c8486ce9b39929b9633a0da8c96444c9239859f4354",
             extract: {
               format: "tar",
@@ -556,7 +558,7 @@ export const gardenPlugin = () =>
           {
             platform: "windows",
             architecture: "amd64",
-            url: "https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v24.0.4/docker-24.0.4.zip",
+            url: `https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v${dockerVersion}/docker-${dockerVersion}.zip`,
             sha256: "1ffb063724147d871ec01824ee458b66a85191a8ecd943ae77775b5352db12ff",
             extract: {
               format: "zip",

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -44,12 +44,72 @@ import { getDeployedImageId } from "../kubernetes/container/util.js"
 import type { DeepPrimitiveMap } from "../../config/common.js"
 import { DEFAULT_DEPLOY_TIMEOUT_SEC } from "../../constants.js"
 import type { ExecBuildConfig } from "../exec/build.js"
+import type { PluginToolSpec } from "../../plugin/tools.js"
 
 export type ContainerProviderConfig = GenericProviderConfig
 
 export type ContainerProvider = Provider<ContainerProviderConfig>
 
-const dockerVersion = "24.0.4"
+export const dockerVersion = "24.0.4"
+export const dockerSpec: PluginToolSpec = {
+  name: "docker",
+  version: dockerVersion,
+  description: `The official Docker CLI, v${dockerVersion}`,
+  type: "binary",
+  _includeInGardenImage: true,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url: `https://download.docker.com/mac/static/stable/x86_64/docker-${dockerVersion}.tgz`,
+      sha256: "a1016b319d8fb5b92e6a4f9ae4082b0fe934bcec4a18f4ddba9b6a5778af230c",
+      extract: {
+        format: "tar",
+        targetPath: "docker/docker",
+      },
+    },
+    {
+      platform: "darwin",
+      architecture: "arm64",
+      url: `https://download.docker.com/mac/static/stable/aarch64/docker-${dockerVersion}.tgz`,
+      sha256: "d99ce023f984b07a57621d804f226bfeedea513ce708aba480a62f5b63631367",
+      extract: {
+        format: "tar",
+        targetPath: "docker/docker",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url: `https://download.docker.com/linux/static/stable/x86_64/docker-${dockerVersion}.tgz`,
+      sha256: "0ab79ae5f19e2ef5bdc3c3009c8b770dea6189e0f1e0ef4935d78fd30519b11d",
+      extract: {
+        format: "tar",
+        targetPath: "docker/docker",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "arm64",
+      url: `https://download.docker.com/linux/static/stable/aarch64/docker-${dockerVersion}.tgz`,
+      sha256: "193a8e1f051adce6a30a4c8486ce9b39929b9633a0da8c96444c9239859f4354",
+      extract: {
+        format: "tar",
+        targetPath: "docker/docker",
+      },
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v${dockerVersion}/docker-${dockerVersion}.zip`,
+      sha256: "1ffb063724147d871ec01824ee458b66a85191a8ecd943ae77775b5352db12ff",
+      extract: {
+        format: "zip",
+        targetPath: "docker/docker.exe",
+      },
+    },
+  ],
+}
 
 // TODO: remove in 0.14. validation should be in the action validation handler.
 export async function configureContainerModule({ log, moduleConfig }: ConfigureModuleParams<ContainerModule>) {
@@ -197,6 +257,7 @@ function convertContainerModuleRuntimeActions(
   }
 
   const volumeModulesReferenced: string[] = []
+
   function configureActionVolumes(action: ContainerRuntimeActionConfig, volumeSpec: ContainerModuleVolumeSpec[]) {
     volumeSpec.forEach((v) => {
       const referencedPvcAction = v.module ? { kind: <const>"Deploy", name: v.module } : undefined
@@ -507,67 +568,7 @@ export const gardenPlugin = () =>
       },
     ],
 
-    tools: [
-      {
-        name: "docker",
-        version: dockerVersion,
-        description: `The official Docker CLI, v${dockerVersion}`,
-        type: "binary",
-        _includeInGardenImage: true,
-        builds: [
-          {
-            platform: "darwin",
-            architecture: "amd64",
-            url: `https://download.docker.com/mac/static/stable/x86_64/docker-${dockerVersion}.tgz`,
-            sha256: "a1016b319d8fb5b92e6a4f9ae4082b0fe934bcec4a18f4ddba9b6a5778af230c",
-            extract: {
-              format: "tar",
-              targetPath: "docker/docker",
-            },
-          },
-          {
-            platform: "darwin",
-            architecture: "arm64",
-            url: `https://download.docker.com/mac/static/stable/aarch64/docker-${dockerVersion}.tgz`,
-            sha256: "d99ce023f984b07a57621d804f226bfeedea513ce708aba480a62f5b63631367",
-            extract: {
-              format: "tar",
-              targetPath: "docker/docker",
-            },
-          },
-          {
-            platform: "linux",
-            architecture: "amd64",
-            url: `https://download.docker.com/linux/static/stable/x86_64/docker-${dockerVersion}.tgz`,
-            sha256: "0ab79ae5f19e2ef5bdc3c3009c8b770dea6189e0f1e0ef4935d78fd30519b11d",
-            extract: {
-              format: "tar",
-              targetPath: "docker/docker",
-            },
-          },
-          {
-            platform: "linux",
-            architecture: "arm64",
-            url: `https://download.docker.com/linux/static/stable/aarch64/docker-${dockerVersion}.tgz`,
-            sha256: "193a8e1f051adce6a30a4c8486ce9b39929b9633a0da8c96444c9239859f4354",
-            extract: {
-              format: "tar",
-              targetPath: "docker/docker",
-            },
-          },
-          {
-            platform: "windows",
-            architecture: "amd64",
-            url: `https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v${dockerVersion}/docker-${dockerVersion}.zip`,
-            sha256: "1ffb063724147d871ec01824ee458b66a85191a8ecd943ae77775b5352db12ff",
-            extract: {
-              format: "zip",
-              targetPath: "docker/docker.exe",
-            },
-          },
-        ],
-      },
-    ],
+    tools: [dockerSpec],
   })
 
 function validateRuntimeCommon(action: Resolved<ContainerRuntimeAction>) {

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -114,7 +114,7 @@ const s = sdk.schema
 gardenPlugin.addTool({
   name: "hadolint",
   version: "2.12.0",
-  description: "A Dockerfile linter.",
+  description: "A Dockerfile linter, v2.12.0",
   type: "binary",
   _includeInGardenImage: false,
   builds: [

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -111,10 +111,11 @@ export const gardenPlugin = sdk.createGardenPlugin({
 
 const s = sdk.schema
 
+const hadolintVersion = "2.12.0"
 gardenPlugin.addTool({
   name: "hadolint",
-  version: "2.12.0",
-  description: "A Dockerfile linter, v2.12.0",
+  version: hadolintVersion,
+  description: `A Dockerfile linter, v${hadolintVersion}`,
   type: "binary",
   _includeInGardenImage: false,
   builds: [
@@ -122,25 +123,25 @@ gardenPlugin.addTool({
     {
       platform: "darwin",
       architecture: "amd64",
-      url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Darwin-x86_64",
+      url: `https://github.com/hadolint/hadolint/releases/download/v${hadolintVersion}/hadolint-Darwin-x86_64`,
       sha256: "2a5b7afcab91645c39a7cebefcd835b865f7488e69be24567f433dfc3d41cd27",
     },
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64",
+      url: `https://github.com/hadolint/hadolint/releases/download/v${hadolintVersion}/hadolint-Linux-x86_64`,
       sha256: "56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010",
     },
     {
       platform: "linux",
       architecture: "arm64",
-      url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-arm64",
+      url: `https://github.com/hadolint/hadolint/releases/download/v${hadolintVersion}/hadolint-Linux-arm64`,
       sha256: "5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6",
     },
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Windows-x86_64.exe",
+      url: `https://github.com/hadolint/hadolint/releases/download/v${hadolintVersion}/hadolint-Windows-x86_64.exe`,
       sha256: "ed89a156290e15452276b2b4c84efa688a5183d3b578bfaec7cfdf986f0632a8",
     },
   ],

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -18,7 +18,7 @@ export const helmVersion = "3.14.0"
 
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
-  description: `The Helm CLI (version ${helmVersion}).`,
+  description: `The Helm CLI, v${helmVersion}`,
   version: helmVersion,
   type: "binary",
   _includeInGardenImage: true,

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -356,7 +356,7 @@ export const kubectlVersion = "1.29.1"
 export const kubectlSpec: PluginToolSpec = {
   name: "kubectl",
   version: kubectlVersion,
-  description: "The official Kubernetes CLI.",
+  description: `The official Kubernetes CLI, v${kubectlVersion}`,
   type: "binary",
   _includeInGardenImage: true,
   builds: [

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -38,7 +38,7 @@ export const kustomizeVersion = "4.5.2"
 export const kustomizeSpec: PluginToolSpec = {
   name: "kustomize",
   version: kustomizeVersion,
-  description: "The kustomize config management CLI.",
+  description: `The kustomize config management CLI, v${kustomizeVersion}`,
   type: "binary",
   _includeInGardenImage: true,
   builds: [

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -87,7 +87,7 @@ export const gardenPlugin = () =>
       {
         name: "octant",
         version: "0.25.1",
-        description: "A web admin UI for Kubernetes.",
+        description: "[DEPRECATED] A web admin UI for Kubernetes, v0.25.1",
         type: "binary",
         _includeInGardenImage: false,
         builds: [

--- a/core/src/plugins/otel-collector/otel-collector.ts
+++ b/core/src/plugins/otel-collector/otel-collector.ts
@@ -53,7 +53,7 @@ const s = sdk.schema
 gardenPlugin.addTool({
   name: "otel-collector",
   version: "v0.80.0",
-  description: "Otel collector service",
+  description: "Otel collector service, v0.80.0",
   type: "binary",
   _includeInGardenImage: false,
   builds: [

--- a/core/src/plugins/otel-collector/otel-collector.ts
+++ b/core/src/plugins/otel-collector/otel-collector.ts
@@ -17,6 +17,7 @@ import { getOtelCollectorConfigFile } from "./config.js"
 import YAML from "yaml"
 import { makeTempDir } from "../../util/fs.js"
 import fsExtra from "fs-extra"
+
 const { writeFile } = fsExtra
 import { streamLogs, waitForLogLine, waitForProcessExit } from "../../util/process.js"
 import getPort from "get-port"
@@ -50,17 +51,18 @@ export const gardenPlugin = sdk.createGardenPlugin({
 
 const s = sdk.schema
 
+const otelCollectorVersion = "0.80.0"
 gardenPlugin.addTool({
   name: "otel-collector",
-  version: "v0.80.0",
-  description: "Otel collector service, v0.80.0",
+  version: `v${otelCollectorVersion}`,
+  description: `Otel collector service, v${otelCollectorVersion}`,
   type: "binary",
   _includeInGardenImage: false,
   builds: [
     {
       platform: "darwin",
       architecture: "amd64",
-      url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_darwin_amd64.tar.gz",
+      url: `https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${otelCollectorVersion}/otelcol-contrib_${otelCollectorVersion}_darwin_amd64.tar.gz`,
       sha256: "2769c382a8296c73f57c0cfece4337599473b9bc7752e22ee4fcd8e4f1e549ce",
       extract: {
         format: "tar",
@@ -70,7 +72,7 @@ gardenPlugin.addTool({
     {
       platform: "darwin",
       architecture: "arm64",
-      url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_darwin_arm64.tar.gz",
+      url: `https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${otelCollectorVersion}/otelcol-contrib_${otelCollectorVersion}_darwin_arm64.tar.gz`,
       sha256: "93149de30b8a47f7c7412a3cf2b5395662c56a5198ab5e942c320216d9a2fd80",
       extract: {
         format: "tar",
@@ -80,7 +82,7 @@ gardenPlugin.addTool({
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_linux_amd64.tar.gz",
+      url: `https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${otelCollectorVersion}/otelcol-contrib_${otelCollectorVersion}_linux_amd64.tar.gz`,
       sha256: "6196e2ec1f8e632abb3c98505c5e111aec47ca86a6f25d9ef5afe538a7b445f0",
       extract: {
         format: "tar",
@@ -90,7 +92,7 @@ gardenPlugin.addTool({
     {
       platform: "linux",
       architecture: "arm64",
-      url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_linux_arm64.tar.gz",
+      url: `https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${otelCollectorVersion}/otelcol-contrib_${otelCollectorVersion}_linux_arm64.tar.gz`,
       sha256: "19d878166dbc39821f11b6a7c2ed896726c8d5ac6c15108b66d8e874efa8db85",
       extract: {
         format: "tar",
@@ -100,7 +102,7 @@ gardenPlugin.addTool({
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_windows_amd64.tar.gz",
+      url: `https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${otelCollectorVersion}/otelcol-contrib_${otelCollectorVersion}_windows_amd64.tar.gz`,
       sha256: "b1a971a468da6d73926b9362029fde8f9142578d69179370ffb57ea35693452b",
       extract: {
         format: "tar",

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -11,6 +11,11 @@ import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
 import { kustomizeSpec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helm3Spec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
 import { downloadBinariesAndVerifyHashes } from "../../../src/util/testing.js"
+import { dockerSpec } from "../../../src/plugins/container/container.js"
+
+describe("Docker binaries", () => {
+  downloadBinariesAndVerifyHashes([dockerSpec])
+})
 
 describe("Mutagen binaries", () => {
   downloadBinariesAndVerifyHashes([mutagenCliSpec])

--- a/plugins/conftest/src/index.ts
+++ b/plugins/conftest/src/index.ts
@@ -402,7 +402,7 @@ export const gardenPlugin = () =>
       {
         name: "conftest",
         version: "0.45.0",
-        description: "A rego-based configuration validator.",
+        description: "A rego-based configuration validator, v0.45.0",
         type: "binary",
         _includeInGardenImage: true,
         builds: [

--- a/plugins/conftest/src/index.ts
+++ b/plugins/conftest/src/index.ts
@@ -11,7 +11,7 @@ import { styles } from "@garden-io/core/build/src/logger/styles.js"
 import slash from "slash"
 import type { ExecaReturnValue } from "execa"
 import { createGardenPlugin } from "@garden-io/sdk"
-import type { PluginContext, Log } from "@garden-io/sdk/build/src/types.js"
+import type { PluginContext, Log, PluginToolSpec } from "@garden-io/sdk/build/src/types.js"
 import { dedent, naturalList } from "@garden-io/sdk/build/src/util/string.js"
 import { matchGlobs, listDirectory } from "@garden-io/sdk/build/src/util/fs.js"
 
@@ -39,6 +39,68 @@ export interface ConftestProviderConfig extends GenericProviderConfig {
 }
 
 export type ConftestProvider = Provider<ConftestProviderConfig>
+
+export const conftestVersion = "0.45.0"
+export const conftestSpec: PluginToolSpec = {
+  name: "conftest",
+  version: conftestVersion,
+  description: `A rego-based configuration validator, v${conftestVersion}`,
+  type: "binary",
+  _includeInGardenImage: true,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url: `https://github.com/open-policy-agent/conftest/releases/download/v${conftestVersion}/conftest_${conftestVersion}_Darwin_x86_64.tar.gz`,
+      sha256: "cd199c00fb634242e9062fb6b68692040198b1a2fee88537add7a719485a9839",
+      extract: {
+        format: "tar",
+        targetPath: "conftest",
+      },
+    },
+    {
+      platform: "darwin",
+      architecture: "arm64",
+      url: `https://github.com/open-policy-agent/conftest/releases/download/v${conftestVersion}/conftest_${conftestVersion}_Darwin_arm64.tar.gz`,
+      sha256: "3c4e2d7fd01e7a2a17558e4e5f8086bc92312a8e8773747e2d4a067ca20127b4",
+      extract: {
+        format: "tar",
+        targetPath: "conftest",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url: `https://github.com/open-policy-agent/conftest/releases/download/v${conftestVersion}/conftest_${conftestVersion}_Linux_x86_64.tar.gz`,
+      sha256: "65edcf630f5cd2142138555542f10f8cbc99588e5dfcefbfa1e8074c7cc82c23",
+      extract: {
+        format: "tar",
+        targetPath: "conftest",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "arm64",
+      url: `https://github.com/open-policy-agent/conftest/releases/download/v${conftestVersion}/conftest_${conftestVersion}_Linux_arm64.tar.gz`,
+      sha256: "9851d4c2a6488fbaab6af34223ed77425bc6fb5a4b349a53e6e1410cdf4798f0",
+      extract: {
+        format: "tar",
+        targetPath: "conftest",
+      },
+    },
+
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `https://github.com/open-policy-agent/conftest/releases/download/v${conftestVersion}/conftest_${conftestVersion}_Windows_x86_64.zip`,
+      sha256: "376135229a8ee5e4a1e77d10dad00dc907b04c4efb7d3857e542371902e309ce",
+      extract: {
+        format: "zip",
+        targetPath: "conftest.exe",
+      },
+    },
+  ],
+}
 
 export const configSchema = () =>
   providerConfigBaseSchema()
@@ -398,70 +460,7 @@ export const gardenPlugin = () =>
         },
       },
     ],
-    tools: [
-      {
-        name: "conftest",
-        version: "0.45.0",
-        description: "A rego-based configuration validator, v0.45.0",
-        type: "binary",
-        _includeInGardenImage: true,
-        builds: [
-          {
-            platform: "darwin",
-            architecture: "amd64",
-            url: "https://github.com/open-policy-agent/conftest/releases/download/v0.45.0/conftest_0.45.0_Darwin_x86_64.tar.gz",
-            sha256: "cd199c00fb634242e9062fb6b68692040198b1a2fee88537add7a719485a9839",
-            extract: {
-              format: "tar",
-              targetPath: "conftest",
-            },
-          },
-          {
-            platform: "darwin",
-            architecture: "arm64",
-            url: "https://github.com/open-policy-agent/conftest/releases/download/v0.45.0/conftest_0.45.0_Darwin_arm64.tar.gz",
-            sha256: "3c4e2d7fd01e7a2a17558e4e5f8086bc92312a8e8773747e2d4a067ca20127b4",
-            extract: {
-              format: "tar",
-              targetPath: "conftest",
-            },
-          },
-          {
-            platform: "linux",
-            architecture: "amd64",
-            url: "https://github.com/open-policy-agent/conftest/releases/download/v0.45.0/conftest_0.45.0_Linux_x86_64.tar.gz",
-            sha256: "65edcf630f5cd2142138555542f10f8cbc99588e5dfcefbfa1e8074c7cc82c23",
-            extract: {
-              format: "tar",
-              targetPath: "conftest",
-            },
-          },
-          {
-            platform: "linux",
-            architecture: "arm64",
-            url: "https://github.com/open-policy-agent/conftest/releases/download/v0.45.0/conftest_0.45.0_Linux_arm64.tar.gz",
-            sha256: "9851d4c2a6488fbaab6af34223ed77425bc6fb5a4b349a53e6e1410cdf4798f0",
-            extract: {
-              format: "tar",
-              targetPath: "conftest",
-            },
-          },
-
-          {
-            platform: "windows",
-            architecture: "amd64",
-            url:
-              "https://github.com/open-policy-agent/conftest/releases/download/v0.45.0/" +
-              "conftest_0.45.0_Windows_x86_64.zip",
-            sha256: "376135229a8ee5e4a1e77d10dad00dc907b04c4efb7d3857e542371902e309ce",
-            extract: {
-              format: "zip",
-              targetPath: "conftest.exe",
-            },
-          },
-        ],
-      },
-    ],
+    tools: [conftestSpec],
   })
 
 function prepareArgs(ctx: PluginContext, provider: ConftestProvider, path: string, spec: ConftestTestSpec) {

--- a/plugins/conftest/test/verify-conftest-binary-hashes.ts
+++ b/plugins/conftest/test/verify-conftest-binary-hashes.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { downloadBinariesAndVerifyHashes } from "@garden-io/core/build/src/util/testing.js"
+import { conftestSpec } from "../src/index.js"
+
+describe("Conftest binaries", () => {
+  downloadBinariesAndVerifyHashes([conftestSpec])
+})

--- a/plugins/jib/src/gradle.ts
+++ b/plugins/jib/src/gradle.ts
@@ -29,7 +29,7 @@ const spec = {
 export const gradleSpec: PluginToolSpec = {
   name: "gradle",
   version: gradleVersion,
-  description: "The gradle CLI.",
+  description: `The gradle CLI, v${gradleVersion}`,
   type: "binary",
   builds: [
     {

--- a/plugins/jib/src/maven.ts
+++ b/plugins/jib/src/maven.ts
@@ -29,7 +29,7 @@ const spec = {
 export const mavenSpec: PluginToolSpec = {
   name: "maven",
   version: mvnVersion,
-  description: "The Maven CLI.",
+  description: `The Maven CLI, v${mvnVersion}`,
   type: "binary",
   builds: [
     {

--- a/plugins/jib/src/mavend.ts
+++ b/plugins/jib/src/mavend.ts
@@ -18,7 +18,6 @@ const buildLock = new AsyncLock()
 export const mvndVersion = "0.9.0"
 
 const mvndSpec = {
-  description: "The Maven Daemon CLI.",
   baseUrl: `https://github.com/apache/maven-mvnd/releases/download/${mvndVersion}/`,
   // 0.9.0 has no ARM64 build for linux yet
   // Should be fixed once 1.0.0 is released
@@ -47,7 +46,7 @@ const mvndSpec = {
 export const mavendSpec: PluginToolSpec = {
   name: "mavend",
   version: mvndVersion,
-  description: "The Maven Daemon CLI.",
+  description: `The Maven Daemon CLI, v${mvndVersion}`,
   type: "binary",
   builds: [
     {

--- a/plugins/jib/src/openjdk.ts
+++ b/plugins/jib/src/openjdk.ts
@@ -27,11 +27,12 @@ interface JdkVersion {
   windows: JdkBinary
 }
 
+const jdk8VersionName = "jdk8u292-b10"
 const jdk8Version: JdkVersion = {
   lookupName: "openjdk-8",
-  description: "The OpenJDK 8 library.",
+  description: `The OpenJDK 8 library, ${jdk8VersionName}`,
   baseUrl: "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/",
-  versionName: "jdk8u292-b10",
+  versionName: jdk8VersionName,
   mac_amd64: {
     filename: "OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.tar.gz",
     sha256: "5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007",
@@ -50,11 +51,12 @@ const jdk8Version: JdkVersion = {
   },
 }
 
+const jdk11VersionName = "jdk-11.0.9.1+1"
 const jdk11Version: JdkVersion = {
   lookupName: "openjdk-11",
-  description: "The OpenJDK 11 library.",
+  description: `The OpenJDK 11 library, ${jdk11VersionName}`,
   baseUrl: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/",
-  versionName: "jdk-11.0.9.1+1",
+  versionName: jdk11VersionName,
   mac_amd64: {
     filename: "OpenJDK11U-jdk_x64_mac_hotspot_11.0.9.1_1.tar.gz",
     sha256: "96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77",
@@ -73,11 +75,12 @@ const jdk11Version: JdkVersion = {
   },
 }
 
+const jdk13VersionName = "jdk-13+33"
 const jdk13Version: JdkVersion = {
   lookupName: "openjdk-13",
-  description: "The OpenJDK 13 library.",
+  description: `[DEPRECATED] The OpenJDK 13 library, ${jdk13VersionName}`,
   baseUrl: "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/",
-  versionName: "jdk-13+33",
+  versionName: jdk13VersionName,
   mac_amd64: {
     filename: "OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz",
     sha256: "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f",
@@ -96,11 +99,12 @@ const jdk13Version: JdkVersion = {
   },
 }
 
+const jdk17VersionName = "jdk-17.0.4.1+1"
 const jdk17Version: JdkVersion = {
   lookupName: "openjdk-17",
-  description: "The OpenJDK 17 library.",
+  description: `The OpenJDK 17 library, ${jdk17VersionName}`,
   baseUrl: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/",
-  versionName: "jdk-17.0.4.1+1",
+  versionName: jdk17VersionName,
   mac_amd64: {
     filename: "OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
     sha256: "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a",
@@ -123,11 +127,12 @@ const jdk17Version: JdkVersion = {
   },
 }
 
+const jdk21VersionName = "jdk-21.0.1+12"
 const jdk21Version: JdkVersion = {
   lookupName: "openjdk-21",
-  description: "The OpenJDK 21 library.",
+  description: `The OpenJDK 21 library, ${jdk21VersionName}`,
   baseUrl: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/",
-  versionName: "jdk-21.0.1+12",
+  versionName: jdk21VersionName,
   mac_amd64: {
     filename: "OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz",
     sha256: "35f3cbc86d7ff0a01facefd741d5cfb675867e0a5ec137f62ba071d2511a45c9",


### PR DESCRIPTION
**What this PR does / why we need it**:
To improve UX, let's always print the concrete versions of the tools in the `garden tools` output.

This PR also does refactoring in the tool definitions. It extracts tools versions as named constants to make the version update process easier. The PR also adds some missing tests to verify the binary hashes for the tools.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
