### PR TITLE
docs(sync): actualise sync list command

### DIFF
--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -278,5 +278,5 @@ Because Garden creates a temporary data directory for Mutagen for every Garden C
 To, for example, get the current list of active syncs in an active Garden process, you could run the following from the project root directory:
 
 ```sh
-.garden/mutagen/latest/mutagen.sh sync list
+garden util mutagen sync list
 ```


### PR DESCRIPTION
Remove outdated command that was referencing a non-existing script.
Use the proper Garden command instead.