### PR TITLE
chore(deps): update `@kubernetes/client-node` to 1.0.0-rc4

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -29,7 +29,7 @@
     "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
     "@homebridge/node-pty-prebuilt-multiarch": "0.11.8",
     "@jsdevtools/readdir-enhanced": "^6.0.4",
-    "@kubernetes/client-node": "github:garden-io/javascript#60f0ea6de09777ceabd5afc3e306801fd0b025cc",
+    "@kubernetes/client-node": "^1.0.0-rc4",
     "@opentelemetry/api": "^1.6.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.46.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1431,7 +1431,7 @@
         "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
         "@homebridge/node-pty-prebuilt-multiarch": "0.11.8",
         "@jsdevtools/readdir-enhanced": "^6.0.4",
-        "@kubernetes/client-node": "github:garden-io/javascript#60f0ea6de09777ceabd5afc3e306801fd0b025cc",
+        "@kubernetes/client-node": "^1.0.0-rc4",
         "@opentelemetry/api": "^1.6.0",
         "@opentelemetry/core": "^1.18.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
@@ -2763,10 +2763,9 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "core/node_modules/@kubernetes/client-node": {
-      "version": "1.0.0-rc3",
-      "resolved": "git+ssh://git@github.com/garden-io/javascript.git#60f0ea6de09777ceabd5afc3e306801fd0b025cc",
-      "integrity": "sha512-VzXsPGsvi4j5gxBU1pduliaguBl8qVczx6jgYbKB13m9HKt+fyGltobKLu7XRhZnnlzd8hAiH8HpOqg+/gT82Q==",
-      "license": "Apache-2.0",
+      "version": "1.0.0-rc4",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.0.0-rc4.tgz",
+      "integrity": "sha512-S7UMp/4jKxjrvO9dUHhx3AmiNTSnxtHR7k3+DI7cEuaOB7QaurtTjJJuAYf+Gi/yO6HpeyvB82uPHwfKyqivdg==",
       "dependencies": {
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^20.3.1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Move away from our fork as our changes have landed upstream in
`1.0.0-rc4` (See also https://github.com/kubernetes-client/javascript/pull/1436)
