### PR TITLE
improvement: improvements to validate command

### DIFF
--- a/core/src/commands/validate.ts
+++ b/core/src/commands/validate.ts
@@ -9,11 +9,26 @@
 import type { CommandParams, CommandResult } from "./base.js"
 import { Command } from "./base.js"
 import { printEmoji, printHeader } from "../logger/util.js"
-import { dedent } from "../util/string.js"
+import { dedent, deline } from "../util/string.js"
 import { styles } from "../logger/styles.js"
 import { resolveWorkflowConfig } from "../config/workflow.js"
+import { StringsParameter } from "../cli/params.js"
+import type { ConfigGraph } from "../graph/config-graph.js"
 
-export class ValidateCommand extends Command {
+const validateOpts = {
+  resolve: new StringsParameter({
+    help: deline`
+      Fully resolve a specific action, including references to runtime outputs from other actions. Actions should be specified as \`<kind>.<name>\` (e.g. \`deploy.my-service\` or \`build.my-image\`). This option can be specified multiple times to fully resolve multiple actions. Use * to fully resolve all actions. Note that this may result in actions being executed during validation (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, we recommend not using this option.
+    `,
+    getSuggestions: ({ configDump }) => {
+      return Object.keys(configDump.actionConfigs)
+    },
+  }),
+}
+
+type Opts = typeof validateOpts
+
+export class ValidateCommand extends Command<{}, Opts> {
   name = "validate"
   help = "Check your garden configuration for errors."
   emoji = "✔️"
@@ -22,15 +37,28 @@ export class ValidateCommand extends Command {
 
   override description = dedent`
     Throws an error and exits with code 1 if something's not right in your garden config files.
+
+    Examples:
+
+        garden validate                              # validate all configs, but don't fully resolve any actions
+        garden validate --resolve build.my-image     # same as above, but fully resolve the build.my-image action
+        garden validate --resolve deploy.my-service
+        garden validate --resolve '*'                # fully resolve all actions
+        garden validate --resolve                    # fully resolve all actions
   `
 
   override printHeader({ log }) {
     printHeader(log, "Validate", "✔️")
   }
 
-  async action({ garden, log }: CommandParams): Promise<CommandResult> {
+  async action({ garden, log, opts }: CommandParams<{}, Opts>): Promise<CommandResult> {
     // This implicitly validates modules and actions.
-    await garden.getResolvedConfigGraph({ log, emit: false })
+    const { resolve } = opts
+    const graph = await garden.getConfigGraph({ log, emit: false })
+    if (resolve) {
+      const actionsToResolve = getActionsToResolve(resolve, graph)
+      await garden.resolveActions({ actions: actionsToResolve, graph, log })
+    }
 
     /*
      * Normally, workflow configs are only resolved when they're run via the `workflow` command (and only the
@@ -48,4 +76,10 @@ export class ValidateCommand extends Command {
 
     return {}
   }
+}
+
+export function getActionsToResolve(toResolve: string[] | undefined, graph: ConfigGraph) {
+  return !toResolve || toResolve.length === 0 || toResolve?.[0] === "*"
+    ? graph.getActions()
+    : graph.getActions({ refs: toResolve })
 }

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -238,7 +238,7 @@ describe("configureHelmModule", () => {
       garden: g,
       log: g.log,
       args: {},
-      opts: withDefaultGlobalOpts({}),
+      opts: withDefaultGlobalOpts({ resolve: undefined }),
     })
   })
 })

--- a/core/test/integ/src/plugins/openshift/tests.ts
+++ b/core/test/integ/src/plugins/openshift/tests.ts
@@ -32,7 +32,7 @@ describe.skip("OpenShift", () => {
       garden,
       log,
       args: {},
-      opts: withDefaultGlobalOpts({}),
+      opts: withDefaultGlobalOpts({ resolve: undefined }),
     })
   })
 

--- a/core/test/unit/src/commands/base.ts
+++ b/core/test/unit/src/commands/base.ts
@@ -245,7 +245,7 @@ describe("Command", () => {
         await validateCmd.run({
           log,
           args: {},
-          opts: withDefaultGlobalOpts({}),
+          opts: withDefaultGlobalOpts({ resolve: undefined }),
           garden,
           sessionId: uuidv4(),
           parentSessionId: devCmdSessionId,
@@ -269,7 +269,7 @@ describe("Command", () => {
         await validateCmd.run({
           log,
           args: {},
-          opts: withDefaultGlobalOpts({}),
+          opts: withDefaultGlobalOpts({ resolve: undefined }),
           garden,
           sessionId: uuidv4(),
           parentSessionId: devCmdSessionId,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -5870,6 +5870,14 @@ Useful for diagnosing slow init performance for projects with lots of actions an
 
 Throws an error and exits with code 1 if something's not right in your garden config files.
 
+Examples:
+
+    garden validate                              # validate all configs, but don't fully resolve any actions
+    garden validate --resolve build.my-image     # same as above, but fully resolve the build.my-image action
+    garden validate --resolve deploy.my-service
+    garden validate --resolve '*'                # fully resolve all actions
+    garden validate --resolve                    # fully resolve all actions
+
 #### Usage
 
     garden validate 

--- a/plugins/terraform/test/validation.ts
+++ b/plugins/terraform/test/validation.ts
@@ -30,7 +30,7 @@ describe("terraform validation", () => {
         garden,
         log: garden.log,
         args: {},
-        opts: withDefaultGlobalOpts({}),
+        opts: withDefaultGlobalOpts({ resolve: undefined }),
       })
     })
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this commit, the `garden validate` command would fully resolve the config graph. This caused problems for users that had references to runtime outputs of actions in their action configs, since fully resolving the graph in such cases means executing the action (e.g. actually building/deploying).

Here, we change the default behavior of the validate command to only partially resolve the config graph, but also introduce a `--resolve` CLI option for resolving some or all actions fully. This allows users to fully resolve action configs for debugging purposes, but also to sidestep action configs with runtime output references.

**Which issue(s) this PR fixes**:

Fixes #5695.