### PR TITLE
fix(module-conversion): skip omitted build deps

### DIFF
--- a/core/test/unit/src/plugins/kubernetes/container/module-conversion.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/module-conversion.ts
@@ -36,7 +36,7 @@ describe("kubernetes container module conversion", () => {
     tmpDir.cleanup()
   })
 
-  it("should ", async () => {
+  it("should include build dependencies among converted runtime actions' dependencies", async () => {
     garden.setModuleConfigs([
       makeModuleConfig<ContainerModuleConfig>(garden.projectRoot, {
         name: "test-image",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

When a module has a build dependency on another module that doesn't have a corresponding Build after being converted into actions (e.g. a build dependency on a `terraform` module), we now log a warning and remove the dependency from the generated actions instead of erroring out.

In 0.12, some users had build dependencies on modules with no-op build steps (e.g. `terraform`, `kubernetes` and `helm` modules)

While this was harmless in 0.12, this resulted in noisy errors before this fix.