### PR TITLE
fix(core): properly escape shell commands

### DIFF
--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -155,14 +155,21 @@ export function getDockerBuildArgs(version: string, specBuildArgs: PrimitiveMap)
     ...specBuildArgs,
   }
 
-  return Object.entries(buildArgs).map(([key, value]) => {
-    // 0 is falsy
-    if (value || value === 0) {
-      return `${key}=${value}`
-    } else {
-      // If the value of a build-arg is null, Docker pulls it from
-      // the environment: https://docs.docker.com/engine/reference/commandline/build/
-      return key
-    }
-  })
+  return Object.entries(buildArgs)
+    .map(([key, value]) => {
+      // If the value is empty, we simply don't pass it to docker
+      if (value === "") {
+        return undefined
+      }
+
+      // 0 is falsy
+      if (value || value === 0) {
+        return `${key}=${value}`
+      } else {
+        // If the value of a build-arg is null, Docker pulls it from
+        // the environment: https://docs.docker.com/engine/reference/commandline/build/
+        return key
+      }
+    })
+    .filter((x): x is string => !!x)
 }

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -47,6 +47,7 @@ import { k8sGetContainerBuildActionOutputs } from "../handlers.js"
 import { stringifyResources } from "../util.js"
 import { styles } from "../../../../logger/styles.js"
 import type { ResolvedBuildAction } from "../../../../actions/build.js"
+import { commandListToShellScript } from "../../../../util/escape.js"
 
 const AWS_ECR_REGEX = /^([^\.]+\.)?dkr\.ecr\.([^\.]+\.)amazonaws\.com\//i // AWS Elastic Container Registry
 
@@ -292,7 +293,7 @@ export function makeBuildkitBuildCommand({
     ...getBuildkitFlags(action),
   ]
 
-  return ["sh", "-c", `cd ${contextPath} && ${buildctlCommand.join(" ")}`]
+  return ["sh", "-c", `cd ${contextPath} && ${commandListToShellScript(buildctlCommand)}`]
 }
 
 export function getBuildkitFlags(action: Resolved<ContainerBuildAction>) {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -340,7 +340,7 @@ export function getBuildkitImageFlags(
     deploymentRegistryExtraSpec = ",registry.insecure=true"
   }
 
-  args.push("--output", `type=image,\\"name=${imageNames.join(",")}\\",push=true${deploymentRegistryExtraSpec}`)
+  args.push("--output", `type=image,"name=${imageNames.join(",")}",push=true${deploymentRegistryExtraSpec}`)
 
   for (const cache of cacheConfig) {
     const cacheImageName = getCacheImageName(moduleOutputs, cache)

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -291,7 +291,7 @@ export function getKanikoBuilderPodManifest({
         name: "init",
         image: getK8sUtilImageName(),
         command: [
-          "/bin/sh",
+          "sh",
           "-c",
           dedent`
             echo "Copying from $SYNC_SOURCE_URL to $SYNC_CONTEXT_PATH"

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -291,7 +291,7 @@ export function getKanikoBuilderPodManifest({
         name: "init",
         image: getK8sUtilImageName(),
         command: [
-          "sh",
+          "/bin/sh",
           "-c",
           dedent`
             echo "Copying from $SYNC_SOURCE_URL to $SYNC_CONTEXT_PATH"

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -45,6 +45,7 @@ import { makePodName } from "../../util.js"
 import type { ContainerBuildAction } from "../../../container/config.js"
 import { defaultDockerfileName } from "../../../container/config.js"
 import { styles } from "../../../../logger/styles.js"
+import { commandListToShellScript } from "../../../../util/escape.js"
 
 export const DEFAULT_KANIKO_FLAGS = ["--cache=true"]
 
@@ -250,7 +251,7 @@ export function getKanikoBuilderPodManifest({
   imagePullSecrets,
   sourceUrl,
   podName,
-  commandStr,
+  kanikoCommand,
 }: {
   provider: KubernetesProvider
   kanikoNamespace: string
@@ -261,7 +262,7 @@ export function getKanikoBuilderPodManifest({
   }[]
   sourceUrl: string
   podName: string
-  commandStr: string
+  kanikoCommand: string[]
 }) {
   const kanikoImage = provider.config.kaniko?.image || defaultKanikoImageName
   const kanikoTolerations = [...(provider.config.kaniko?.tolerations || []), builderToleration]
@@ -293,12 +294,12 @@ export function getKanikoBuilderPodManifest({
           "/bin/sh",
           "-c",
           dedent`
-            echo "Copying from ${sourceUrl} to ${contextPath}"
-            mkdir -p ${contextPath}
+            echo "Copying from $SYNC_SOURCE_URL to $SYNC_CONTEXT_PATH"
+            mkdir -p "$SYNC_CONTEXT_PATH"
             n=0
             until [ "$n" -ge 30 ]
             do
-              rsync ${syncArgs.join(" ")} && break
+              rsync ${commandListToShellScript(syncArgs)} && break
               n=$((n+1))
               sleep 1
             done
@@ -306,6 +307,16 @@ export function getKanikoBuilderPodManifest({
           `,
         ],
         imagePullPolicy: "IfNotPresent",
+        env: [
+          {
+            name: "SYNC_SOURCE_URL",
+            value: sourceUrl,
+          },
+          {
+            name: "SYNC_CONTEXT_PATH",
+            value: contextPath,
+          },
+        ],
         volumeMounts: [
           {
             name: sharedVolumeName,
@@ -318,7 +329,16 @@ export function getKanikoBuilderPodManifest({
       {
         name: "kaniko",
         image: kanikoImage,
-        command: ["sh", "-c", commandStr],
+        command: [
+          "/bin/sh",
+          "-c",
+          dedent`
+            ${commandListToShellScript(kanikoCommand)};
+            export exitcode=$?;
+            ${commandListToShellScript(["touch", `${sharedMountPath}/done`])};
+            exit $exitcode;
+          `,
+        ],
         volumeMounts: [
           {
             name: authSecretName,
@@ -365,15 +385,7 @@ async function runKaniko({
 
   const podName = makePodName("kaniko", action.name)
 
-  // Escape the args so that we can safely interpolate them into the kaniko command
-  const argsStr = args.map((arg) => JSON.stringify(arg)).join(" ")
-
-  const commandStr = dedent`
-    /kaniko/executor ${argsStr};
-    export exitcode=$?;
-    touch ${sharedMountPath}/done;
-    exit $exitcode;
-  `
+  const kanikoCommand = ["/kaniko/executor", ...args]
 
   const utilHostname = `${utilDeploymentName}.${utilNamespace}.svc.cluster.local`
   const sourceUrl = `rsync://${utilHostname}:${utilRsyncPort}/volume/${ctx.workingCopyId}/${action.name}/`
@@ -392,7 +404,7 @@ async function runKaniko({
     sourceUrl,
     syncArgs,
     imagePullSecrets,
-    commandStr,
+    kanikoCommand,
     kanikoNamespace,
     authSecretName,
   })

--- a/core/src/plugins/kubernetes/jib-container.ts
+++ b/core/src/plugins/kubernetes/jib-container.ts
@@ -168,7 +168,7 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
 
     const { log: skopeoLog } = await runner.exec({
       log,
-      command: ["sh", "-c", syncCommand.join(" ")],
+      command: syncCommand,
       timeoutSec: pushTimeout + 5,
       containerName: utilContainerName,
       buffer: true,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -335,7 +335,7 @@ export async function prepareRunPodSpec({
 
     // We start the container with a named pipe and tail that, to get the logs from the actual command
     // we plan on running. Then we sleep, so that we can copy files out of the container.
-    preparedPodSpec.containers[0].command = ["/bin/sh", "-c", "mkfifo /tmp/output && cat /tmp/output && sleep 86400"]
+    preparedPodSpec.containers[0].command = ["sh", "-c", "mkfifo /tmp/output && cat /tmp/output && sleep 86400"]
   } else {
     if (args) {
       preparedPodSpec.containers[0].args = args
@@ -572,7 +572,7 @@ async function runWithArtifacts({
 
     try {
       await runner.exec({
-        command: ["/bin/sh", "tar --help"],
+        command: ["sh", "-c", "tar --help"],
         containerName: mainContainerName,
         log,
         stdout,
@@ -606,7 +606,7 @@ async function runWithArtifacts({
       const res = await runner.exec({
         // Pipe the output from the command to the /tmp/output pipe, including stderr. Some shell voodoo happening
         // here, but this was the only working approach I could find after a lot of trial and error.
-        command: ["/bin/sh", "-c", getCommandExecutionScript([...command!, ...(args || [])])],
+        command: ["sh", "-c", getCommandExecutionScript([...command!, ...(args || [])])],
         containerName: mainContainerName,
         log,
         stdout,
@@ -655,7 +655,7 @@ async function runWithArtifacts({
         // Tarball the requested files and stream to the above extractor.
         runner
           .exec({
-            command: ["/bin/sh", "-c", getArtifactsTarScript(artifacts)],
+            command: ["sh", "-c", getArtifactsTarScript(artifacts)],
             containerName: mainContainerName,
             log,
             stdout: extractor,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -564,7 +564,7 @@ async function runWithArtifacts({
 
     try {
       await runner.exec({
-        command: ["tar", "--help"],
+        command: ["/bin/sh", "tar --help"],
         containerName: mainContainerName,
         log,
         stdout,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -594,14 +594,11 @@ async function runWithArtifacts({
       })
     }
 
-    // Escape the command, so that we can safely pass it as a single string
-    const cmd = [...command!, ...(args || [])].map((s) => JSON.stringify(s))
-
     try {
       const res = await runner.exec({
         // Pipe the output from the command to the /tmp/output pipe, including stderr. Some shell voodoo happening
         // here, but this was the only working approach I could find after a lot of trial and error.
-        command: ["/bin/sh", "-c", getCommandExecutionScript(cmd)],
+        command: ["/bin/sh", "-c", getCommandExecutionScript([...command!, ...(args || [])])],
         containerName: mainContainerName,
         log,
         stdout,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -335,7 +335,7 @@ export async function prepareRunPodSpec({
 
     // We start the container with a named pipe and tail that, to get the logs from the actual command
     // we plan on running. Then we sleep, so that we can copy files out of the container.
-    preparedPodSpec.containers[0].command = ["sh", "-c", "mkfifo /tmp/output && cat /tmp/output && sleep 86400"]
+    preparedPodSpec.containers[0].command = ["/bin/sh", "-c", "mkfifo /tmp/output && cat /tmp/output && sleep 86400"]
   } else {
     if (args) {
       preparedPodSpec.containers[0].args = args
@@ -578,7 +578,7 @@ async function runWithArtifacts({
       // using that (tar is not statically compiled so we can't copy that directly). Keeping this snippet around
       // for that:
       // await runner.exec({
-      //   command: ["sh", "-c", `mkdir -p /.garden/bin/ && sed -n 'w /.garden/bin/arc' && chmod +x /.garden/bin/arc`],
+      //   command: ["/bin/sh", "-c", `mkdir -p /.garden/bin/ && sed -n 'w /.garden/bin/arc' && chmod +x /.garden/bin/arc`],
       //   container: containerName,
       //   ignoreError: false,
       //   input: <binary>,
@@ -601,7 +601,7 @@ async function runWithArtifacts({
       const res = await runner.exec({
         // Pipe the output from the command to the /tmp/output pipe, including stderr. Some shell voodoo happening
         // here, but this was the only working approach I could find after a lot of trial and error.
-        command: ["sh", "-c", getCommandExecutionScript(cmd)],
+        command: ["/bin/sh", "-c", getCommandExecutionScript(cmd)],
         containerName: mainContainerName,
         log,
         stdout,
@@ -650,7 +650,7 @@ async function runWithArtifacts({
         // Tarball the requested files and stream to the above extractor.
         runner
           .exec({
-            command: ["sh", "-c", getArtifactsTarScript(artifacts)],
+            command: ["/bin/sh", "-c", getArtifactsTarScript(artifacts)],
             containerName: mainContainerName,
             log,
             stdout: extractor,

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -70,6 +70,7 @@ import type { GetSyncStatusResult, SyncState, SyncStatus } from "../../plugin/ha
 import { ConfigurationError } from "../../exceptions.js"
 import { gardenEnv } from "../../constants.js"
 import { styles } from "../../logger/styles.js"
+import { commandListToShellScript } from "../../util/escape.js"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 
@@ -457,7 +458,7 @@ export async function configureSyncMode({
       const initContainer = {
         name: "garden-dev-init",
         image: k8sSyncUtilImageName,
-        command: ["cp", "/usr/local/bin/mutagen-agent", mutagenAgentPath],
+        command: ["/bin/sh", "-c", commandListToShellScript(["cp", "/usr/local/bin/mutagen-agent", mutagenAgentPath])],
         imagePullPolicy: "IfNotPresent",
         volumeMounts: [gardenVolumeMount],
       }

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -457,7 +457,7 @@ export async function configureSyncMode({
       const initContainer = {
         name: "garden-dev-init",
         image: k8sSyncUtilImageName,
-        command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent " + mutagenAgentPath],
+        command: ["cp", "/usr/local/bin/mutagen-agent", mutagenAgentPath],
         imagePullPolicy: "IfNotPresent",
         volumeMounts: [gardenVolumeMount],
       }

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -591,7 +591,7 @@ export class GardenServer extends EventEmitter {
 
       try {
         // FIXME: Why do we need to sleep for 1 second?
-        proc = pty.spawn("/bin/sh", ["-c", `sleep 1; ${commandListToShellScript([command, ...args])}`], {
+        proc = pty.spawn("sh", ["-c", `sleep 1; ${commandListToShellScript([command, ...args])}`], {
           name: "xterm-256color",
           cols: columns,
           rows,

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -591,7 +591,7 @@ export class GardenServer extends EventEmitter {
 
       try {
         // FIXME: Why do we need to sleep for 1 second?
-        proc = pty.spawn("sh", ["-c", `sleep 1; ${commandListToShellScript([command, ...args])}`], {
+        proc = pty.spawn("/bin/sh", ["-c", `sleep 1; ${commandListToShellScript([command, ...args])}`], {
           name: "xterm-256color",
           cols: columns,
           rows,

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -51,6 +51,7 @@ import { defaultServerPort } from "../commands/serve.js"
 import type PTY from "@homebridge/node-pty-prebuilt-multiarch"
 import pty from "@homebridge/node-pty-prebuilt-multiarch"
 import { styles } from "../logger/styles.js"
+import { commandListToShellScript } from "../util/escape.js"
 
 const skipLogsForCommands = ["autocomplete"]
 const serverLogName = "garden-server"
@@ -589,7 +590,8 @@ export class GardenServer extends EventEmitter {
       }
 
       try {
-        proc = pty.spawn("sh", ["-c", `sleep 1; ${command} ${args.join(" ")}`], {
+        // FIXME: Why do we need to sleep for 1 second?
+        proc = pty.spawn("sh", ["-c", `sleep 1; ${commandListToShellScript([command, ...args])}`], {
           name: "xterm-256color",
           cols: columns,
           rows,

--- a/core/src/util/escape.ts
+++ b/core/src/util/escape.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/core/src/util/escape.ts
+++ b/core/src/util/escape.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Wraps every parameter in single quotes, escaping contained single quotes (for use in bash scripts). Joins the elements with a space character.
+ *
+ * Examples:
+ *
+ *   // returns `echo 'hello world'`
+ *   commandListToShellScript(["echo", "hello world"])
+ *
+ *   // returns `echo 'hello'"'"'world'`
+ *   commandListToShellScript(["echo", "hello'world"])
+ *
+ *   // returns `echo ''"'"'; exec ls /'`
+ *   commandListToShellScript(["echo", "'; exec ls /"])
+ *
+ * Caveat: This is only safe if the command is directly executed. It is not safe, if you wrap the output of this in double quotes, for instance.
+ *
+ * // SAFE
+ *    exec(["sh", "-c", ${commandListToShellScript(["some", "command", "--with" untrustedInput])}])
+ *    exec(["sh", "-c", dedent`
+ *       set -e
+ *       echo "running command..."
+ *       ${commandListToShellScript(["some", "command", "--with" untrustedInput])}
+ *       echo "done"
+ *    `])
+ *
+ * // UNSAFE! don't do this
+ *
+ *    const commandWithUntrustedInput = commandListToShellScript(["some", "command", "--with" untrustedInput])
+ *    exec(["sh", "-c", `some_var="${commandWithUntrustedInput}"; echo "$some_var"`])
+ *
+ * The second is UNSAFE, because we can't know that the /double quotes/ need to be escaped here.
+ *
+ * If you can, use environment variables instead of this, to pass untrusted values to shell scripts, e.g. if you do not need to construct a command with untrusted input.
+ *
+ * // SAFE
+ *
+ *    exec(["sh", "-c", `some_var="$UNTRUSTED_INPUT"; echo "$some_var"`], { env: { UNTRUSTED_INPUT: untrustedInput } })
+ *
+ * @param command array of command line arguments
+ * @returns string to be used as shell script statement to execute the given command.
+ */
+export function commandListToShellScript(command: string[]) {
+  return command.map((c) => `'${c.replaceAll("'", `'"'"'`)}'`).join(" ")
+}

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -452,7 +452,7 @@ describe("kubernetes container deployment handlers", () => {
         {
           name: "garden-dev-init",
           image: getK8sSyncUtilImageName(),
-          command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent /.garden/mutagen-agent"],
+          command: ["/bin/sh", "-c", "'cp' '/usr/local/bin/mutagen-agent' '/.garden/mutagen-agent'"],
           imagePullPolicy: "IfNotPresent",
           volumeMounts: [
             {

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -113,7 +113,7 @@ describe("kubernetes Pod runner functions", () => {
 
     describe("start", () => {
       it("creates a Pod and waits for it to start", async () => {
-        const pod = makePod(["sh", "-c", "sleep 600"])
+        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -145,7 +145,7 @@ describe("kubernetes Pod runner functions", () => {
 
     describe("exec", () => {
       it("runs the specified command in the Pod", async () => {
-        const pod = makePod(["sh", "-c", "sleep 600"])
+        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -167,7 +167,7 @@ describe("kubernetes Pod runner functions", () => {
       })
 
       it("throws if execution times out", async () => {
-        const pod = makePod(["sh", "-c", "sleep 600"])
+        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -179,13 +179,13 @@ describe("kubernetes Pod runner functions", () => {
 
         await runner.start({ log })
         await expectError(
-          () => runner.exec({ log, command: ["sh", "-c", "sleep 100"], timeoutSec: 1, buffer: true }),
+          () => runner.exec({ log, command: ["/bin/sh", "-c", "sleep 100"], timeoutSec: 1, buffer: true }),
           (err) => expect(err.message).to.equal("Command timed out after 1 seconds.")
         )
       })
 
       it("throws if command returns non-zero exit code", async () => {
-        const pod = makePod(["sh", "-c", "sleep 600"])
+        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -197,7 +197,7 @@ describe("kubernetes Pod runner functions", () => {
 
         await runner.start({ log })
         await expectError(
-          () => runner.exec({ log, command: ["sh", "-c", "echo foo && exit 2"], buffer: true }),
+          () => runner.exec({ log, command: ["/bin/sh", "-c", "echo foo && exit 2"], buffer: true }),
           (err) => {
             expect(err.message).to.eql(dedent`
               Failed with exit code 2.
@@ -212,7 +212,7 @@ describe("kubernetes Pod runner functions", () => {
 
     describe("getLogs", () => {
       it("retrieves the logs from the Pod", async () => {
-        const pod = makePod(["sh", "-c", "echo foo && sleep 600"])
+        const pod = makePod(["/bin/sh", "-c", "echo foo && sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -233,7 +233,7 @@ describe("kubernetes Pod runner functions", () => {
       })
 
       it("retrieves the logs from the Pod after it terminates", async () => {
-        const pod = makePod(["sh", "-c", "echo foo"])
+        const pod = makePod(["/bin/sh", "-c", "echo foo"])
 
         runner = new PodRunner({
           ctx,
@@ -1298,7 +1298,7 @@ describe("kubernetes Pod runner functions", () => {
             const result = await runAndCopy({
               ctx: await garden.getPluginContext({ provider, templateContext: undefined, events: undefined }),
               log: garden.log,
-              command: ["sh", "-c", "touch /task.txt && sleep 10"],
+              command: ["/bin/sh", "-c", "touch /task.txt && sleep 10"],
               args: [],
               interactive,
               action,

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -113,7 +113,7 @@ describe("kubernetes Pod runner functions", () => {
 
     describe("start", () => {
       it("creates a Pod and waits for it to start", async () => {
-        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
+        const pod = makePod(["sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -145,7 +145,7 @@ describe("kubernetes Pod runner functions", () => {
 
     describe("exec", () => {
       it("runs the specified command in the Pod", async () => {
-        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
+        const pod = makePod(["sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -167,7 +167,7 @@ describe("kubernetes Pod runner functions", () => {
       })
 
       it("throws if execution times out", async () => {
-        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
+        const pod = makePod(["sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -179,13 +179,13 @@ describe("kubernetes Pod runner functions", () => {
 
         await runner.start({ log })
         await expectError(
-          () => runner.exec({ log, command: ["/bin/sh", "-c", "sleep 100"], timeoutSec: 1, buffer: true }),
+          () => runner.exec({ log, command: ["sh", "-c", "sleep 100"], timeoutSec: 1, buffer: true }),
           (err) => expect(err.message).to.equal("Command timed out after 1 seconds.")
         )
       })
 
       it("throws if command returns non-zero exit code", async () => {
-        const pod = makePod(["/bin/sh", "-c", "sleep 600"])
+        const pod = makePod(["sh", "-c", "sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -197,7 +197,7 @@ describe("kubernetes Pod runner functions", () => {
 
         await runner.start({ log })
         await expectError(
-          () => runner.exec({ log, command: ["/bin/sh", "-c", "echo foo && exit 2"], buffer: true }),
+          () => runner.exec({ log, command: ["sh", "-c", "echo foo && exit 2"], buffer: true }),
           (err) => {
             expect(err.message).to.eql(dedent`
               Failed with exit code 2.
@@ -212,7 +212,7 @@ describe("kubernetes Pod runner functions", () => {
 
     describe("getLogs", () => {
       it("retrieves the logs from the Pod", async () => {
-        const pod = makePod(["/bin/sh", "-c", "echo foo && sleep 600"])
+        const pod = makePod(["sh", "-c", "echo foo && sleep 600"])
 
         runner = new PodRunner({
           ctx,
@@ -233,7 +233,7 @@ describe("kubernetes Pod runner functions", () => {
       })
 
       it("retrieves the logs from the Pod after it terminates", async () => {
-        const pod = makePod(["/bin/sh", "-c", "echo foo"])
+        const pod = makePod(["sh", "-c", "echo foo"])
 
         runner = new PodRunner({
           ctx,
@@ -1298,7 +1298,7 @@ describe("kubernetes Pod runner functions", () => {
             const result = await runAndCopy({
               ctx: await garden.getPluginContext({ provider, templateContext: undefined, events: undefined }),
               log: garden.log,
-              command: ["/bin/sh", "-c", "touch /task.txt && sleep 10"],
+              command: ["sh", "-c", "touch /task.txt && sleep 10"],
               args: [],
               interactive,
               action,

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -247,9 +247,9 @@ describe("buildkit build", () => {
         dockerfile: "dockerfile",
       })
       const cdCmd = `cd ${contextPath}`
-      const buildctlCmd = `buildctl build --frontend=dockerfile.v0 --local context=${contextPath} --local dockerfile=${contextPath} --opt filename=dockerfile --output type=image,\\"name=gcr.io/deploymentRegistry/namespace/${
+      const buildctlCmd = `'buildctl' 'build' '--frontend=dockerfile.v0' '--local context=${contextPath}' '--local' 'dockerfile=${contextPath}' '--opt' 'filename=dockerfile' '--output' 'type=image,"name=gcr.io/deploymentRegistry/namespace/${
         action.name
-      }:${action.versionString()}\\",push=true --opt build-arg:GARDEN_MODULE_VERSION=${action.versionString()} --opt build-arg:GARDEN_ACTION_VERSION=${action.versionString()} --opt target=foo`
+      }:${action.versionString()}",push=true' '--opt' 'build-arg:GARDEN_MODULE_VERSION=${action.versionString()}' '--opt' 'build-arg:GARDEN_ACTION_VERSION=${action.versionString()}' '--opt' 'target=foo'`
 
       expect(buildCommand).to.eql(["sh", "-c", `${cdCmd} && ${buildctlCmd}`])
     })
@@ -290,7 +290,7 @@ describe("buildkit build", () => {
           "--export-cache",
           "type=inline",
           "--output",
-          `type=image,\\"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache\\",push=true`,
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache",push=true`,
           "--import-cache",
           `type=registry,ref=${registry}/namespace/name:_buildcache`,
         ])
@@ -315,7 +315,7 @@ describe("buildkit build", () => {
 
         expect(flags).to.eql([
           "--output",
-          `type=image,\\"name=${registry}/namespace/name:v-xxxxxx\\",push=true`,
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
           "--import-cache",
           `type=registry,ref=${registry}/namespace/name:_buildcache`,
           "--export-cache",
@@ -349,7 +349,7 @@ describe("buildkit build", () => {
 
         expect(flags).to.eql([
           "--output",
-          `type=image,\\"name=${registry}/namespace/name:v-xxxxxx\\",push=true`,
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
           "--import-cache",
           `type=registry,ref=${registry}/namespace/name:_buildcache`,
           "--export-cache",
@@ -384,7 +384,7 @@ describe("buildkit build", () => {
 
         expect(flags).to.eql([
           "--output",
-          `type=image,\\"name=${registry}/namespace/name:v-xxxxxx\\",push=true`,
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
           "--import-cache",
           `type=registry,ref=${registry}/namespace/name:_buildcache`,
           "--export-cache",
@@ -419,7 +419,7 @@ describe("buildkit build", () => {
         "--export-cache",
         "type=inline",
         "--output",
-        `type=image,\\"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache\\",push=true`,
+        `type=image,"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache",push=true`,
         "--import-cache",
         `type=registry,ref=${registry}/namespace/name:_buildcache`,
       ])
@@ -455,7 +455,7 @@ describe("buildkit build", () => {
       expect(flags).to.eql([
         // output to deploymentRegistry
         "--output",
-        `type=image,\\"name=${deploymentRegistry}/namespace/name:v-xxxxxx\\",push=true`,
+        `type=image,"name=${deploymentRegistry}/namespace/name:v-xxxxxx",push=true`,
 
         // import and export to cacheRegistry with mode=max
         "--import-cache",
@@ -506,7 +506,7 @@ describe("buildkit build", () => {
       expect(flags).to.eql([
         // output to deploymentRegistry
         "--output",
-        `type=image,\\"name=${deploymentRegistry}/namespace/name:v-xxxxxx\\",push=true`,
+        `type=image,"name=${deploymentRegistry}/namespace/name:v-xxxxxx",push=true`,
         // import and export to cacheRegistry with mode=max
         // import first _buildcache-featureBranch, then _buildcache-main
         "--import-cache",

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -247,7 +247,7 @@ describe("buildkit build", () => {
         dockerfile: "dockerfile",
       })
       const cdCmd = `cd ${contextPath}`
-      const buildctlCmd = `'buildctl' 'build' '--frontend=dockerfile.v0' '--local context=${contextPath}' '--local' 'dockerfile=${contextPath}' '--opt' 'filename=dockerfile' '--output' 'type=image,"name=gcr.io/deploymentRegistry/namespace/${
+      const buildctlCmd = `'buildctl' 'build' '--frontend=dockerfile.v0' '--local' 'context=${contextPath}' '--local' 'dockerfile=${contextPath}' '--opt' 'filename=dockerfile' '--output' 'type=image,"name=gcr.io/deploymentRegistry/namespace/${
         action.name
       }:${action.versionString()}",push=true' '--opt' 'build-arg:GARDEN_MODULE_VERSION=${action.versionString()}' '--opt' 'build-arg:GARDEN_ACTION_VERSION=${action.versionString()}' '--opt' 'target=foo'`
 

--- a/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
@@ -95,7 +95,7 @@ describe("kaniko build", () => {
           containers: [
             {
               command: [
-                "sh",
+                "/bin/sh",
                 "-c",
                 "'build' 'command';\nexport exitcode=$?;\n'touch' '/.garden/done';\nexit $exitcode;",
               ],

--- a/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
@@ -76,7 +76,7 @@ describe("kaniko build", () => {
         getKanikoBuilderPodManifest({
           provider,
           podName: "builder-pod",
-          commandStr: "build command",
+          kanikoCommand: ["build", "command"],
           kanikoNamespace: "namespace",
           authSecretName: "authSecret",
           syncArgs: ["arg1", "arg2"],
@@ -94,7 +94,11 @@ describe("kaniko build", () => {
         spec: {
           containers: [
             {
-              command: ["sh", "-c", "build command"],
+              command: [
+                "sh",
+                "-c",
+                "'build' 'command';\nexport exitcode=$?;\n'touch' '/.garden/done';\nexit $exitcode;",
+              ],
               image: defaultKanikoImageName,
               name: "kaniko",
               resources: {
@@ -126,7 +130,7 @@ describe("kaniko build", () => {
               command: [
                 "/bin/sh",
                 "-c",
-                'echo "Copying from sourceURL to /.garden/context"\nmkdir -p /.garden/context\nn=0\nuntil [ "$n" -ge 30 ]\ndo\n  rsync arg1 arg2 && break\n  n=$((n+1))\n  sleep 1\ndone\necho "Done!"',
+                'echo "Copying from $SYNC_SOURCE_URL to $SYNC_CONTEXT_PATH"\nmkdir -p "$SYNC_CONTEXT_PATH"\nn=0\nuntil [ "$n" -ge 30 ]\ndo\n  rsync \'arg1\' \'arg2\' && break\n  n=$((n+1))\n  sleep 1\ndone\necho "Done!"',
               ],
               image: getK8sUtilImageName(),
               imagePullPolicy: "IfNotPresent",
@@ -135,6 +139,16 @@ describe("kaniko build", () => {
                 {
                   mountPath: "/.garden",
                   name: "comms",
+                },
+              ],
+              env: [
+                {
+                  name: "SYNC_SOURCE_URL",
+                  value: "sourceURL",
+                },
+                {
+                  name: "SYNC_CONTEXT_PATH",
+                  value: "/.garden/context",
                 },
               ],
             },
@@ -185,7 +199,7 @@ describe("kaniko build", () => {
       const manifest = getKanikoBuilderPodManifest({
         provider,
         podName: "builder-pod",
-        commandStr: "build command",
+        kanikoCommand: ["build", "command"],
         kanikoNamespace: "namespace",
         authSecretName: "authSecret",
         syncArgs: ["arg1", "arg2"],

--- a/core/test/unit/src/util/escape.ts
+++ b/core/test/unit/src/util/escape.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/core/test/unit/src/util/escape.ts
+++ b/core/test/unit/src/util/escape.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { commandListToShellScript } from "../../../../src/util/escape.js"
+
+describe("commandListToShellScript", () => {
+  it("transforms a list of command line arguments to a shell script", () => {
+    const commandList = ["echo", "hello", "world"]
+    const commandString = commandListToShellScript(commandList)
+    expect(commandString).to.equal("'echo' 'hello' 'world'")
+  })
+
+  it("escapes single quotes in command line arguments", () => {
+    const commandList = ["echo", "hello", "world's"]
+    const commandString = commandListToShellScript(commandList)
+    expect(commandString).to.equal(`'echo' 'hello' 'world'"'"'s'`)
+  })
+
+  it("replaces all single quotes", () => {
+    const commandList = ["echo", "'''"]
+    const commandString = commandListToShellScript(commandList)
+    expect(commandString).to.equal(`'echo' ''"'"''"'"''"'"''`)
+  })
+
+  it("avoids shell injection attacks if used properly", () => {
+    const commandList = ["echo", "'; exec ls /"]
+    const commandString = commandListToShellScript(commandList)
+    expect(commandString).to.equal(`'echo' ''"'"'; exec ls /'`)
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Shell commands need to be carefully constructed to avoid command
injection issues, and also to avoid issues with the shell interpreting
input strings, e.g. parenthesis or glob characters.

If possible, we should pass a command list for executing commands.

For untrusted input values, one should use environment variables and
access them from the shell script. Make sure to access them wrapped
around double quotes, otherwise the script is prone to command injection
attacks.

Sometimes it is needed to construct a shell script to chain multuiple
commands together. In this case, this commit introduces a utility
function `commandListToShellScript`.

It wraps every parameter in single quotes, escaping contained single quotes (for use in bash scripts). Joins the elements with a space character.

 Examples:

```
// returns `echo 'hello world'`
commandListToShellScript(["echo", "hello world"])

// returns `echo 'hello'"'"'world'`
commandListToShellScript(["echo", "hello'world"])

// returns `echo ''"'"'; exec ls /'`
commandListToShellScript(["echo", "'; exec ls /"])
```

Caveat: This is only safe if the command is directly executed. It is not safe, if you wrap the output of this in double quotes, for instance.

```
// SAFE
exec(["sh", "-c", ${commandListToShellScript(["some", "command", "--with" untrustedInput])}])
exec(["sh", "-c", dedent`
    set -e
    echo "running command..."
    ${commandListToShellScript(["some", "command", "--with" untrustedInput])}
    echo "done"
`])

// UNSAFE! don't do this

const commandWithUntrustedInput = commandListToShellScript(["some", "command", "--with" untrustedInput])
exec(["sh", "-c", `some_var="${commandWithUntrustedInput}"; echo "$some_var"`])
```

The second is UNSAFE, because we can't know that the /double quotes/ need to be escaped here.

If you can, use environment variables instead of this, to pass untrusted values to shell scripts, e.g. if you do not need to construct a command with untrusted input.

```
// SAFE
exec(["sh", "-c", `some_var="$UNTRUSTED_INPUT"; echo "$some_var"`], { env: { UNTRUSTED_INPUT: untrustedInput } })
```


**Which issue(s) this PR fixes**:

Swooped in: Fixes #4081
