### PR TITLE
feat(k8s): support mode=max for AWS ECR with cluster-buildkit build mode

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -449,13 +449,14 @@ export const kubernetesConfigBase = () =>
 
             See the following table for details on our detection mechanism:
 
-            | Registry Name                   | Registry Domain         | Assumed \`mode=max\` support |
-            |---------------------------------|-------------------------|------------------------------|
-            | Google Cloud Artifact Registry  | \`pkg.dev\`             | Yes                          |
-            | Azure Container Registry        | \`azurecr.io\`          | Yes                          |
-            | GitHub Container Registry       | \`ghcr.io\`             | Yes                          |
-            | DockerHub                       | \`hub.docker.com\`     | Yes                          |
-            | Any other registry              |                         | No                           |
+            | Registry Name                   | Registry Domain                    | Assumed \`mode=max\` support |
+            |---------------------------------|------------------------------------|------------------------------|
+            | AWS Elastic Container Registry  | \`dkr.ecr.<region>.amazonaws.com\` | Yes (with \`image-manifest=true\`) |
+            | Google Cloud Artifact Registry  | \`pkg.dev\`                        | Yes                          |
+            | Azure Container Registry        | \`azurecr.io\`                     | Yes                          |
+            | GitHub Container Registry       | \`ghcr.io\`                        | Yes                          |
+            | DockerHub                       | \`hub.docker.com\`                 | Yes                          |
+            | Any other registry              |                                    | No                           |
 
             In case you need to override the defaults for your registry, you can do it like so:
 

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -48,7 +48,7 @@ import { stringifyResources } from "../util.js"
 import { styles } from "../../../../logger/styles.js"
 import type { ResolvedBuildAction } from "../../../../actions/build.js"
 
-const AWS_ECR_REGEX = /^([^/]+\.)?dkr.ecr.([^/]+\.).amazonaws.com\//i // AWS Elastic Container Registry
+const AWS_ECR_REGEX = /^([^\.]+\.)?dkr\.ecr\.([^\.]+\.)amazonaws\.com\//i // AWS Elastic Container Registry
 
 // NOTE: If you change this, please make sure to also change the table in our documentation in config.ts
 const MODE_MAX_ALLOWED_REGISTRIES = [

--- a/docs/k8s-plugins/guides/in-cluster-building.md
+++ b/docs/k8s-plugins/guides/in-cluster-building.md
@@ -202,10 +202,11 @@ Please keep in mind that you should also configure a garbage collection policy i
 
 #### Multi-stage caching
 
-If your `Dockerfile` has multiple stages, you can benefit from `mode=max` caching. It is automatically enabled, if your registry is not in our list of unsupported registries.
-Currently, those are AWS ECR and Google GCR. If you are using GCR, you can switch to the Google Artifact Registry, which supports `mode=max`.
+If your `Dockerfile` has multiple stages, you can benefit from `mode=max` caching. It is automatically enabled, if your registry is in our list of supported registries.
 
-You can also configure a different cache registry for your images. That way you can keep using ECR or GCR, while having better cache hit rate with `mode=max`:
+You can find the list of supported registries in [Kubernetes provider configuration guide](../../reference/providers/kubernetes.md#providersclusterbuildkitcache).
+
+You can also configure a different cache registry for your images. That way you can use `mode=max` to achieve a better cache hit rate, even if your registry does not support `mode=max`.
 
 ```yaml
 clusterBuildkit:
@@ -217,6 +218,19 @@ clusterBuildkit:
 ```
 
 For this mode of operation you need secrets for all the registries configured in your `imagePullSecrets`.
+
+Please note that most registries do support `mode=max`. If you are using a self-hosted registry, we do not use `mode=max` by default out of caution. You can force to enable it to achieve a better cache-hit rate with self-hosted registries:
+
+```
+clusterBuildkit:
+  cache:
+      - type: registry
+        mode: max # Force mode=max as our self-hosted registry is not in the list of supported registries
+        registry:
+          hostname: company-registry.example.com
+          namespace: my-team-cache
+
+```
 
 ### Local Docker
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -65,13 +65,14 @@ providers:
       #
       # See the following table for details on our detection mechanism:
       #
-      # | Registry Name                   | Registry Domain         | Assumed `mode=max` support |
-      # |---------------------------------|-------------------------|------------------------------|
-      # | Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
-      # | Azure Container Registry        | `azurecr.io`          | Yes                          |
-      # | GitHub Container Registry       | `ghcr.io`             | Yes                          |
-      # | DockerHub                       | `hub.docker.com`     | Yes                          |
-      # | Any other registry              |                         | No                           |
+      # | Registry Name                   | Registry Domain                    | Assumed `mode=max` support |
+      # |---------------------------------|------------------------------------|------------------------------|
+      # | AWS Elastic Container Registry  | `dkr.ecr.<region>.amazonaws.com` | Yes (with `image-manifest=true`) |
+      # | Google Cloud Artifact Registry  | `pkg.dev`                        | Yes                          |
+      # | Azure Container Registry        | `azurecr.io`                     | Yes                          |
+      # | GitHub Container Registry       | `ghcr.io`                        | Yes                          |
+      # | DockerHub                       | `hub.docker.com`                 | Yes                          |
+      # | Any other registry              |                                    | No                           |
       #
       # In case you need to override the defaults for your registry, you can do it like so:
       #
@@ -617,13 +618,14 @@ option.
 
 See the following table for details on our detection mechanism:
 
-| Registry Name                   | Registry Domain         | Assumed `mode=max` support |
-|---------------------------------|-------------------------|------------------------------|
-| Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
-| Azure Container Registry        | `azurecr.io`          | Yes                          |
-| GitHub Container Registry       | `ghcr.io`             | Yes                          |
-| DockerHub                       | `hub.docker.com`     | Yes                          |
-| Any other registry              |                         | No                           |
+| Registry Name                   | Registry Domain                    | Assumed `mode=max` support |
+|---------------------------------|------------------------------------|------------------------------|
+| AWS Elastic Container Registry  | `dkr.ecr.<region>.amazonaws.com` | Yes (with `image-manifest=true`) |
+| Google Cloud Artifact Registry  | `pkg.dev`                        | Yes                          |
+| Azure Container Registry        | `azurecr.io`                     | Yes                          |
+| GitHub Container Registry       | `ghcr.io`                        | Yes                          |
+| DockerHub                       | `hub.docker.com`                 | Yes                          |
+| Any other registry              |                                    | No                           |
 
 In case you need to override the defaults for your registry, you can do it like so:
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -58,13 +58,14 @@ providers:
       #
       # See the following table for details on our detection mechanism:
       #
-      # | Registry Name                   | Registry Domain         | Assumed `mode=max` support |
-      # |---------------------------------|-------------------------|------------------------------|
-      # | Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
-      # | Azure Container Registry        | `azurecr.io`          | Yes                          |
-      # | GitHub Container Registry       | `ghcr.io`             | Yes                          |
-      # | DockerHub                       | `hub.docker.com`     | Yes                          |
-      # | Any other registry              |                         | No                           |
+      # | Registry Name                   | Registry Domain                    | Assumed `mode=max` support |
+      # |---------------------------------|------------------------------------|------------------------------|
+      # | AWS Elastic Container Registry  | `dkr.ecr.<region>.amazonaws.com` | Yes (with `image-manifest=true`) |
+      # | Google Cloud Artifact Registry  | `pkg.dev`                        | Yes                          |
+      # | Azure Container Registry        | `azurecr.io`                     | Yes                          |
+      # | GitHub Container Registry       | `ghcr.io`                        | Yes                          |
+      # | DockerHub                       | `hub.docker.com`                 | Yes                          |
+      # | Any other registry              |                                    | No                           |
       #
       # In case you need to override the defaults for your registry, you can do it like so:
       #
@@ -562,13 +563,14 @@ option.
 
 See the following table for details on our detection mechanism:
 
-| Registry Name                   | Registry Domain         | Assumed `mode=max` support |
-|---------------------------------|-------------------------|------------------------------|
-| Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
-| Azure Container Registry        | `azurecr.io`          | Yes                          |
-| GitHub Container Registry       | `ghcr.io`             | Yes                          |
-| DockerHub                       | `hub.docker.com`     | Yes                          |
-| Any other registry              |                         | No                           |
+| Registry Name                   | Registry Domain                    | Assumed `mode=max` support |
+|---------------------------------|------------------------------------|------------------------------|
+| AWS Elastic Container Registry  | `dkr.ecr.<region>.amazonaws.com` | Yes (with `image-manifest=true`) |
+| Google Cloud Artifact Registry  | `pkg.dev`                        | Yes                          |
+| Azure Container Registry        | `azurecr.io`                     | Yes                          |
+| GitHub Container Registry       | `ghcr.io`                        | Yes                          |
+| DockerHub                       | `hub.docker.com`                 | Yes                          |
+| Any other registry              |                                    | No                           |
 
 In case you need to override the defaults for your registry, you can do it like so:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
AWS ECR now supports `mode=max` together with an extra option
`image-manifest=true`.

See also https://aws.amazon.com/blogs/containers/announcing-remote-cache-support-in-amazon-ecr-for-buildkit-clients/

**Which issue(s) this PR fixes**:

Fixes #5683

**Special notes for your reviewer**:
