### PR TITLE
chore(lint): enable linter for `*.tsx` files

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -257,7 +257,7 @@
     "clean": "shx rm -rf build",
     "dev": "nodemon --watch src/template-string/*.pegjs --exec npm run build",
     "fix-format": "npm run lint -- --fix --quiet",
-    "lint": "eslint --ignore-pattern 'src/lib/**' --ext .ts src/ test/",
+    "lint": "eslint --ignore-pattern 'src/lib/**' --ext .ts,.tsx src/ test/",
     "migration:generate": "typeorm migration:generate --config ormconfig.js -n",
     "_integ": "mocha --config .mocharc.integ.yml",
     "integ-kind": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"cluster-buildkit cluster-buildkit-rootless kaniko remote-only\" npm run _integ --",

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -190,13 +190,16 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
   }
 
   private async initCommandHandler(params: ActionParams) {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const _this = this
     const { garden, log, opts } = params
 
     // override the session for this manager to ensure we inherit from
     // the initial garden dummy instance
     const manager = this.getManager(log, garden.sessionId)
+
+    const quit = () => {
+      this.commandLine?.disable("🌷  Thanks for stopping by, love you! ❤️")
+      this.terminate()
+    }
 
     const cl = new CommandLine({
       log,
@@ -230,11 +233,6 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
         })
         .catch(() => {})
         .finally(() => quit())
-    }
-
-    function quit() {
-      cl?.disable("🌷  Thanks for stopping by, love you! ❤️")
-      _this.terminate()
     }
 
     process.on("SIGINT", quitWithWarning)

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -190,6 +190,7 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
   }
 
   private async initCommandHandler(params: ActionParams) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const _this = this
     const { garden, log, opts } = params
 

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -6,14 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { CommandResult, CommandParams, ConsoleCommand } from "./base.js"
+import type { CommandResult, CommandParams } from "./base.js"
+import { ConsoleCommand } from "./base.js"
 import { renderDivider } from "../logger/util.js"
-import React, { FC, useState } from "react"
+import type { FC } from "react"
+import React, { useState } from "react"
 import { Box, render, Text, useInput, useStdout } from "ink"
 import { serveArgs, ServeCommand, serveOpts } from "./serve.js"
-import { LoggerType } from "../logger/logger.js"
 import { ParameterError, toGardenError } from "../exceptions.js"
-import { InkTerminalWriter } from "../logger/writers/ink-terminal-writer.js"
+import type { InkTerminalWriter } from "../logger/writers/ink-terminal-writer.js"
 import { CommandLine } from "../cli/command-line.js"
 import { globalOptions, StringsParameter } from "../cli/params.js"
 import { pick } from "lodash-es"
@@ -101,7 +102,7 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
 
     const commandLine = await this.initCommandHandler(params)
 
-    const Dev: FC<{}> = ({ }) => {
+    const Dev: FC<{}> = ({}) => {
       // Stream log output directly to stdout, on top of the Ink components below
       const { stdout, write } = useStdout()
       inkWriter.setWriteCallback(write)
@@ -226,7 +227,7 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
             "garden dev"
           )}, use ${styles.command("Ctrl-D")} or the ${styles.command(`exit`)} command.`,
         })
-        .catch(() => { })
+        .catch(() => {})
         .finally(() => quit())
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable linter for `*.tsx` files too. 

