### PR TITLE
feat(sync): deprecate non-interactive `sync start` and `stop` commands

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -161,7 +161,7 @@ export class DeployCommand extends Command<Args, Opts> {
   }
 
   override useInkTerminalWriter(params) {
-    return !!this.maybePersistent(params)
+    return this.maybePersistent(params)
   }
 
   override terminate() {

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -20,6 +20,7 @@ import { createActionLog } from "../../logger/log-entry.js"
 import type { DeployAction } from "../../actions/deploy.js"
 import type { ConfigGraph } from "../../graph/config-graph.js"
 import type { Garden } from "../../index.js"
+import { styles } from "../../logger/styles.js"
 
 const syncStartArgs = {
   names: new StringsParameter({
@@ -94,6 +95,17 @@ export class SyncStartCommand extends Command<Args, Opts> {
 
   async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     const { garden, log, args, opts } = params
+
+    if (!params.parentCommand) {
+      log.warn(
+        dedent`Behaviour of ${styles.command(
+          "sync start"
+        )} is now deprecated and will be changed in a future breaking change release.
+        Instead we recommend running ${styles.command("garden deploy --sync")} or starting syncs ${styles.italic(
+          "inside"
+        )} the dev console with either ${styles.command("deploy --sync")} or ${styles.command("sync start")}.`
+      )
+    }
 
     // We default to starting syncs for all Deploy actions
     const names = args.names || ["*"]


### PR DESCRIPTION
The current behaviour of both commands is now deprecated and will be changed in a future breaking change release.
Both commands will be allowed to execute only inside dev console.

We recommend to run these commands from inside dev console starting from now.