### PR TITLE
fix(cloud): correctly parse user ID when creating cloud secrets

### DIFF
--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -17,7 +17,7 @@ import { Command } from "../../base.js"
 import type { ApiCommandError, SecretResult } from "../helpers.js"
 import { handleBulkOperationResult, makeSecretFromResponse, noApiMsg } from "../helpers.js"
 import { dedent, deline } from "../../../util/string.js"
-import { IntegerParameter, PathParameter, StringParameter, StringsParameter } from "../../../cli/params.js"
+import { PathParameter, StringParameter, StringsParameter } from "../../../cli/params.js"
 import type { StringMap } from "../../../config/common.js"
 import dotenv from "dotenv"
 import type { CloudProject } from "../../../cloud/api.js"
@@ -33,7 +33,7 @@ export const secretsCreateArgs = {
 }
 
 export const secretsCreateOpts = {
-  "scope-to-user-id": new IntegerParameter({
+  "scope-to-user-id": new StringParameter({
     help: deline`Scope the secret to a user with the given ID. User scoped secrets must be scoped to an environment as well.`,
   }),
   "scope-to-env": new StringParameter({
@@ -81,7 +81,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     // Apparently TS thinks that optional params are always defined so we need to cast them to their
     // true type here.
     const envName = opts["scope-to-env"] as string | undefined
-    const userId = opts["scope-to-user-id"] as number | undefined
+    const userId = opts["scope-to-user-id"] as string | undefined
     const fromFile = opts["from-file"] as string | undefined
     let secrets: StringMap
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -452,7 +452,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--scope-to-user-id` |  | number | Scope the secret to a user with the given ID. User scoped secrets must be scoped to an environment as well.
+  | `--scope-to-user-id` |  | string | Scope the secret to a user with the given ID. User scoped secrets must be scoped to an environment as well.
   | `--scope-to-env` |  | string | Scope the secret to an environment. Note that this does not default to the environment that the command runs in (i.e. the one set via the --env flag) and that you need to set this explicitly if you want to create an environment scoped secret.
   | `--from-file` |  | path | Read the secrets from the file at the given path. The file should have standard &quot;dotenv&quot; format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 


### PR DESCRIPTION
Before this fix we incorrectly parsed the user ID as an integer, not a string. This fixes that.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
