### PR TITLE
fix(template): support template strings in `ConfigTemplate.configs`

### DIFF
--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -27,6 +27,7 @@ import type { Garden } from "../garden.js"
 import { ConfigurationError, GardenError } from "../exceptions.js"
 import { resolve, posix } from "path"
 import fsExtra from "fs-extra"
+
 const { ensureDir } = fsExtra
 import type { TemplatedModuleConfig } from "../plugins/templated.js"
 import { omit } from "lodash-es"
@@ -273,9 +274,16 @@ async function renderConfigs({
   renderConfig: RenderTemplateConfig
 }): Promise<TemplatableConfig[]> {
   const templateDescription = `${configTemplateKind} '${template.name}'`
+  const templateConfigs = template.configs || []
+  const partiallyResolvedTemplateConfigs = resolveTemplateStrings({
+    value: templateConfigs,
+    context,
+    contextOpts: { allowPartial: true },
+    source: undefined,
+  })
 
   return Promise.all(
-    (template.configs || []).map(async (m) => {
+    partiallyResolvedTemplateConfigs.map(async (m) => {
       // Resolve just the name, which must be immediately resolvable
       let resolvedName = m.name
 

--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -279,7 +279,7 @@ async function renderConfigs({
     value: templateConfigs,
     context,
     contextOpts: { allowPartial: true },
-    source: undefined,
+    source: { yamlDoc: template.internal.yamlDoc, basePath: ["inputs"] },
   })
 
   return Promise.all(

--- a/core/test/data/test-projects/config-templates-with-templating/project.garden.yml
+++ b/core/test/data/test-projects/config-templates-with-templating/project.garden.yml
@@ -1,0 +1,8 @@
+apiVersion: garden.io/v1
+kind: Project
+name: config-templates-with-templating
+environments:
+  - name: local
+providers:
+  - name: local-kubernetes
+    environments: [local]

--- a/core/test/data/test-projects/config-templates-with-templating/runs.garden.yml
+++ b/core/test/data/test-projects/config-templates-with-templating/runs.garden.yml
@@ -1,0 +1,5 @@
+kind: RenderTemplate
+template: template-runs
+name: my-runs
+inputs:
+  names: ["run-a", "run-b"]

--- a/core/test/data/test-projects/config-templates-with-templating/schema.json
+++ b/core/test/data/test-projects/config-templates-with-templating/schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "names": {
+      "type": "array"
+    }
+  }
+}

--- a/core/test/data/test-projects/config-templates-with-templating/tempate.garden.yml
+++ b/core/test/data/test-projects/config-templates-with-templating/tempate.garden.yml
@@ -1,0 +1,13 @@
+kind: ConfigTemplate
+name: template-runs
+inputsSchemaPath: schema.json
+
+configs:
+  - $concat:
+      $forEach: ${inputs.names}
+      $return:
+        kind: Run
+        type: exec
+        name: "${item.value}"
+        spec:
+          command: ["echo", "${item.value}"]

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -269,8 +269,8 @@ describe("resolveWorkflowConfig", () => {
     }
 
     expect(workflow).to.exist
-    expect(workflow.steps[0].script).to.equal('echo "${inputs.envName}"') // <- resolved later
-    expect(omit(workflow.internal, "yamlDoc")).to.eql(internal)
+    expect(workflow.steps[0].script).to.equal('echo "${environment.name}"') // <- resolved later
+    expect(omit(workflow.internal, "yamlDoc")).to.eql(internal) // <- `inputs.envName` should be resolved
   })
 
   describe("populateNamespaceForTriggers", () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2991,8 +2991,8 @@ describe("Garden", () => {
         templateName: "combo",
         inputs: {
           name: "test",
-          envName: "${environment.name}", // <- resolved later
-          providerKey: "${providers.test-plugin.outputs.testKey}", // <- resolved later
+          envName: "${environment.name}", // <- should be resolved to itself
+          providerKey: "${providers.test-plugin.outputs.testKey}", // <- should be resolved to itself
         },
       }
 
@@ -3001,14 +3001,14 @@ describe("Garden", () => {
       expect(test).to.exist
 
       expect(build.type).to.equal("test")
-      expect(build.spec.command).to.include("${inputs.name}") // <- resolved later
+      expect(build.spec.command).to.include(internal.inputs.name) // <- should be resolved
       expect(omit(build.internal, "yamlDoc")).to.eql(internal)
 
-      expect(deploy["build"]).to.equal("${parent.name}-${inputs.name}") // <- resolved later
+      expect(deploy["build"]).to.equal(`${internal.parentName}-${internal.inputs.name}`) // <- should be resolved
       expect(omit(deploy.internal, "yamlDoc")).to.eql(internal)
 
-      expect(test.dependencies).to.eql(["build.${parent.name}-${inputs.name}"]) // <- resolved later
-      expect(test.spec.command).to.eql(["echo", "${inputs.envName}", "${inputs.providerKey}"]) // <- resolved later
+      expect(test.dependencies).to.eql([`build.${internal.parentName}-${internal.inputs.name}`]) // <- should be resolved
+      expect(test.spec.command).to.eql(["echo", internal.inputs.envName, internal.inputs.providerKey]) // <- should be resolved
       expect(omit(test.internal, "yamlDoc")).to.eql(internal)
     })
 
@@ -3025,12 +3025,12 @@ describe("Garden", () => {
         templateName: "workflows",
         inputs: {
           name: "test",
-          envName: "${environment.name}", // <- resolved later
+          envName: "${environment.name}", // <- should be resolved to itself
         },
       }
 
       expect(workflow).to.exist
-      expect(workflow.steps).to.eql([{ script: 'echo "${inputs.envName}"' }]) // <- resolved later
+      expect(workflow.steps).to.eql([{ script: `echo "${internal.inputs.envName}"` }]) // <- should be resolved
       expect(omit(workflow.internal, "yamlDoc")).to.eql(internal)
     })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to this PR Garden did not allow the templating in the `ConfigTemplate.configs` like this:

```yaml
kind: ConfigTemplate
name: runs-template
inputsSchemaPath: schema.json

configs:
  - $concat:
      $forEach: ${inputs.names}
      $return:
        kind: Run
        type: exec
        name: "${item.value}"
        spec:
          command: ["echo", "${item.value}"]

---
kind: RenderTemplate
template: runs-template
name: my-runs
inputs:
  names: ["run-a", "run-b"]
```

and it failed with error:
```console
Unexpected kind 'undefined' found in ConfigTemplate 'runs-template'. Supported kinds are: Build, Deploy, Run, Test and Workflow
```

<details>
  <summary>Click to expand schema.json</summary>

```yaml
{
  "type": "object",
  "properties": {
    "names": {
      "type": "array"
    }
  }
}
```

</details>

Now, Garden partially resolves the `configs` field of a given `ConfigTemplate`.