### PR TITLE
fix(core): increase max event listener count

### DIFF
--- a/core/src/events/events.ts
+++ b/core/src/events/events.ts
@@ -45,7 +45,7 @@ export class EventBus extends EventEmitter2.EventEmitter2 {
     super({
       wildcard: false,
       newListener: false,
-      maxListeners: 5000, // we may need to adjust this
+      maxListeners: 50000, // we may need to adjust this
     })
     this.keyIndex = {}
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Some users with very large projects occasionally run into a "maximum event listeners exceeded" warning. It's not quite clear why this would happen, but maybe this is to be expected for larger projects.

Raising the limit should be harmless, and might help reveal underlying issues with the event listener lifecycle.