### PR TITLE
feat(modules): allow opting out of build staging

### DIFF
--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -132,8 +132,8 @@ export class BuildStaging {
   }
 
   getBuildPath(config: BuildActionConfig<string, any> | ModuleConfig): string {
-    // We don't stage the build for local exec modules, so the module path is effectively the build path.
-    if (config.kind === "Module" && config.type === "exec" && config["local"] === true) {
+    // We don't stage the build for local modules, so the module path is effectively the build path.
+    if (config.kind === "Module" && config["local"] === true) {
       return config.path
     }
 

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -446,6 +446,7 @@ export function prepareModuleResource(spec: any, configPath: string, projectRoot
       dependencies,
       timeout: spec.build?.timeout || DEFAULT_BUILD_TIMEOUT_SEC,
     },
+    local: spec.local,
     configPath,
     description: spec.description,
     disabled: spec.disabled,

--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -92,6 +92,7 @@ interface ModuleSpecCommon {
   apiVersion?: string
   allowPublish?: boolean
   build?: BaseBuildSpec
+  local?: boolean
   description?: string
   disabled?: boolean
   exclude?: string[]
@@ -187,6 +188,24 @@ export const coreModuleSpecSchema = createSchema({
 // These fields may be resolved later in the process, and allow for usage of template strings
 export const baseModuleSpecKeys = memoize(() => ({
   build: baseBuildSpecSchema().unknown(true),
+  local: joi
+    .boolean()
+    .description(
+      dedent`
+      If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+      instead of in the Garden build directory (under .garden/build/<module-name>).
+
+      Garden will therefore not stage the build for local modules. This means that include/exclude filters
+      and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+      If you use use \`build.dependencies[].copy\` for one or more build dependencies of this module, the copied files
+      will be copied to the module source directory (instead of the build directory, as is the default case when
+      \`local = false\`).
+
+      Note: This maps to the \`buildAtSource\` option in this module's generated Build action (if any).
+      `
+    )
+    .default(false),
   description: joi.string().description("A description of the module."),
   disabled: joi
     .boolean()

--- a/core/src/plugins/exec/convert.ts
+++ b/core/src/plugins/exec/convert.ts
@@ -32,7 +32,6 @@ export function prepareExecBuildAction(params: ConvertModuleParams<ExecModule>):
       ...params.baseFields,
       ...dummyBuild,
 
-      buildAtSource: module.spec.local,
       dependencies: module.build.dependencies.map(convertBuildDependency),
 
       timeout: module.build.timeout,

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -914,6 +914,7 @@ export function makeDummyBuild({
 
     copyFrom,
     source: module.repositoryUrl ? { repository: { url: module.repositoryUrl } } : undefined,
+    buildAtSource: module.local,
 
     allowPublish: module.allowPublish,
     dependencies,
@@ -941,6 +942,9 @@ function inheritModuleToAction(module: GardenModule, action: ActionConfig) {
     action.disabled = true
   }
   action.internal.basePath = module.path
+  if (isBuildActionConfig(action)) {
+    action.buildAtSource = module.local
+  }
   if (module.configPath) {
     action.internal.configFilePath = module.configPath
   }

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -131,9 +131,8 @@ export async function moduleFromConfig({
   const moduleTypes = await garden.getModuleTypes()
   const compatibleTypes = [config.type, ...getModuleTypeBases(moduleTypes[config.type], moduleTypes).map((t) => t.name)]
 
-  // Special-casing local exec modules, otherwise setting build path as <build dir>/<module name>
-  const buildPath =
-    config.type === "exec" && config.spec.local ? config.path : join(garden.buildStaging.buildDirPath, config.name)
+  // Special-casing local modules, otherwise setting build path as <build dir>/<module name>
+  const buildPath = config.local ? config.path : join(garden.buildStaging.buildDirPath, config.name)
 
   await garden.buildStaging.ensureDir(buildPath)
 

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -104,6 +104,7 @@ describe("configureHelmModule", () => {
         dependencies: [],
         timeout: DEFAULT_BUILD_TIMEOUT_SEC,
       },
+      local: false,
       configPath: resolve(ctx.projectRoot, "api", "garden.yml"),
       description: "The API backend for the voting UI",
       disabled: false,

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -274,6 +274,7 @@ describe("loadConfigResources", () => {
       repositoryUrl: undefined,
       allowPublish: undefined,
       build: { dependencies: [], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+      local: undefined,
       path: modulePathA,
       variables: { msg: "OK" },
       varfile: undefined,
@@ -414,6 +415,7 @@ describe("loadConfigResources", () => {
         repositoryUrl: undefined,
         allowPublish: undefined,
         build: { dependencies: [], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+        local: undefined,
         path: projectPathMultipleModules,
         serviceConfigs: [],
         spec: {
@@ -454,6 +456,7 @@ describe("loadConfigResources", () => {
           dependencies: [{ name: "module-from-project-config", copy: [] }],
           timeout: DEFAULT_BUILD_TIMEOUT_SEC,
         },
+        local: undefined,
         path: modulePathAMultiple,
         serviceConfigs: [],
         spec: {
@@ -484,6 +487,7 @@ describe("loadConfigResources", () => {
         exclude: undefined,
         repositoryUrl: undefined,
         build: { dependencies: [], timeout: DEFAULT_BUILD_TIMEOUT_SEC },
+        local: undefined,
         path: modulePathAMultiple,
         serviceConfigs: [],
         spec: {

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -17,7 +17,6 @@ import { createActionLog } from "../../../../../src/logger/log-entry.js"
 import { keyBy, omit } from "lodash-es"
 import {
   getDataDir,
-  makeTestModule,
   expectError,
   createProjectConfig,
   TestGarden,
@@ -26,7 +25,6 @@ import {
 } from "../../../../helpers.js"
 import { RunTask } from "../../../../../src/tasks/run.js"
 import { makeTestGarden } from "../../../../helpers.js"
-import type { ModuleConfig } from "../../../../../src/config/module.js"
 import type { ConfigGraph } from "../../../../../src/graph/config-graph.js"
 import fsExtra from "fs-extra"
 const { pathExists, emptyDir, readFile, remove } = fsExtra
@@ -34,7 +32,6 @@ import { TestTask } from "../../../../../src/tasks/test.js"
 import { dedent } from "../../../../../src/util/string.js"
 import { sleep } from "../../../../../src/util/util.js"
 import type { ExecModuleConfig } from "../../../../../src/plugins/exec/moduleConfig.js"
-import { configureExecModule } from "../../../../../src/plugins/exec/moduleConfig.js"
 import { actionFromConfig } from "../../../../../src/graph/actions.js"
 import type { TestAction, TestActionConfig } from "../../../../../src/actions/test.js"
 import type { PluginContext } from "../../../../../src/plugin-context.js"
@@ -226,7 +223,7 @@ describe("exec plugin", () => {
         },
       ])
 
-      expect(moduleLocal.spec.local).to.eql(true)
+      expect(moduleLocal.local).to.eql(true)
       expect(moduleLocal.build.dependencies).to.eql([])
       expect(moduleLocal.spec.build.command).to.eql(["pwd"])
 
@@ -354,28 +351,6 @@ describe("exec plugin", () => {
       await _garden.processTasks({ tasks: [testTask], throwOnError: false })
 
       expect(await pathExists(join(_garden.artifactsPath, "test-outputs", "test-a.txt"))).to.be.true
-    })
-
-    describe("configureExecModule", () => {
-      it("should throw if a local exec module has a build.copy spec", async () => {
-        const moduleConfig = makeTestModule(<Partial<ModuleConfig>>{
-          build: {
-            dependencies: [
-              {
-                name: "foo",
-                copy: [
-                  {
-                    source: ".",
-                    target: ".",
-                  },
-                ],
-              },
-            ],
-          },
-          spec: { local: true },
-        })
-        await expectError(async () => await configureExecModule({ ctx, moduleConfig, log }), "configuration")
-      })
     })
 
     describe("build", () => {
@@ -1122,8 +1097,8 @@ describe("exec plugin", () => {
               makeModuleConfig<ExecModuleConfig>(garden.projectRoot, {
                 name,
                 type: "exec",
+                local, // <---
                 spec: {
-                  local, // <---
                   build: {
                     command: buildCommand,
                   },

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1481,6 +1481,21 @@ providers:
           # Maximum time in seconds to wait for build to finish.
           timeout:
 
+        # If set to true, Garden will run the build command, services, tests, and tasks in the module source
+        # directory,
+        # instead of in the Garden build directory (under .garden/build/<module-name>).
+        #
+        # Garden will therefore not stage the build for local modules. This means that include/exclude filters
+        # and ignore files are not applied to local modules, except to calculate the module/action versions.
+        #
+        # If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied
+        # files
+        # will be copied to the module source directory (instead of the build directory, as is the default case when
+        # `local = false`).
+        #
+        # Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+        local:
+
         # A description of the module.
         description:
 
@@ -2381,6 +2396,19 @@ moduleConfigs:
       # Maximum time in seconds to wait for build to finish.
       timeout:
 
+    # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+    # instead of in the Garden build directory (under .garden/build/<module-name>).
+    #
+    # Garden will therefore not stage the build for local modules. This means that include/exclude filters
+    # and ignore files are not applied to local modules, except to calculate the module/action versions.
+    #
+    # If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+    # will be copied to the module source directory (instead of the build directory, as is the default case when
+    # `local = false`).
+    #
+    # Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+    local:
+
     # A description of the module.
     description:
 
@@ -2938,6 +2966,19 @@ modules:
 
       # Maximum time in seconds to wait for build to finish.
       timeout:
+
+    # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+    # instead of in the Garden build directory (under .garden/build/<module-name>).
+    #
+    # Garden will therefore not stage the build for local modules. This means that include/exclude filters
+    # and ignore files are not applied to local modules, except to calculate the module/action versions.
+    #
+    # If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+    # will be copied to the module source directory (instead of the build directory, as is the default case when
+    # `local = false`).
+    #
+    # Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+    local:
 
     # A description of the module.
     description:

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -69,6 +69,19 @@ modules:
       # Maximum time in seconds to wait for build to finish.
       timeout: 600
 
+    # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+    # instead of in the Garden build directory (under .garden/build/<module-name>).
+    #
+    # Garden will therefore not stage the build for local modules. This means that include/exclude filters
+    # and ignore files are not applied to local modules, except to calculate the module/action versions.
+    #
+    # If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+    # will be copied to the module source directory (instead of the build directory, as is the default case when
+    # `local = false`).
+    #
+    # Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+    local: false
+
     # A description of the module.
     description:
 
@@ -364,6 +377,26 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `modules[].local`
+
+[modules](#modules) > local
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `modules[].description`
 

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -54,6 +54,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -278,6 +291,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -57,6 +57,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -286,6 +299,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -62,6 +62,19 @@ build:
   # https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for details).
   targetImage:
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -848,6 +861,24 @@ For multi-stage Dockerfiles, specify which image/stage to build (see https://doc
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -66,6 +66,19 @@ build:
   # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
   command: []
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -165,13 +178,6 @@ variables:
 # to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding
 # varfiles exist).
 varfile:
-
-# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
-# instead of in the Garden build directory (under .garden/build/<module-name>).
-#
-# Garden will therefore not stage the build for local exec modules. This means that include/exclude filters
-# and ignore files are not applied to local exec modules.
-local: false
 
 # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
 # `GARDEN`) and values must be primitives.
@@ -476,6 +482,24 @@ build:
     - build
 ```
 
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
 ### `description`
 
 A description of the module.
@@ -645,18 +669,6 @@ Example:
 ```yaml
 varfile: "my-module.env"
 ```
-
-### `local`
-
-If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
-instead of in the Garden build directory (under .garden/build/<module-name>).
-
-Garden will therefore not stage the build for local exec modules. This means that include/exclude filters
-and ignore files are not applied to local exec modules.
-
-| Type      | Default | Required |
-| --------- | ------- | -------- |
-| `boolean` | `false` | No       |
 
 ### `env`
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -60,6 +60,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -277,6 +290,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -56,6 +56,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -731,6 +744,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -130,6 +130,19 @@ build:
   # Specify extra flags to pass to maven/gradle when building the container image.
   extraFlags:
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -1063,6 +1076,24 @@ Specify extra flags to pass to maven/gradle when building the container image.
 | Type            | Required |
 | --------------- | -------- |
 | `array[string]` | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -58,6 +58,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -712,6 +725,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -54,6 +54,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -341,6 +354,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -56,6 +56,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -357,6 +370,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -18,7 +18,7 @@ A special module type, for rendering [module templates](../../using-garden/confi
 Specify the name of a ConfigTemplate with the `template` field, and provide any expected inputs using the `inputs` field. The generated modules becomes sub-modules of this module.
 
 Note that the following common Module configuration fields are disallowed for this module type:
-`build`, `description`, `include`, `exclude`, `repositoryUrl`, `allowPublish`, `generateFiles`, `variables` and `varfile`
+`build`, `local`, `description`, `include`, `exclude`, `repositoryUrl`, `allowPublish`, `generateFiles`, `variables` and `varfile`
 
 Below is the full schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
 guide](../../using-garden/configuration-overview.md).
@@ -58,6 +58,19 @@ build:
 
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
+
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
 
 # A description of the module.
 description:
@@ -274,6 +287,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -60,6 +60,19 @@ build:
   # Maximum time in seconds to wait for build to finish.
   timeout: 600
 
+# If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+# instead of in the Garden build directory (under .garden/build/<module-name>).
+#
+# Garden will therefore not stage the build for local modules. This means that include/exclude filters
+# and ignore files are not applied to local modules, except to calculate the module/action versions.
+#
+# If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+# will be copied to the module source directory (instead of the build directory, as is the default case when
+# `local = false`).
+#
+# Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+local: false
+
 # A description of the module.
 description:
 
@@ -303,6 +316,24 @@ Maximum time in seconds to wait for build to finish.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `600`   | No       |
+
+### `local`
+
+If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
+instead of in the Garden build directory (under .garden/build/<module-name>).
+
+Garden will therefore not stage the build for local modules. This means that include/exclude filters
+and ignore files are not applied to local modules, except to calculate the module/action versions.
+
+If you use use `build.dependencies[].copy` for one or more build dependencies of this module, the copied files
+will be copied to the module source directory (instead of the build directory, as is the default case when
+`local = false`).
+
+Note: This maps to the `buildAtSource` option in this module's generated Build action (if any).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, @TimBeyer, and @vvagaytsev.
-->

**What this PR does / why we need it**:


Here, we make the `local` config field (previously only available to `exec` modules) available for all module types.

When used, it maps to the `buildAtSource` field of any generated Build actions in the module conversion process.

This is done because some users/projects that haven't migrated from modules to actions yet need to reference symlinked directories in their builds, where the simplest solution appears to be to simply opt out of build staging for those modules.

**Which issue(s) this PR fixes**:

Workaround for #2382.

**Notes for reviewer**:

Will this cause problems with build copying? Does allowing this violate any subtle invariants?