### PR TITLE
refactor(port-forward): add explicit types

### DIFF
--- a/core/src/plugin/handlers/Deploy/get-port-forward.ts
+++ b/core/src/plugin/handlers/Deploy/get-port-forward.ts
@@ -16,7 +16,7 @@ import type { DeployAction } from "../../../actions/deploy.js"
 import { ActionTypeHandlerSpec } from "../base/base.js"
 import type { Executed } from "../../../actions/types.js"
 
-type GetPortForwardParams<T extends DeployAction> = PluginDeployActionParamsBase<T> & ForwardablePort
+export type GetPortForwardParams<T extends DeployAction> = PluginDeployActionParamsBase<T> & ForwardablePort
 
 export interface GetPortForwardResult {
   hostname: string

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -6,11 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { getPortForward } from "../port-forward.js"
-import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../constants.js"
-import type { Log } from "../../../logger/log-entry.js"
 import type { KubernetesResourceConfig, KubernetesPluginContext, KubernetesResourceSpec } from "../config.js"
-import { getSystemNamespace } from "../namespace.js"
 import type {
   ContainerBuildAction,
   ContainerResourcesSpec,
@@ -36,18 +32,6 @@ export function getDeployedImageId(action: Resolved<ContainerRuntimeAction>): st
       message: `${action.longDescription()} specifies neither a \`build\` nor \`spec.image\``,
     })
   }
-}
-
-export async function getRegistryPortForward(ctx: KubernetesPluginContext, log: Log) {
-  const systemNamespace = await getSystemNamespace(ctx, ctx.provider, log)
-
-  return getPortForward({
-    ctx,
-    log,
-    namespace: systemNamespace,
-    targetResource: `Deployment/${CLUSTER_REGISTRY_DEPLOYMENT_NAME}`,
-    port: CLUSTER_REGISTRY_PORT,
-  })
 }
 
 export function getResourceRequirements(

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { KubernetesResourceConfig, KubernetesPluginContext, KubernetesResourceSpec } from "../config.js"
+import type { KubernetesResourceConfig, KubernetesResourceSpec } from "../config.js"
 import type {
   ContainerBuildAction,
   ContainerResourcesSpec,

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -27,7 +27,7 @@ import { execa } from "execa"
 import type { KubernetesDeployAction } from "./kubernetes-type/config.js"
 import type { HelmDeployAction } from "./helm/config.js"
 import type { DeployAction } from "../../actions/deploy.js"
-import type { GetPortForwardResult } from "../../plugin/handlers/Deploy/get-port-forward.js"
+import type { GetPortForwardParams, GetPortForwardResult } from "../../plugin/handlers/Deploy/get-port-forward.js"
 import type { ActionMode, Resolved } from "../../actions/types.js"
 
 // TODO: implement stopPortForward handler
@@ -183,14 +183,9 @@ export async function getPortForward({
   })
 }
 
-export async function getPortForwardHandler(params: {
-  ctx: PluginContext
-  log: Log
-  action: DeployAction
-  namespace: string | undefined
-  targetName?: string
-  targetPort: number
-}): Promise<GetPortForwardResult> {
+type PortForwardHandlerParams = GetPortForwardParams<DeployAction> & { namespace: string | undefined }
+
+export async function getPortForwardHandler(params: PortForwardHandlerParams): Promise<GetPortForwardResult> {
   const { ctx, log, action, targetName, targetPort } = params
 
   const provider = ctx.provider as KubernetesProvider


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR introduces a named types for the params of `getPortForwardHandler`. It also removes some dead code.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
