### PR TITLE
feat(container): allow global extra build flags e.g. for custom remote builders

### DIFF
--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -423,7 +423,7 @@ export const gardenPlugin = () =>
       Provides the \`container\` actions and module type.
       _Note that this provider is currently automatically included, and you do not need to configure it in your project configuration._
     `,
-    configSchema: providerConfigBaseSchema(),
+    configSchema: configSchema(),
 
     createActionTypes: {
       Build: [

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -42,11 +42,25 @@ import { publishContainerBuild } from "./publish.js"
 import type { Resolved } from "../../actions/types.js"
 import { getDeployedImageId } from "../kubernetes/container/util.js"
 import type { DeepPrimitiveMap } from "../../config/common.js"
+import { joi } from "../../config/common.js"
 import { DEFAULT_DEPLOY_TIMEOUT_SEC } from "../../constants.js"
 import type { ExecBuildConfig } from "../exec/build.js"
 import type { PluginToolSpec } from "../../plugin/tools.js"
 
-export type ContainerProviderConfig = GenericProviderConfig
+export interface ContainerProviderConfig extends GenericProviderConfig {
+  dockerBuildExtraFlags?: string[]
+}
+
+export const configSchema = () =>
+  providerConfigBaseSchema()
+    .keys({
+      dockerBuildExtraFlags: joi.array().items(joi.string()).description(dedent`
+          **Stability: Experimental**. Subject to breaking changes within minor releases.
+
+          Extra flags to pass to the \`docker build\` command. Will extend the \`spec.extraFlags\` specified in each container Build action.
+          `),
+    })
+    .unknown(false)
 
 export type ContainerProvider = Provider<ContainerProviderConfig>
 

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -35,6 +35,7 @@ import { joinWithPosix } from "../../util/fs.js"
 import type { Resolved } from "../../actions/types.js"
 import pMemoize from "../../lib/p-memoize.js"
 import { styles } from "../../logger/styles.js"
+import type { ContainerProviderConfig } from "./container.js"
 
 interface DockerVersion {
   client?: string
@@ -353,7 +354,7 @@ const helpers = {
     cwd: string
     args: string[]
     log: Log
-    ctx: PluginContext
+    ctx: PluginContext<ContainerProviderConfig>
     ignoreError?: boolean
     stdout?: Writable
     stderr?: Writable

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -46,7 +46,7 @@ import type { ContainerBuildAction } from "../../../container/config.js"
 import { defaultDockerfileName } from "../../../container/config.js"
 import { styles } from "../../../../logger/styles.js"
 import { commandListToShellScript } from "../../../../util/escape.js"
-import { ContainerProviderConfig } from "../../../container/container.js"
+import type { ContainerProviderConfig } from "../../../container/container.js"
 
 export const DEFAULT_KANIKO_FLAGS = ["--cache=true"]
 

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -46,6 +46,7 @@ import type { ContainerBuildAction } from "../../../container/config.js"
 import { defaultDockerfileName } from "../../../container/config.js"
 import { styles } from "../../../../logger/styles.js"
 import { commandListToShellScript } from "../../../../util/escape.js"
+import { ContainerProviderConfig } from "../../../container/container.js"
 
 export const DEFAULT_KANIKO_FLAGS = ["--cache=true"]
 
@@ -168,7 +169,9 @@ export const kanikoBuild: BuildHandler = async (params) => {
     args.push("--insecure")
   }
 
-  args.push(...getDockerBuildFlags(action))
+  const containerProviderConfig: ContainerProviderConfig = provider.dependencies.container.config
+
+  args.push(...getDockerBuildFlags(action, containerProviderConfig))
 
   const buildRes = await runKaniko({
     ctx,

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -17,7 +17,6 @@ import type { DebugInfo, GetDebugInfoParams } from "../../plugin/handlers/Provid
 import { kubectl, kubectlSpec } from "./kubectl.js"
 import type { KubernetesConfig, KubernetesPluginContext } from "./config.js"
 import { configSchema } from "./config.js"
-import { ConfigurationError } from "../../exceptions.js"
 import { cleanupClusterRegistry } from "./commands/cleanup-cluster-registry.js"
 import { clusterInit } from "./commands/cluster-init.js"
 import { pullImage } from "./commands/pull-image.js"
@@ -54,6 +53,7 @@ export async function configureProvider({
   projectName,
   projectRoot,
   config,
+  log,
 }: ConfigureProviderParams<KubernetesConfig>) {
   // Convert string shorthand to canonical format
   if (isString(config.namespace)) {
@@ -71,12 +71,11 @@ export async function configureProvider({
   }
 
   if (config.name !== "local-kubernetes" && !config.deploymentRegistry) {
-    throw new ConfigurationError({
-      message: dedent`
-        Configuring a 'deploymentRegistry' in the kubernetes provider section of the project configuration is required when working with remote Kubernetes clusters.
+    log.warn(dedent`
+      You are using a remote Kubernetes cluster and did not configure a 'deploymentRegistry' in the kubernetes provider section of the project configuration.
 
-        See also ${makeDocsLinkStyled("kubernetes-plugins/remote-k8s")}`,
-    })
+      For guidance in setting up remote Kubernetes clusters please refer to ${makeDocsLinkStyled("kubernetes-plugins/remote-k8s")}
+    `)
   }
 
   if (config.kubeconfig) {

--- a/core/test/integ/src/plugins/container/container.ts
+++ b/core/test/integ/src/plugins/container/container.ts
@@ -289,7 +289,7 @@ describe("plugins.container", () => {
         graph: await garden.getConfigGraph({ log, emit: false }),
       })
 
-      const args = getDockerBuildFlags(resolvedBuild)
+      const args = getDockerBuildFlags(resolvedBuild, ctx.provider.config)
 
       expect(args.slice(-2)).to.eql(["--cache-from", "some-image:latest"])
     })
@@ -305,7 +305,7 @@ describe("plugins.container", () => {
         graph: await garden.getConfigGraph({ log, emit: false }),
       })
 
-      const args = getDockerBuildFlags(resolvedBuild)
+      const args = getDockerBuildFlags(resolvedBuild, ctx.provider.config)
 
       // Also module version is set for backwards compatability
       expect(args.slice(0, 2)).to.eql(["--build-arg", `GARDEN_MODULE_VERSION=${buildAction.versionString()}`])

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -29,6 +29,12 @@ providers:
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
+    # **Stability: Experimental**. Subject to breaking changes within minor releases.
+    #
+    # Extra flags to pass to the `docker build` command. Will extend the `spec.extraFlags` specified in each container
+    # Build action.
+    dockerBuildExtraFlags:
 ```
 ## Configuration Keys
 
@@ -91,4 +97,16 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].dockerBuildExtraFlags[]`
+
+[providers](#providers) > dockerBuildExtraFlags
+
+**Stability: Experimental**. Subject to breaking changes within minor releases.
+
+Extra flags to pass to the `docker build` command. Will extend the `spec.extraFlags` specified in each container Build action.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Allows overriding the docker command, and setting global extra build flags.

This can be useful when configuring custom remote builders.

Example:

```
providers:
 - name: exec
   initScript: |
      docker buildx create --driver ... custom-builder
 - name: container
   dockerBuildExtraFlags: ["--builder", "custom-builder", "--push"]
```

This is useful as a first step for experimental Namespace builder support.

This PR also changes the Kubernetes provider initialization to allow missing `deploymentRegistry` config flag in remote kubernetes clusters. It now prints a warning instead of throwing an error.

**Special notes for your reviewer**:
