### PR TITLE
refactor(resolve-module): separate filtering and warnings logging

### DIFF
--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -860,11 +860,15 @@ export const convertModules = profileAsync(async function convertModules(
     const [missingBuilds, existingBuilds] = partition(action.dependencies || [], isMissingBuildDependency)
     action.dependencies = existingBuilds
 
+    const moduleName = action.internal.moduleName
+    if (!moduleName) {
+      continue
+    }
+
     for (const missingBuild of missingBuilds) {
-      const moduleName = action.internal.moduleName
       const depName = missingBuild.name
       const depType = graph.getModule(depName)?.type
-      if (moduleName && depType) {
+      if (depType) {
         log.warn(
           deline`
             Action ${styles.highlight(actionReferenceToString(action))} depends on

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -868,22 +868,24 @@ export const convertModules = profileAsync(async function convertModules(
     for (const missingBuild of missingBuilds) {
       const depName = missingBuild.name
       const depType = graph.getModule(depName)?.type
-      if (depType) {
-        log.warn(
-          deline`
-            Action ${styles.highlight(actionReferenceToString(action))} depends on
-            ${styles.highlight("build." + depName)} (from module ${styles.highlight(depName)} of type ${depType}),
-            which doesn't exist. This is probably because there's no need for a Build action when converting modules
-            of type ${depType} to actions. Skipping this dependency.
-          `
-        )
-        log.warn(
-          deline`
-            Please remove the build dependency on ${styles.highlight(depName)} from the module
-            ${styles.highlight(moduleName)}'s configuration.
-          `
-        )
+      if (!depType) {
+        continue
       }
+
+      log.warn(
+        deline`
+          Action ${styles.highlight(actionReferenceToString(action))} depends on
+          ${styles.highlight("build." + depName)} (from module ${styles.highlight(depName)} of type ${depType}),
+          which doesn't exist. This is probably because there's no need for a Build action when converting modules
+          of type ${depType} to actions. Skipping this dependency.
+        `
+      )
+      log.warn(
+        deline`
+          Please remove the build dependency on ${styles.highlight(depName)} from the module
+          ${styles.highlight(moduleName)}'s configuration.
+        `
+      )
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `partition` to separate existing and missing deps, and then process each collection separately, just for better readability and ensuring SRP.

A leftover from the core review for #5727 :)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
