### PR TITLE
fix(k8s): retry websocket errors

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -40,6 +40,7 @@
     "@opentelemetry/sdk-trace-base": "^1.21.0",
     "@opentelemetry/semantic-conventions": "^1.17.1",
     "@scg82/exit-hook": "^3.4.1",
+    "@types/ws": "^8.5.10",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "analytics-node": "6.2.0",

--- a/core/src/plugins/kubernetes/retry.ts
+++ b/core/src/plugins/kubernetes/retry.ts
@@ -201,8 +201,10 @@ const errorMessageRegexesForRetry = [
   // (rpc error: code = ResourceExhausted desc = etcdserver: throttle: too many requests)
   /too many requests/,
   /Unable to connect to the server/,
-  /WebsocketError: Unexpected server response/,
   // We often flaked with this error on microk8s in the CI:
   // > pods "api-test-xxxx" is forbidden: error looking up service account container-default/default: serviceaccount "default" not found
   /forbidden: error looking up service account/,
+
+  // We get WebsocketError without HTTP status code on some API operations, e.g. exec in a pod
+  /WebsocketError/,
 ]

--- a/core/test/unit/src/plugins/kubernetes/retry.ts
+++ b/core/test/unit/src/plugins/kubernetes/retry.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { KubernetesError } from "../../../../../src/plugins/kubernetes/api.js"
+import type { ErrorEvent, WebSocket } from "ws"
+import { shouldRetry, toKubernetesError } from "../../../../../src/plugins/kubernetes/retry.js"
+import { expect } from "chai"
+import dedent from "dedent"
+
+const testKubeOp = "test"
+const websocketError: ErrorEvent = {
+  error: new Error("error message"),
+  message: "This is a test error message",
+  type: "error",
+  target: true as unknown as WebSocket,
+}
+
+describe("toKubernetesError", () => {
+  it("should handle WebsocketError", () => {
+    const err = toKubernetesError(websocketError, testKubeOp)
+
+    expect(err).to.be.instanceof(KubernetesError)
+    expect(err.message).to.equal(dedent`
+      Error while performing Kubernetes API operation test: WebsocketError
+
+      This is a test error message
+    `)
+    expect(err.responseStatusCode).to.be.undefined
+    expect(err.apiMessage).to.be.undefined
+    expect(err.type).to.equal("kubernetes")
+  })
+})
+
+describe("shouldRetry", () => {
+  it("should retry WebsocketError", () => {
+    expect(shouldRetry(websocketError, testKubeOp)).to.be.true
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1372,6 +1372,7 @@
         "@opentelemetry/sdk-trace-base": "^1.21.0",
         "@opentelemetry/semantic-conventions": "^1.17.1",
         "@scg82/exit-hook": "^3.4.1",
+        "@types/ws": "^8.5.10",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "analytics-node": "6.2.0",
@@ -2736,14 +2737,6 @@
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.12.tgz",
       "integrity": "sha512-beX81q12OQo809WJ/UYCvUDvJR3YQ4wtehYYQ6eNw5VLyd+KUNBRV4FgzZCHBmACbdPulH9F9ifhxzFFU9TWvQ=="
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "core/node_modules/@kubernetes/client-node/node_modules/byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
@@ -3161,15 +3154,6 @@
         "@types/koa": "*"
       }
     },
-    "core/node_modules/@types/koa-websocket/node_modules/@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "core/node_modules/@types/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.4.tgz",
@@ -3367,6 +3351,14 @@
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true
+    },
+    "core/node_modules/@types/ws": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "core/node_modules/ajv": {
       "version": "8.12.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

We failed retrying `WebsocketError` during Pod exec operations, because the regex "WebsocketError: Unexpected server response" did not match
anymore after we refactored `toKubernetesError`, because the formatting
changed.

Let's retry if just the name `WebsocketError` appears in the message.

**Which issue(s) this PR fixes**:

Fixes #5729

**Special notes for your reviewer**:
