### PR TITLE
ci: fix env setup for Windows tests

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1094,6 +1094,7 @@ jobs:
       - run:
           name: Install Deps
           command: |
+            Import-Module "$Env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
             choco install --limit-output --no-progress -y git rsync gcloudsdk kubernetes-cli
             $Env:CLOUDSDK_PYTHON = gcloud components copy-bundled-python
             gcloud components install gke-gcloud-auth-plugin --quiet


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR fixes the [failures](https://app.circleci.com/pipelines/github/garden-io/garden/23459/workflows/06e8dab2-5a4d-46e2-b471-b8a081330b7d/jobs/478798) in the environment setup for Windows tests.

The CI error was:
```console
Update done!

RefreshEnv.cmd does not work when run from this process. If you're in PowerShell, please 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1' and try again.

Exited with code exit status 1
```

This PR applies the fix suggested in the logs above.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
