### PR TITLE
fix(k8s): also retry API requests on 500 status

### DIFF
--- a/core/src/plugins/kubernetes/retry.ts
+++ b/core/src/plugins/kubernetes/retry.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import httpStatusCodes from "http-status-codes"
+import { StatusCodes } from "http-status-codes"
 import { ApiException as KubernetesApiException } from "@kubernetes/client-node"
 import { sleep } from "../../util/util.js"
 import type { Log } from "../../logger/log-entry.js"
@@ -170,13 +170,14 @@ export function shouldRetry(error: unknown, context: string): boolean {
 }
 
 export const statusCodesForRetry: number[] = [
-  httpStatusCodes.REQUEST_TIMEOUT,
-  httpStatusCodes.TOO_MANY_REQUESTS,
+  StatusCodes.REQUEST_TIMEOUT,
+  StatusCodes.TOO_MANY_REQUESTS,
 
-  httpStatusCodes.INTERNAL_SERVER_ERROR,
-  httpStatusCodes.BAD_GATEWAY,
-  httpStatusCodes.SERVICE_UNAVAILABLE,
-  httpStatusCodes.GATEWAY_TIMEOUT,
+  StatusCodes.INTERNAL_SERVER_ERROR,
+  StatusCodes.BAD_GATEWAY,
+  StatusCodes.SERVICE_UNAVAILABLE,
+  StatusCodes.GATEWAY_TIMEOUT,
+  StatusCodes.INTERNAL_SERVER_ERROR,
 
   // Cloudflare-specific status codes
   521, // Web Server Is Down


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Added 500 / internal server error to the list of status codes that result in a retry for Kubernetes API requests, since in practice this error code may indicate a transient problem (and the user would generally want an automatic retry in such cases).

**Which issue(s) this PR fixes**:

Should fix #5729.