### PR TITLE
feat(helm): store garden metadata in configmap instead of helm values

### DIFF
--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -304,5 +304,8 @@ export async function getHelmGardenMetadataConfigMapData({
     name: `garden-helm-metadata-${action.name}`,
     namespace,
   })
-  return deserializeValues(gardenMetadataConfigMap.data!) as HelmGardenMetadataConfigMapData
+  if (!gardenMetadataConfigMap.data) {
+    throw new Error(`Configmap with garden metadata for release ${action.name} is empty`)
+  }
+  return deserializeValues(gardenMetadataConfigMap.data) as HelmGardenMetadataConfigMapData
 }

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -24,7 +24,7 @@ import type { HelmDeployAction } from "./config.js"
 import type { ActionMode, Resolved } from "../../../actions/types.js"
 import { deployStateToActionState } from "../../../plugin/handlers/Deploy/get-status.js"
 import { isTruthy } from "../../../util/util.js"
-import { ChildProcessError } from "../../../exceptions.js"
+import { ChildProcessError, RuntimeError } from "../../../exceptions.js"
 import { gardenAnnotationKey } from "../../../util/string.js"
 import { deserializeValues } from "../../../util/serialization.js"
 
@@ -305,7 +305,7 @@ export async function getHelmGardenMetadataConfigMapData({
     namespace,
   })
   if (!gardenMetadataConfigMap.data) {
-    throw new Error(`Configmap with garden metadata for release ${action.name} is empty`)
+    throw new RuntimeError({ message: `Configmap with garden metadata for release ${action.name} is empty` })
   }
   return deserializeValues(gardenMetadataConfigMap.data) as HelmGardenMetadataConfigMapData
 }

--- a/core/test/data/test-projects/helm-local-mode/backend-image/garden.yml
+++ b/core/test/data/test-projects/helm-local-mode/backend-image/garden.yml
@@ -1,4 +1,4 @@
-kind: Module
+kind: Build
 description: Image for the backend service
 type: container
 name: backend-image

--- a/core/test/data/test-projects/helm-local-mode/backend/garden.yml
+++ b/core/test/data/test-projects/helm-local-mode/backend/garden.yml
@@ -1,41 +1,35 @@
-kind: Module
+kind: Deploy
 name: backend
 description: Helm chart for the backend service
 type: helm
+dependencies:
+  - build.backend-image
+spec:
+  localMode:
+    ports:
+    - local: 8090
+      remote: 8080
+    # starts the local application
+    command: [ ]
+    target:
+      kind: Deployment
+      name: backend
+      containerName: backend
 
-localMode:
-  ports:
-   - local: 8090
-     remote: 8080
-  # starts the local application
-  command: [ ]
-  target:
-    kind: Deployment
-    name: backend
-    containerName: backend
+  # this is here to test that local mode always take precedence over sync mode
+  sync:
+    paths:
+      - target:
+          kind: Deployment
+          name: backend
+        containerPath: /app
+        mode: one-way
 
-# this is here to test that local mode always take precedence over sync mode
-sync:
-  paths:
-    - target: /app
-      mode: one-way
-
-serviceResource:
-  kind: Deployment
-  containerModule: backend-image
-
-build:
-  dependencies: [ "backend-image" ]
-
-values:
-  image:
-    repository: ${modules.backend-image.outputs.deployment-image-name}
-    tag: ${modules.backend-image.version}
-  ingress:
-    enabled: true
-    paths: [ "/hello-backend" ]
-    hosts: [ "backend.${var.baseHostname}" ]
-
-tasks:
-  - name: test
-    command: [ "sh", "-c", "echo task output" ]
+  values:
+    image:
+      repository: ${actions.build.backend-image.outputs.deployment-image-name}
+      tag: ${actions.build.backend-image.version}
+    ingress:
+      enabled: true
+      paths: [ "/hello-backend" ]
+      hosts: [ "backend.${var.baseHostname}" ]

--- a/core/test/data/test-projects/helm-local-mode/frontend/garden.yml
+++ b/core/test/data/test-projects/helm-local-mode/frontend/garden.yml
@@ -1,27 +1,37 @@
-kind: Module
+kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-services:
-  - name: frontend
-    ports:
-      - name: http
-        containerPort: 8080
-    healthCheck:
-      httpGet:
-        path: /hello-frontend
-        port: http
-    ingresses:
-      - path: /hello-frontend
-        port: http
-      - path: /call-backend
-        port: http
-    dependencies:
-      - backend
-tests:
-  - name: unit
-    args: [npm, test]
-  - name: integ
-    args: [npm, run, integ]
-    dependencies:
-      - frontend
+dependencies:
+  - deploy.backend
+spec:
+  ports:
+    - name: http
+      containerPort: 8080
+  healthCheck:
+    httpGet:
+      path: /hello-frontend
+      port: http
+  ingresses:
+    - path: /hello-frontend
+      port: http
+    - path: /call-backend
+      port: http
+---
+kind: Test
+name: frontend-unit
+description: Frontend service unit tests
+type: container
+dependencies:
+  - deploy.frontend
+spec:
+  command: [npm, test]
+---
+kind: Test
+name: frontend-integ
+description: Frontend service integ tests
+type: container
+dependencies:
+  - deploy.frontend
+spec:
+  command: [npm, run, integ]

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -566,24 +566,14 @@ ${expectedIngressOutput}
     it("should return just garden-values.yml if no valueFiles are configured", async () => {
       const action = await garden.resolveAction<HelmDeployAction>({ action: graph.getDeploy("api"), log, graph })
       action["_config"].spec.valueFiles = []
-      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql([
-        "--values",
-        gardenValuesPath,
-        "--set",
-        "\\.garden.mode=default",
-      ])
+      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql(["--values", gardenValuesPath])
     })
 
     it("should add a --set flag if in sync mode", async () => {
       graph = await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { sync: ["deploy.api"] } })
       const action = await garden.resolveAction<HelmDeployAction>({ action: graph.getDeploy("api"), log, graph })
       action["_config"].spec.valueFiles = []
-      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql([
-        "--values",
-        gardenValuesPath,
-        "--set",
-        "\\.garden.mode=sync",
-      ])
+      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql(["--values", gardenValuesPath])
     })
 
     it("should add a default --set flag if the aciton doesn't support it's mode", async () => {
@@ -591,12 +581,7 @@ ${expectedIngressOutput}
       graph = await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { local: ["deploy.api"] } })
       const action = await garden.resolveAction<HelmDeployAction>({ action: graph.getDeploy("api"), log, graph })
       action["_config"].spec.valueFiles = []
-      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql([
-        "--values",
-        gardenValuesPath,
-        "--set",
-        "\\.garden.mode=default",
-      ])
+      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql(["--values", gardenValuesPath])
     })
 
     it("should return a --values arg for each valueFile configured", async () => {
@@ -610,8 +595,6 @@ ${expectedIngressOutput}
         resolve(action.getBuildPath(), "bar.yaml"),
         "--values",
         gardenValuesPath,
-        "--set",
-        "\\.garden.mode=default",
       ])
     })
 
@@ -624,8 +607,6 @@ ${expectedIngressOutput}
         resolve(action.getBuildPath(), "../relative.yaml"),
         "--values",
         gardenValuesPath,
-        "--set",
-        "\\.garden.mode=default",
       ])
     })
   })
@@ -653,7 +634,6 @@ ${expectedIngressOutput}
 
       expect(valuesPath).to.not.be.undefined
       const data = await getFileData(valuesPath)
-      expect(data).to.ownProperty(".garden")
       expect(data).to.ownProperty("image")
     })
 

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -10,10 +10,11 @@ import { expect } from "chai"
 
 import type { TestGarden } from "../../../../../helpers.js"
 import { getDataDir, makeTestGarden } from "../../../../../helpers.js"
-import { helmDeploy } from "../../../../../../src/plugins/kubernetes/helm/deployment.js"
+import { deleteHelmDeploy, helmDeploy } from "../../../../../../src/plugins/kubernetes/helm/deployment.js"
 import type { KubernetesPluginContext, KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config.js"
 import {
   gardenCloudAECPauseAnnotation,
+  getHelmGardenMetadataConfigMapData,
   getReleaseStatus,
   getRenderedResources,
 } from "../../../../../../src/plugins/kubernetes/helm/status.js"
@@ -28,6 +29,7 @@ import type { HelmDeployAction } from "../../../../../../src/plugins/kubernetes/
 import { createActionLog } from "../../../../../../src/logger/log-entry.js"
 import type { NamespaceStatus } from "../../../../../../src/types/namespace.js"
 import { FakeCloudApi } from "../../../../../helpers/api.js"
+import { getActionNamespace } from "../../../../../../src/plugins/kubernetes/namespace.js"
 
 describe("helmDeploy in local-mode", () => {
   let garden: TestGarden
@@ -61,7 +63,7 @@ describe("helmDeploy in local-mode", () => {
   })
 
   // TODO-G2
-  it.skip("should deploy a chart with local mode enabled", async () => {
+  it("should deploy a chart with local mode enabled", async () => {
     graph = await garden.getConfigGraph({
       log: garden.log,
       emit: false,
@@ -90,9 +92,9 @@ describe("helmDeploy in local-mode", () => {
     })
 
     expect(status.state).to.equal("ready")
-    expect(status.mode).to.equal("local")
-    expect(status.detail["values"][".garden"]).to.eql({
-      moduleName: "backend",
+    expect(status.detail.mode).to.equal("local")
+    expect(status.detail.gardenMetadata).to.eql({
+      actionName: "backend",
       projectName: garden.projectName,
       version: action.versionString(),
       mode: "local",
@@ -158,8 +160,11 @@ describe("helmDeploy", () => {
     })
 
     expect(releaseStatus.state).to.equal("ready")
-    expect(releaseStatus.detail["values"][".garden"]).to.eql({
-      moduleName: "api",
+    // getReleaseStatus fetches these details from a configmap in the action namespace.
+    // This means we are testing that the configmap is created correctly every time we
+    // test the gardenMetadata details from getReleaseStatus.
+    expect(releaseStatus.detail.gardenMetadata).to.eql({
+      actionName: "api",
       projectName: garden.projectName,
       version: action.versionString(),
       mode: "default",
@@ -196,8 +201,8 @@ describe("helmDeploy", () => {
     })
 
     expect(releaseStatus.state).to.equal("ready")
-    expect(releaseStatus.detail["values"][".garden"]).to.eql({
-      moduleName: "api-module",
+    expect(releaseStatus.detail.gardenMetadata).to.eql({
+      actionName: "api-module",
       projectName: garden.projectName,
       version: action.versionString(),
       mode: "default",
@@ -234,8 +239,8 @@ describe("helmDeploy", () => {
 
     expect(status.state).to.equal("ready")
     expect(status.detail.mode).to.eql("sync")
-    expect(status.detail["values"][".garden"]).to.eql({
-      moduleName: "api",
+    expect(status.detail.gardenMetadata).to.eql({
+      actionName: "api",
       projectName: garden.projectName,
       version: action.versionString(),
       mode: "sync",
@@ -280,6 +285,90 @@ describe("helmDeploy", () => {
     await api.apps.readNamespacedDeployment({ name: "chart-with-namespace", namespace })
   })
 
+  it("should mark a chart that is deployed but does not have a matching configmap as outdated", async () => {
+    graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+    const action = await garden.resolveAction<HelmDeployAction>({
+      action: graph.getDeploy("api"),
+      log: garden.log,
+      graph,
+    })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+    const namespace = await getActionNamespace({
+      ctx,
+      log: garden.log,
+      action,
+      provider: ctx.provider,
+    })
+    // Here, we're not going through a router, so we listen for the `namespaceStatus` event directly.
+    await helmDeploy({
+      ctx,
+      log: actionLog,
+      action,
+      force: false,
+    })
+
+    const releaseName = getReleaseName(action)
+    const releaseStatus = await getReleaseStatus({
+      ctx,
+      action,
+      releaseName,
+      log: garden.log,
+    })
+
+    expect(releaseStatus.state).to.equal("ready")
+    // delete the configmap
+    const api = await KubeApi.factory(actionLog, ctx, ctx.provider)
+    await api.core.deleteNamespacedConfigMap({
+      namespace,
+      name: `garden-helm-metadata-${action.name}`,
+    })
+
+    const releaseStatusAfterDelete = await getReleaseStatus({
+      ctx,
+      action,
+      releaseName,
+      log: garden.log,
+    })
+
+    expect(releaseStatusAfterDelete.state).to.equal("outdated")
+  })
+
+  it("should remove the garden metadata configmap associated with a helm deploy action when the chart is uninstalled", async () => {
+    graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+    const action = await garden.resolveAction<HelmDeployAction>({
+      action: graph.getDeploy("api"),
+      log: garden.log,
+      graph,
+    })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+    const namespace = await getActionNamespace({
+      ctx,
+      log: garden.log,
+      action,
+      provider: ctx.provider,
+    })
+    // Here, we're not going through a router, so we listen for the `namespaceStatus` event directly.
+    await helmDeploy({
+      ctx,
+      log: actionLog,
+      action,
+      force: false,
+    })
+
+    const releaseName = getReleaseName(action)
+    const releaseStatus = await getReleaseStatus({
+      ctx,
+      action,
+      releaseName,
+      log: garden.log,
+    })
+
+    expect(releaseStatus.state).to.equal("ready")
+
+    await deleteHelmDeploy({ ctx, log: actionLog, action })
+    expect(getHelmGardenMetadataConfigMapData({ ctx, action, log: actionLog, namespace })).to.throw
+  })
+
   it("should mark a chart that has been paused by Garden Cloud AEC as outdated", async () => {
     const log = getRootLogger().createLog()
     const fakeCloudApi = await FakeCloudApi.factory({ log })
@@ -318,8 +407,8 @@ describe("helmDeploy", () => {
     })
 
     expect(releaseStatus.state).to.equal("ready")
-    expect(releaseStatus.detail["values"][".garden"]).to.eql({
-      moduleName: "api",
+    expect(releaseStatus.detail.gardenMetadata).to.eql({
+      actionName: "api",
       projectName: gardenWithCloudApi.projectName,
       version: action.versionString(),
       mode: "default",

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -9,7 +9,7 @@
 import { expect } from "chai"
 
 import type { TestGarden } from "../../../../../helpers.js"
-import { getDataDir, makeTestGarden } from "../../../../../helpers.js"
+import { expectError, getDataDir, makeTestGarden } from "../../../../../helpers.js"
 import { deleteHelmDeploy, helmDeploy } from "../../../../../../src/plugins/kubernetes/helm/deployment.js"
 import type { KubernetesPluginContext, KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config.js"
 import {
@@ -366,7 +366,7 @@ describe("helmDeploy", () => {
     expect(releaseStatus.state).to.equal("ready")
 
     await deleteHelmDeploy({ ctx, log: actionLog, action })
-    expect(getHelmGardenMetadataConfigMapData({ ctx, action, log: actionLog, namespace })).to.throw
+    await expectError(async () => await getHelmGardenMetadataConfigMapData({ ctx, action, log: actionLog, namespace }))
   })
 
   it("should mark a chart that has been paused by Garden Cloud AEC as outdated", async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Store garden metadata for Helm deploy actions in a config map in the same namespace instead of adding them as additional values to the Helm release, which caused schema validation to fail for Helm charts with `additionalProperties: false` in the `values.schema.json`.

Also fixes a skipped integration test on `localMode` for Helm Charts by updating the example project from modules to actions.

**Which issue(s) this PR fixes**: 

Fixes #3962

**Special notes for your reviewer**:
