### PR TITLE
chore(buildkit): remove liveness probe to avoid unneccessary restarts of buildkit

### DIFF
--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -463,13 +463,6 @@ export function getBuildkitDeployment(
                 initialDelaySeconds: 3,
                 periodSeconds: 5,
               },
-              livenessProbe: {
-                exec: {
-                  command: ["buildctl", "debug", "workers"],
-                },
-                initialDelaySeconds: 5,
-                periodSeconds: 30,
-              },
               securityContext: {
                 privileged: true,
               },

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -68,13 +68,6 @@ describe("buildkit build", () => {
           },
         ],
         image: buildkitImageName,
-        livenessProbe: {
-          exec: {
-            command: ["buildctl", "debug", "workers"],
-          },
-          initialDelaySeconds: 5,
-          periodSeconds: 30,
-        },
         name: "buildkitd",
         readinessProbe: {
           exec: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:
If the liveness probe fails, buildkit gets restarted which cancels the context. The command for the liveness probe seems to sometimes fail, even though the build is still going on. With removing the explicit liveness probe, we use the default kubernetes liveness probe, which is tied to the lifecycle of the main container process.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
