### PR TITLE
fix(k8s): attempt execing on running pod

### DIFF
--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -262,7 +262,14 @@ export async function execInWorkload({
   const api = await KubeApi.factory(log, ctx, provider)
   const pods = await getCurrentWorkloadPods(api, namespace, workload)
 
-  const pod = pods[0]
+  const runningPods = pods.filter((p) => checkPodStatus(p) === "ready")
+  if (runningPods.length === 0) {
+    throw new DeploymentError({
+      message: `No running pods found for ${getResourceKey(workload)}`,
+    })
+  }
+
+  const pod = sample(runningPods)
 
   if (!pod) {
     // This should not happen because of the prior status check, but checking to be sure


### PR DESCRIPTION
**What this PR does / why we need it**:
Try to choose a running Pod for execing into. Without this, users might get the following error persistently if the first pod happened to be crashlooping:

```
run.test✖ Failed processing Run type=kubernetes-exec name=test (took 12.35 sec). This is what happened:

────────────────────────────────────────────────────────────────────────────────────────────────────
Error while performing Kubernetes API operation Pod exec: WebsocketError

Unexpected server response: 500
────────────────────────────────────────────────────────────────────────────────────────────────────

```

**Which issue(s) this PR fixes**:

Fixes #5729

**Special notes for your reviewer**:
