### PR TITLE
ci(windows): update to the latest Win Server 2022 executor

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1092,6 +1092,14 @@ jobs:
       - checkout
       - *attach-workspace
       - run:
+          # Print PowerShell version for diagnostics
+          name: Print PowerShell versions
+          command: $PSVersionTable
+      - run:
+          # Print Chocolatey version for diagnostics
+          name: Print Chocolatey versions
+          command: choco --version
+      - run:
           name: Install Deps
           command: |
             Import-Module "$Env:ChocolateyInstall\helpers\chocolateyProfile.psm1"

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@5.0.0
   rok8s-scripts: fairwinds/rok8s-scripts@11.1.3
   macos: circleci/macos@2.4.0
 
@@ -1086,7 +1086,7 @@ jobs:
 
   test-windows:
     executor:
-      name: win/default
+      name: win/server-2022
       size: large
     steps:
       - checkout


### PR DESCRIPTION
Some enhancements in the Windows test environment configuration:

* Use the latest available executor `circleci/windows@5.0.0` for `win/server-2022`
* Print the versions of the installed Chocolatey and PowerShell (it might be useful for troubleshooting).