### PR TITLE
chore(test): move string unit tests to the dedicated file

### DIFF
--- a/core/test/unit/src/util/string.ts
+++ b/core/test/unit/src/util/string.ts
@@ -7,7 +7,28 @@
  */
 
 import { expect } from "chai"
-import { tailString, stripQuotes } from "../../../../src/util/string.js"
+import { splitFirst, splitLast, stripQuotes, tailString } from "../../../../src/util/string.js"
+import { describe } from "mocha"
+
+describe("splitFirst", () => {
+  it("should split string on first occurrence of given delimiter", () => {
+    expect(splitFirst("foo:bar:boo", ":")).to.eql(["foo", "bar:boo"])
+  })
+
+  it("should return the whole string as first element when no delimiter is found in string", () => {
+    expect(splitFirst("foo", ":")).to.eql(["foo", ""])
+  })
+})
+
+describe("splitLast", () => {
+  it("should split string on last occurrence of given delimiter", () => {
+    expect(splitLast("foo:bar:boo", ":")).to.eql(["foo:bar", "boo"])
+  })
+
+  it("should return the whole string as last element when no delimiter is found in string", () => {
+    expect(splitLast("foo", ":")).to.eql(["", "foo"])
+  })
+})
 
 describe("tailString", () => {
   it("should return string unchanged if it's shorter than maxLength", () => {

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -19,7 +19,6 @@ import {
   isValidDateInstance,
 } from "../../../../src/util/util.js"
 import { expectError } from "../../../helpers.js"
-import { splitLast, splitFirst } from "../../../../src/util/string.js"
 import { getRootLogger } from "../../../../src/logger/logger.js"
 import { dedent } from "../../../../src/util/string.js"
 import { safeDumpYaml } from "../../../../src/util/serialization.js"
@@ -166,26 +165,6 @@ describe("util", () => {
       await expectError(() => pickKeys(obj, <any>["a", "foo", "bar"], "banana"), {
         contains: "Could not find banana(s): foo, bar",
       })
-    })
-  })
-
-  describe("splitFirst", () => {
-    it("should split string on first occurrence of given delimiter", () => {
-      expect(splitFirst("foo:bar:boo", ":")).to.eql(["foo", "bar:boo"])
-    })
-
-    it("should return the whole string as first element when no delimiter is found in string", () => {
-      expect(splitFirst("foo", ":")).to.eql(["foo", ""])
-    })
-  })
-
-  describe("splitLast", () => {
-    it("should split string on last occurrence of given delimiter", () => {
-      expect(splitLast("foo:bar:boo", ":")).to.eql(["foo:bar", "boo"])
-    })
-
-    it("should return the whole string as last element when no delimiter is found in string", () => {
-      expect(splitLast("foo", ":")).to.eql(["", "foo"])
     })
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A quick janitorial PR to keep the string util tests in the same file. I've made that while porting the util unit tests to Grow.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
