### PR TITLE
fix(k8s): use the same service account for pulling images as building

### DIFF
--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -20,7 +20,12 @@ import { dockerAuthSecretKey, getK8sUtilImageName, systemDockerAuthSecretName } 
 import { getAppNamespace, getSystemNamespace } from "../namespace.js"
 import { randomString } from "../../../util/string.js"
 import type { PluginContext } from "../../../plugin-context.js"
-import { ensureBuilderSecret, ensureServiceAccount, inClusterBuilderServiceAccount } from "../container/build/common.js"
+import {
+  ensureBuilderSecret,
+  ensureServiceAccount,
+  getBuilderServiceAccountAnnotations,
+  inClusterBuilderServiceAccount,
+} from "../container/build/common.js"
 import type { ContainerBuildAction } from "../../container/config.js"
 import { k8sGetContainerBuildActionOutputs } from "../container/handlers.js"
 import type { Resolved } from "../../../actions/types.js"
@@ -133,7 +138,7 @@ async function pullFromExternalRegistry({ ctx, log, localId, remoteId }: PullPar
     log,
     api,
     namespace,
-    annotations: ctx.provider.config.kaniko?.serviceAccountAnnotations,
+    annotations: getBuilderServiceAccountAnnotations(ctx.provider.config),
   })
 
   const runner = new PodRunner({

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -20,7 +20,7 @@ import { dockerAuthSecretKey, getK8sUtilImageName, systemDockerAuthSecretName } 
 import { getAppNamespace, getSystemNamespace } from "../namespace.js"
 import { randomString } from "../../../util/string.js"
 import type { PluginContext } from "../../../plugin-context.js"
-import { ensureBuilderSecret } from "../container/build/common.js"
+import { ensureBuilderSecret, inClusterBuilderServiceAccount } from "../container/build/common.js"
 import type { ContainerBuildAction } from "../../container/config.js"
 import { k8sGetContainerBuildActionOutputs } from "../container/handlers.js"
 import type { Resolved } from "../../../actions/types.js"
@@ -141,6 +141,7 @@ async function pullFromExternalRegistry({ ctx, log, localId, remoteId }: PullPar
         namespace,
       },
       spec: {
+        serviceAccountName: inClusterBuilderServiceAccount,
         containers: [
           {
             name: "main",

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -20,12 +20,7 @@ import { dockerAuthSecretKey, getK8sUtilImageName, systemDockerAuthSecretName } 
 import { getAppNamespace, getSystemNamespace } from "../namespace.js"
 import { randomString } from "../../../util/string.js"
 import type { PluginContext } from "../../../plugin-context.js"
-import {
-  ensureBuilderSecret,
-  ensureServiceAccount,
-  getBuilderServiceAccountAnnotations,
-  inClusterBuilderServiceAccount,
-} from "../container/build/common.js"
+import { ensureBuilderSecret, ensureServiceAccount, inClusterBuilderServiceAccount } from "../container/build/common.js"
 import type { ContainerBuildAction } from "../../container/config.js"
 import { k8sGetContainerBuildActionOutputs } from "../container/handlers.js"
 import type { Resolved } from "../../../actions/types.js"
@@ -138,7 +133,6 @@ async function pullFromExternalRegistry({ ctx, log, localId, remoteId }: PullPar
     log,
     api,
     namespace,
-    annotations: getBuilderServiceAccountAnnotations(ctx.provider.config),
   })
 
   const runner = new PodRunner({

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -20,7 +20,7 @@ import { dockerAuthSecretKey, getK8sUtilImageName, systemDockerAuthSecretName } 
 import { getAppNamespace, getSystemNamespace } from "../namespace.js"
 import { randomString } from "../../../util/string.js"
 import type { PluginContext } from "../../../plugin-context.js"
-import { ensureBuilderSecret, inClusterBuilderServiceAccount } from "../container/build/common.js"
+import { ensureBuilderSecret, ensureServiceAccount, inClusterBuilderServiceAccount } from "../container/build/common.js"
 import type { ContainerBuildAction } from "../../container/config.js"
 import { k8sGetContainerBuildActionOutputs } from "../container/handlers.js"
 import type { Resolved } from "../../../actions/types.js"
@@ -127,6 +127,14 @@ async function pullFromExternalRegistry({ ctx, log, localId, remoteId }: PullPar
     `docker://${remoteId}`,
     `docker-archive:${tmpTarPath}:${localId}`,
   ]
+
+  await ensureServiceAccount({
+    ctx,
+    log,
+    api,
+    namespace,
+    annotations: ctx.provider.config.kaniko?.serviceAccountAnnotations,
+  })
 
   const runner = new PodRunner({
     api,

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -22,7 +22,6 @@ import type { KubernetesDeployment } from "../../types.js"
 import type { Log } from "../../../../logger/log-entry.js"
 import { waitForResources, compareDeployedResources } from "../../status/status.js"
 import type { KubernetesProvider, KubernetesPluginContext, ClusterBuildkitCacheConfig } from "../../config.js"
-import type { PluginContext } from "../../../../plugin-context.js"
 import type { BuildStatusHandler, BuildHandler } from "./common.js"
 import {
   skopeoBuildStatus,
@@ -180,7 +179,7 @@ export async function ensureBuildkit({
   api,
   namespace,
 }: {
-  ctx: PluginContext
+  ctx: KubernetesPluginContext
   provider: KubernetesProvider
   log: Log
   api: KubeApi
@@ -191,7 +190,6 @@ export async function ensureBuildkit({
     log,
     api,
     namespace,
-    annotations: provider.config.clusterBuildkit?.serviceAccountAnnotations,
   })
 
   return deployLock.acquire(namespace, async () => {

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -284,16 +284,17 @@ export async function ensureServiceAccount({
   log,
   api,
   namespace,
-  annotations,
 }: {
-  ctx: PluginContext
+  ctx: KubernetesPluginContext
   log: Log
   api: KubeApi
   namespace: string
-  annotations?: StringMap
 }): Promise<boolean> {
   return deployLock.acquire(namespace, async () => {
-    const serviceAccount = getBuilderServiceAccountSpec(namespace, annotations)
+    const serviceAccount = getBuilderServiceAccountSpec(
+      namespace,
+      getBuilderServiceAccountAnnotations(ctx.provider.config)
+    )
 
     const status = await compareDeployedResources({
       ctx: ctx as KubernetesPluginContext,
@@ -341,7 +342,7 @@ export async function ensureUtilDeployment({
   api,
   namespace,
 }: {
-  ctx: PluginContext
+  ctx: KubernetesPluginContext
   provider: KubernetesProvider
   log: Log
   api: KubeApi
@@ -352,7 +353,6 @@ export async function ensureUtilDeployment({
     log,
     api,
     namespace,
-    annotations: provider.config.kaniko?.serviceAccountAnnotations,
   })
 
   return deployLock.acquire(namespace, async () => {

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -9,7 +9,7 @@
 import AsyncLock from "async-lock"
 import type { ContainerBuildAction, ContainerRegistryConfig } from "../../../container/moduleConfig.js"
 import type { KubeApi } from "../../api.js"
-import type { KubernetesPluginContext, KubernetesProvider } from "../../config.js"
+import type { KubernetesConfig, KubernetesPluginContext, KubernetesProvider } from "../../config.js"
 import { PodRunner, PodRunnerError } from "../../run.js"
 import type { PluginContext } from "../../../../plugin-context.js"
 import { hashString, sleep } from "../../../../util/util.js"
@@ -267,6 +267,16 @@ export function skopeoManifestUnknown(errMsg: string | null | undefined): boolea
     errMsg.includes("Failed to fetch") ||
     /(artifact|repository) [^ ]+ not found/.test(errMsg)
   )
+}
+
+export function getBuilderServiceAccountAnnotations(config: KubernetesConfig): StringMap | undefined {
+  if (config.buildMode === "kaniko") {
+    return config.kaniko?.serviceAccountAnnotations
+  }
+  if (config.buildMode === "cluster-buildkit") {
+    return config.clusterBuildkit?.serviceAccountAnnotations
+  }
+  return undefined
 }
 
 export async function ensureServiceAccount({

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -139,7 +139,6 @@ export const kanikoBuild: BuildHandler = async (params) => {
       log,
       api,
       namespace: kanikoNamespace,
-      annotations: provider.config.kaniko?.serviceAccountAnnotations,
     })
   }
 

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -9,7 +9,6 @@
 import { expectError, grouped } from "../../../../../../helpers.js"
 import type { Garden } from "../../../../../../../src/garden.js"
 import type { ConfigGraph } from "../../../../../../../src/graph/config-graph.js"
-import type { PluginContext } from "../../../../../../../src/plugin-context.js"
 import type {
   ClusterBuildkitCacheConfig,
   KubernetesPluginContext,
@@ -42,7 +41,7 @@ describe.skip("Kubernetes Container Build Extension", () => {
   let log: ActionLog
   let graph: ConfigGraph
   let provider: KubernetesProvider
-  let ctx: PluginContext
+  let ctx: KubernetesPluginContext
 
   after(async () => {
     if (garden) {
@@ -55,7 +54,11 @@ describe.skip("Kubernetes Container Build Extension", () => {
     log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
     graph = await garden.getConfigGraph({ log: garden.log, emit: false })
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+    ctx = (await garden.getPluginContext({
+      provider,
+      templateContext: undefined,
+      events: undefined,
+    })) as KubernetesPluginContext
   }
 
   async function executeBuild(buildActionName: string) {
@@ -584,7 +587,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
   let cleanup: (() => void) | undefined
   let log: ActionLog
   let provider: KubernetesProvider
-  let ctx: PluginContext
+  let ctx: KubernetesPluginContext
   let api: KubeApi
   after(async () => {
     if (garden) {
@@ -596,7 +599,11 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
     ;({ garden, cleanup } = await getContainerTestGarden(environmentName, { remoteContainerAuth }))
     log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+    ctx = (await garden.getPluginContext({
+      provider,
+      templateContext: undefined,
+      events: undefined,
+    })) as KubernetesPluginContext
     api = await KubeApi.factory(log, ctx, provider)
   }
   grouped("kaniko").context("kaniko service account annotations", () => {
@@ -611,7 +618,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
       provider.config.kaniko = { serviceAccountAnnotations: annotations }
       const serviceAccount = getBuilderServiceAccountSpec(projectNamespace, annotations)
 
-      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace, annotations })
+      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace })
 
       const status = await compareDeployedResources({
         ctx: ctx as KubernetesPluginContext,
@@ -631,7 +638,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
       provider.config.kaniko = { serviceAccountAnnotations: originalAnnotations }
       const originalServiceAccount = getBuilderServiceAccountSpec(projectNamespace, originalAnnotations)
 
-      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace, annotations: originalAnnotations })
+      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace })
 
       const status = await compareDeployedResources({
         ctx: ctx as KubernetesPluginContext,
@@ -649,7 +656,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
       provider.config.kaniko = { serviceAccountAnnotations: reducedAnnotations }
       const updatedServiceAccount = getBuilderServiceAccountSpec(projectNamespace, reducedAnnotations)
 
-      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace, annotations: reducedAnnotations })
+      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace })
 
       const updatedStatus = await compareDeployedResources({
         ctx: ctx as KubernetesPluginContext,
@@ -712,7 +719,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
       provider.config.clusterBuildkit = { serviceAccountAnnotations: annotations, cache: defaultCacheConfig }
       const serviceAccount = getBuilderServiceAccountSpec(projectNamespace, annotations)
 
-      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace, annotations })
+      await ensureServiceAccount({ ctx, log, api, namespace: projectNamespace })
 
       const status = await compareDeployedResources({
         ctx: ctx as KubernetesPluginContext,

--- a/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
@@ -13,7 +13,6 @@ import type {
   KubernetesProvider,
 } from "../../../../../../../src/plugins/kubernetes/config.js"
 import type { Garden } from "../../../../../../../src/index.js"
-import type { PluginContext } from "../../../../../../../src/plugin-context.js"
 import {
   buildkitBuildHandler,
   ensureBuildkit,
@@ -33,7 +32,7 @@ describe.skip("ensureBuildkit", () => {
   let garden: Garden
   let cleanup: (() => void) | undefined
   let provider: KubernetesProvider
-  let ctx: PluginContext
+  let ctx: KubernetesPluginContext
   let api: KubeApi
   let namespace: string
 
@@ -58,7 +57,11 @@ describe.skip("ensureBuildkit", () => {
 
   beforeEach(async () => {
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+    ctx = (await garden.getPluginContext({
+      provider,
+      templateContext: undefined,
+      events: undefined,
+    })) as KubernetesPluginContext
     api = await KubeApi.factory(garden.log, ctx, provider)
     namespace = (
       await getNamespaceStatus({

--- a/docs/k8s-plugins/guides/in-cluster-building.md
+++ b/docs/k8s-plugins/guides/in-cluster-building.md
@@ -503,7 +503,7 @@ providers:
       serviceAccountAnnotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<web-identity-role-name>
     # If you use the buildkit build mode
-    buildMode: buildkit
+    buildMode: cluster-buildkit
     clusterBuildkit:
       serviceAccountAnnotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<web-identity-role-name>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:
The pull-image command spawns a pod for each image to pull. If you have set-up IRSA or Google Workload Identity for in-cluster building these pods also need to use the same service account as for in-cluster building.
**Which issue(s) this PR fixes**:

Fixes #5591

**Special notes for your reviewer**:
