### PR TITLE
refactor(git): collect Git utils in one class

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -100,6 +100,10 @@ export class GitCli {
     this.git = gitCliExecutor(params)
   }
 
+  public async exec(...args: string[]) {
+    return await this.git(...args)
+  }
+
   public async getModifiedFiles(path: string): Promise<string[]> {
     try {
       return await this.git("diff-index", "--name-only", "HEAD", path)
@@ -111,10 +115,6 @@ export class GitCli {
         throw err
       }
     }
-  }
-
-  public async exec(...args: string[]) {
-    return await this.git(...args)
   }
 
   public async getLastCommitHash(): Promise<string> {

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -93,7 +93,7 @@ function gitCliExecutor({ log, cwd, failOnPrompt = false }: GitCliParams): GitCl
   }
 }
 
-export class GitClient {
+export class GitCli {
   private readonly git: GitCliExecutor
 
   constructor(params: GitCliParams) {
@@ -204,7 +204,7 @@ export class GitHandler extends VcsHandler {
       }
 
       try {
-        const git = new GitClient({ log, cwd: path, failOnPrompt })
+        const git = new GitCli({ log, cwd: path, failOnPrompt })
         const repoRoot = await git.getRepositoryRoot()
         this.repoRoots.set(path, repoRoot)
         return repoRoot
@@ -265,7 +265,7 @@ export class GitHandler extends VcsHandler {
 
     let files: VcsFile[] = []
 
-    const git = new GitClient({ log: gitLog, cwd: path, failOnPrompt })
+    const git = new GitCli({ log: gitLog, cwd: path, failOnPrompt })
     const gitRoot = await this.getRepoRoot(gitLog, path, failOnPrompt)
 
     // List modified files, so that we can ensure we have the right hash for them later
@@ -533,7 +533,7 @@ export class GitHandler extends VcsHandler {
     failOnPrompt = false
   ) {
     await ensureDir(absPath)
-    const git = new GitClient({ log, cwd: absPath, failOnPrompt })
+    const git = new GitCli({ log, cwd: absPath, failOnPrompt })
     // Use `--recursive` to include submodules
     if (!isSha1(hash)) {
       return git.exec(
@@ -606,7 +606,7 @@ export class GitHandler extends VcsHandler {
 
   async updateRemoteSource({ url, name, sourceType, log, failOnPrompt = false }: RemoteSourceParams) {
     const absPath = this.getRemoteSourceLocalPath(name, url, sourceType)
-    const git = new GitClient({ log, cwd: absPath, failOnPrompt })
+    const git = new GitCli({ log, cwd: absPath, failOnPrompt })
     const { repositoryUrl, hash } = parseGitUrl(url)
 
     await this.ensureRemoteSource({ url, name, sourceType, log, failOnPrompt })
@@ -715,7 +715,7 @@ export class GitHandler extends VcsHandler {
   }
 
   async getPathInfo(log: Log, path: string, failOnPrompt = false): Promise<VcsInfo> {
-    const git = new GitClient({ log, cwd: path, failOnPrompt })
+    const git = new GitCli({ log, cwd: path, failOnPrompt })
 
     const output: VcsInfo = {
       branch: "",

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -69,7 +69,7 @@ export function parseGitUrl(url: string) {
   return { repositoryUrl: parts[0], hash: parts[1] }
 }
 
-export interface GitCliExecutor {
+interface GitCliExecutor {
   /**
    * @throws ChildProcessError
    */
@@ -78,7 +78,7 @@ export interface GitCliExecutor {
 
 type GitCliParams = { log: Log; cwd: string; failOnPrompt?: boolean }
 
-export function gitCliExecutor({ log, cwd, failOnPrompt = false }: GitCliParams): GitCliExecutor {
+function gitCliExecutor({ log, cwd, failOnPrompt = false }: GitCliParams): GitCliExecutor {
   /**
    * @throws ChildProcessError
    */

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -69,7 +69,7 @@ export function parseGitUrl(url: string) {
   return { repositoryUrl: parts[0], hash: parts[1] }
 }
 
-export interface GitCli {
+export interface GitCliExecutor {
   /**
    * @throws ChildProcessError
    */
@@ -78,7 +78,7 @@ export interface GitCli {
 
 type GitCliParams = { log: Log; cwd: string; failOnPrompt?: boolean }
 
-export function gitCli({ log, cwd, failOnPrompt = false }: GitCliParams): GitCli {
+export function gitCliExecutor({ log, cwd, failOnPrompt = false }: GitCliParams): GitCliExecutor {
   /**
    * @throws ChildProcessError
    */
@@ -94,10 +94,10 @@ export function gitCli({ log, cwd, failOnPrompt = false }: GitCliParams): GitCli
 }
 
 export class GitClient {
-  private readonly git: GitCli
+  private readonly git: GitCliExecutor
 
   constructor(params: GitCliParams) {
-    this.git = gitCli(params)
+    this.git = gitCliExecutor(params)
   }
 
   public async getModifiedFiles(path: string): Promise<string[]> {

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -76,7 +76,9 @@ export interface GitCli {
   (...args: string[]): Promise<string[]>
 }
 
-export function gitCli(log: Log, cwd: string, failOnPrompt = false): GitCli {
+type GitCliParams = { log: Log; cwd: string; failOnPrompt?: boolean }
+
+export function gitCli({ log, cwd, failOnPrompt = false }: GitCliParams): GitCli {
   /**
    * @throws ChildProcessError
    */
@@ -91,37 +93,49 @@ export function gitCli(log: Log, cwd: string, failOnPrompt = false): GitCli {
   }
 }
 
-export async function getModifiedFiles(git: GitCli, path: string): Promise<string[]> {
-  try {
-    return await git("diff-index", "--name-only", "HEAD", path)
-  } catch (err) {
-    if (err instanceof ChildProcessError && err.details.code === 128) {
-      // no commit in repo
-      return []
-    } else {
-      throw err
+export class GitClient {
+  private readonly git: GitCli
+
+  constructor(params: GitCliParams) {
+    this.git = gitCli(params)
+  }
+
+  public async getModifiedFiles(path: string): Promise<string[]> {
+    try {
+      return await this.git("diff-index", "--name-only", "HEAD", path)
+    } catch (err) {
+      if (err instanceof ChildProcessError && err.details.code === 128) {
+        // no commit in repo
+        return []
+      } else {
+        throw err
+      }
     }
   }
-}
 
-export async function getLastCommitHash(git: GitCli): Promise<string> {
-  const result = await git("rev-parse", "HEAD")
-  return result[0]
-}
+  public async exec(...args: string[]) {
+    return await this.git(...args)
+  }
 
-export async function getRepositoryRoot(git: GitCli): Promise<string> {
-  const result = await git("rev-parse", "--show-toplevel")
-  return result[0]
-}
+  public async getLastCommitHash(): Promise<string> {
+    const result = await this.git("rev-parse", "HEAD")
+    return result[0]
+  }
 
-export async function getBranchName(git: GitCli): Promise<string> {
-  const result = await git("rev-parse", "--abbrev-ref", "HEAD")
-  return result[0]
-}
+  public async getRepositoryRoot(): Promise<string> {
+    const result = await this.git("rev-parse", "--show-toplevel")
+    return result[0]
+  }
 
-export async function getOriginUrl(git: GitCli): Promise<string> {
-  const result = await git("config", "--get", "remote.origin.url")
-  return result[0]
+  public async getBranchName(): Promise<string> {
+    const result = await this.git("rev-parse", "--abbrev-ref", "HEAD")
+    return result[0]
+  }
+
+  public async getOriginUrl(): Promise<string> {
+    const result = await this.git("config", "--get", "remote.origin.url")
+    return result[0]
+  }
 }
 
 interface GitSubTreeIncludeExcludeFiles extends BaseIncludeExcludeFiles {
@@ -190,8 +204,8 @@ export class GitHandler extends VcsHandler {
       }
 
       try {
-        const git = gitCli(log, path, failOnPrompt)
-        const repoRoot = await getRepositoryRoot(git)
+        const git = new GitClient({ log, cwd: path, failOnPrompt })
+        const repoRoot = await git.getRepositoryRoot()
         this.repoRoots.set(path, repoRoot)
         return repoRoot
       } catch (err) {
@@ -251,12 +265,12 @@ export class GitHandler extends VcsHandler {
 
     let files: VcsFile[] = []
 
-    const git = gitCli(gitLog, path, failOnPrompt)
+    const git = new GitClient({ log: gitLog, cwd: path, failOnPrompt })
     const gitRoot = await this.getRepoRoot(gitLog, path, failOnPrompt)
 
     // List modified files, so that we can ensure we have the right hash for them later
     const modified = new Set(
-      (await getModifiedFiles(git, path))
+      (await git.getModifiedFiles(path))
         // The output here is relative to the git root, and not the directory `path`
         .map((modifiedRelPath) => resolve(gitRoot, modifiedRelPath))
     )
@@ -274,7 +288,7 @@ export class GitHandler extends VcsHandler {
     const trackedButIgnored = new Set(
       !this.ignoreFile
         ? []
-        : await git(
+        : await git.exec(
             ...globalArgs,
             "ls-files",
             "--ignored",
@@ -519,10 +533,10 @@ export class GitHandler extends VcsHandler {
     failOnPrompt = false
   ) {
     await ensureDir(absPath)
-    const git = gitCli(log, absPath, failOnPrompt)
+    const git = new GitClient({ log, cwd: absPath, failOnPrompt })
     // Use `--recursive` to include submodules
     if (!isSha1(hash)) {
-      return git(
+      return git.exec(
         "-c",
         "protocol.file.allow=always",
         "clone",
@@ -538,11 +552,19 @@ export class GitHandler extends VcsHandler {
     // If SHA1 is used we need to fetch the changes as git clone doesn't allow to shallow clone
     // a specific hash
     try {
-      await git("init")
-      await git("remote", "add", "origin", repositoryUrl)
-      await git("-c", "protocol.file.allow=always", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", hash)
-      await git("checkout", "FETCH_HEAD")
-      return git("-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+      await git.exec("init")
+      await git.exec("remote", "add", "origin", repositoryUrl)
+      await git.exec(
+        "-c",
+        "protocol.file.allow=always",
+        "fetch",
+        "--depth=1",
+        "--recurse-submodules=yes",
+        "origin",
+        hash
+      )
+      await git.exec("checkout", "FETCH_HEAD")
+      return git.exec("-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
     } catch (err) {
       throw new RuntimeError({
         message: dedent`
@@ -584,26 +606,28 @@ export class GitHandler extends VcsHandler {
 
   async updateRemoteSource({ url, name, sourceType, log, failOnPrompt = false }: RemoteSourceParams) {
     const absPath = this.getRemoteSourceLocalPath(name, url, sourceType)
-    const git = gitCli(log, absPath, failOnPrompt)
+    const git = new GitClient({ log, cwd: absPath, failOnPrompt })
     const { repositoryUrl, hash } = parseGitUrl(url)
 
     await this.ensureRemoteSource({ url, name, sourceType, log, failOnPrompt })
 
     await this.withRemoteSourceLock(sourceType, name, async () => {
       const gitLog = log.createLog({ name, showDuration: true }).info("Getting remote state")
-      await git("remote", "update")
+      await git.exec("remote", "update")
 
-      const localCommitId = await getLastCommitHash(git)
-      const remoteCommitId = isSha1(hash) ? hash : getCommitIdFromRefList(await git("ls-remote", repositoryUrl, hash))
+      const localCommitId = await git.getLastCommitHash()
+      const remoteCommitId = isSha1(hash)
+        ? hash
+        : getCommitIdFromRefList(await git.exec("ls-remote", repositoryUrl, hash))
 
       if (localCommitId !== remoteCommitId) {
         gitLog.info(`Fetching from ${url}`)
 
         try {
-          await git("fetch", "--depth=1", "origin", hash)
-          await git("reset", "--hard", `origin/${hash}`)
+          await git.exec("fetch", "--depth=1", "origin", hash)
+          await git.exec("reset", "--hard", `origin/${hash}`)
           // Update submodules if applicable (no-op if no submodules in repo)
-          await git("-c", "protocol.file.allow=always", "submodule", "update", "--recursive")
+          await git.exec("-c", "protocol.file.allow=always", "submodule", "update", "--recursive")
         } catch (err) {
           gitLog.error(`Failed fetching from ${url}`)
           throw new RuntimeError({
@@ -691,7 +715,7 @@ export class GitHandler extends VcsHandler {
   }
 
   async getPathInfo(log: Log, path: string, failOnPrompt = false): Promise<VcsInfo> {
-    const git = gitCli(log, path, failOnPrompt)
+    const git = new GitClient({ log, cwd: path, failOnPrompt })
 
     const output: VcsInfo = {
       branch: "",
@@ -700,8 +724,8 @@ export class GitHandler extends VcsHandler {
     }
 
     try {
-      output.branch = await getBranchName(git)
-      output.commitHash = await getLastCommitHash(git)
+      output.branch = await git.getBranchName()
+      output.commitHash = await git.getLastCommitHash()
     } catch (err) {
       if (err instanceof ChildProcessError && err.details.code !== 128) {
         throw err
@@ -709,7 +733,7 @@ export class GitHandler extends VcsHandler {
     }
 
     try {
-      output.originUrl = await getOriginUrl(git)
+      output.originUrl = await git.getOriginUrl()
     } catch (err) {
       // Just ignore if not available
       log.silly(`Tried to retrieve git remote.origin.url but encountered an error: ${err}`)

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -14,7 +14,7 @@ import { basename, dirname, join, relative, resolve } from "path"
 
 import type { TestGarden } from "../../../helpers.js"
 import { expectError, getDataDir, makeTestGarden, makeTestGardenA } from "../../../helpers.js"
-import { explainGitError, getCommitIdFromRefList, GitClient, GitHandler, parseGitUrl } from "../../../../src/vcs/git.js"
+import { explainGitError, getCommitIdFromRefList, GitCli, GitHandler, parseGitUrl } from "../../../../src/vcs/git.js"
 import type { Log } from "../../../../src/logger/log-entry.js"
 import { hashRepoUrl } from "../../../../src/util/ext-source-util.js"
 import { dedent, deline } from "../../../../src/util/string.js"
@@ -65,7 +65,7 @@ async function addToIgnore(tmpPath: string, pathToExclude: string, ignoreFilenam
   await writeFile(gardenignorePath, pathToExclude)
 }
 
-async function getGitHash(git: GitClient, path: string) {
+async function getGitHash(git: GitCli, path: string) {
   return (await git.exec("hash-object", path))[0]
 }
 
@@ -86,7 +86,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
   let garden: TestGarden
   let tmpDir: tmp.DirectoryResult
   let tmpPath: string
-  let git: GitClient
+  let git: GitCli
   let handler: GitHandler
   let log: Log
 
@@ -104,7 +104,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       ignoreFile: defaultIgnoreFilename,
       cache: garden.treeCache,
     })
-    git = new GitClient({ log, cwd: tmpPath })
+    git = new GitCli({ log, cwd: tmpPath })
   })
 
   afterEach(async () => {
@@ -809,7 +809,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
         const subPath = resolve(tmpPath, "subdir")
         await mkdirp(subPath)
 
-        const _git = new GitClient({ log, cwd: subPath })
+        const _git = new GitCli({ log, cwd: subPath })
         await _git.exec("init")
 
         const fileName = "foo"

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -14,8 +14,7 @@ import { basename, dirname, join, relative, resolve } from "path"
 
 import type { TestGarden } from "../../../helpers.js"
 import { expectError, getDataDir, makeTestGarden, makeTestGardenA } from "../../../helpers.js"
-import type { GitCli } from "../../../../src/vcs/git.js"
-import { explainGitError, getCommitIdFromRefList, gitCli, GitHandler, parseGitUrl } from "../../../../src/vcs/git.js"
+import { explainGitError, getCommitIdFromRefList, GitClient, GitHandler, parseGitUrl } from "../../../../src/vcs/git.js"
 import type { Log } from "../../../../src/logger/log-entry.js"
 import { hashRepoUrl } from "../../../../src/util/ext-source-util.js"
 import { dedent, deline } from "../../../../src/util/string.js"
@@ -66,8 +65,8 @@ async function addToIgnore(tmpPath: string, pathToExclude: string, ignoreFilenam
   await writeFile(gardenignorePath, pathToExclude)
 }
 
-async function getGitHash(git: GitCli, path: string) {
-  return (await git("hash-object", path))[0]
+async function getGitHash(git: GitClient, path: string) {
+  return (await git.exec("hash-object", path))[0]
 }
 
 type GitHandlerCls = new (params: VcsHandlerParams) => GitHandler
@@ -87,7 +86,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
   let garden: TestGarden
   let tmpDir: tmp.DirectoryResult
   let tmpPath: string
-  let git: GitCli
+  let git: GitClient
   let handler: GitHandler
   let log: Log
 
@@ -105,7 +104,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       ignoreFile: defaultIgnoreFilename,
       cache: garden.treeCache,
     })
-    git = gitCli(log, tmpPath)
+    git = new GitClient({ log, cwd: tmpPath })
   })
 
   afterEach(async () => {
@@ -123,8 +122,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
 
         await createFile(path)
         await writeFile(path, "my change")
-        await git("add", ".")
-        await git("commit", "-m", "foo")
+        await git.exec("add", ".")
+        await git.exec("commit", "-m", "foo")
 
         const hash = await getGitHash(git, path)
 
@@ -135,8 +134,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
         const path = resolve(tmpPath, "foo.txt")
 
         await createFile(path)
-        await git("add", ".")
-        await git("commit", "-m", "foo")
+        await git.exec("add", ".")
+        await git.exec("commit", "-m", "foo")
 
         await writeFile(path, "my change")
 
@@ -158,8 +157,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
 
             await createFile(filePath)
             await writeFile(filePath, "original content")
-            await git("add", ".")
-            await git("commit", "-m", "foo")
+            await git.exec("add", ".")
+            await git.exec("commit", "-m", "foo")
 
             await handler.writeFile(log, filePath, "my change")
             const beforeHash = (await handler.getFiles({ path: dirPath, scanRoot: undefined, log }))[0].hash
@@ -196,8 +195,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       it("should work with tracked files with spaces in the name", async () => {
         const path = join(tmpPath, "my file.txt")
         await createFile(path)
-        await git("add", path)
-        await git("commit", "-m", "foo")
+        await git.exec("add", path)
+        await git.exec("commit", "-m", "foo")
 
         const hash = await getGitHash(git, path)
 
@@ -207,8 +206,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       it("should work with tracked+modified files with spaces in the name", async () => {
         const path = join(tmpPath, "my file.txt")
         await createFile(path)
-        await git("add", path)
-        await git("commit", "-m", "foo")
+        await git.exec("add", path)
+        await git.exec("commit", "-m", "foo")
 
         await writeFile(path, "fooooo")
 
@@ -220,8 +219,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       it("should gracefully skip files that are deleted after having been committed", async () => {
         const filePath = join(tmpPath, "my file.txt")
         await createFile(filePath)
-        await git("add", filePath)
-        await git("commit", "-m", "foo")
+        await git.exec("add", filePath)
+        await git.exec("commit", "-m", "foo")
 
         await remove(filePath)
 
@@ -758,8 +757,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
         await createFile(path)
         await addToIgnore(tmpPath, name)
 
-        await git("add", path)
-        await git("commit", "-m", "foo")
+        await git.exec("add", path)
+        await git.exec("commit", "-m", "foo")
 
         const files = (await handler.getFiles({ path: tmpPath, scanRoot: undefined, exclude: [], log })).filter(
           (f) => !f.path.includes(defaultIgnoreFilename)
@@ -773,8 +772,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
 
         await createFile(path)
         await writeFile(path, "my change")
-        await git("add", ".")
-        await git("commit", "-m", "foo")
+        await git.exec("add", ".")
+        await git.exec("commit", "-m", "foo")
 
         const hash = await getGitHash(git, path)
 
@@ -810,8 +809,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
         const subPath = resolve(tmpPath, "subdir")
         await mkdirp(subPath)
 
-        const _git = gitCli(log, subPath)
-        await _git("init")
+        const _git = new GitClient({ log, cwd: subPath })
+        await _git.exec("init")
 
         const fileName = "foo"
         const filePath = resolve(tmpPath, fileName)
@@ -1178,9 +1177,9 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       await createFile(path)
       await writeFile(path, "iogjeiojgeowigjewoijoeiw")
       const stats = await lstat(path)
-      await git("add", path)
+      await git.exec("add", path)
 
-      const files = (await git("ls-files", "-s", path))[0]
+      const files = (await git.exec("ls-files", "-s", path))[0]
       const expected = files.split(" ")[1]
 
       const hash = await handler.hashObject(stats, path)
@@ -1194,11 +1193,11 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       await writeFile(filePath, "kfgjdslgjaslj")
 
       await symlink("foo", symlinkPath)
-      await git("add", symlinkPath)
+      await git.exec("add", symlinkPath)
 
       const stats = await lstat(symlinkPath)
 
-      const files = (await git("ls-files", "-s", symlinkPath))[0]
+      const files = (await git.exec("ls-files", "-s", symlinkPath))[0]
       const expected = files.split(" ")[1]
 
       const hash = await handler.hashObject(stats, symlinkPath)


### PR DESCRIPTION
@stefreak we discussed this yesterday. This PR introduces a standalone class that holds convenience methods for Git operations and supports arbitrary commands execution. Such approach allows to avoid passing the Git executor instance to every utility function.

Continuation of #5902.