### PR TITLE
docs(k8s): update Kubernetes support policy

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -146,6 +146,9 @@ export const gardenPlugin = () => {
     The [Quickstart guide](${makeDocsLink`getting-started/quickstart`}) guide is also helpful as an introduction.
 
     Note that if you're using a local Kubernetes cluster (e.g. minikube or Docker Desktop), the [local-kubernetes provider](./local-kubernetes.md) simplifies (and automates) the configuration and setup quite a bit.
+
+    Please note that Garden is committed to supporting [the _latest officially supported_ versions](https://kubernetes.io/releases/).
+    The information on the Kubernetes support and EOL timelines can be found [here](https://endoflife.date/kubernetes).
   `,
     configSchema: configSchema(),
     outputsSchema,

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,8 @@ You need the following dependencies on your local machine to use Garden:
 - Git (v2.14 or newer)
 - _[Windows only]_ rsync (v3.1.0 or newer)
 
-And if you'd like to build and run services locally, you need [a local installation of Kubernetes](https://kubernetes.io/docs/tutorials/hello-minikube/). Garden is committed to supporting [the _latest six_ stable versions (i.e. if the latest stable version is v1.23.x, Garden supports v1.18.x and newer)](https://kubernetes.io/releases/).
+And if you'd like to build and run services locally, you need [a local installation of Kubernetes](https://kubernetes.io/docs/tutorials/hello-minikube/). Garden is committed to supporting [the _latest officially supported_ versions](https://kubernetes.io/releases/).
+The information on the Kubernetes support and EOL timelines can be found [here](https://endoflife.date/kubernetes).
 
 ## macOS
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -17,6 +17,9 @@ The [Quickstart guide](../../getting-started/quickstart.md) guide is also helpfu
 
 Note that if you're using a local Kubernetes cluster (e.g. minikube or Docker Desktop), the [local-kubernetes provider](./local-kubernetes.md) simplifies (and automates) the configuration and setup quite a bit.
 
+Please note that Garden is committed to supporting [the _latest officially supported_ versions](https://kubernetes.io/releases/).
+The information on the Kubernetes support and EOL timelines can be found [here](https://endoflife.date/kubernetes).
+
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 
 The reference is divided into two sections. The [first section](#complete-yaml-schema) contains the complete YAML schema, and the [second section](#configuration-keys) describes each schema key.


### PR DESCRIPTION
Update the instructions on the Kubernetes support by Garden.
Now Garden only supports the latest and the officially maintained Kubernetes versions.

This is a follow-up PR for #5664 and #5696.