### PR TITLE
fix(k8s): work around a rare websocket connection issue & warn

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -817,7 +817,7 @@ class PodRunnerNotFoundError extends PodRunnerError {
   }
 }
 
-class PodRunnerTimeoutError extends PodRunnerError {
+export class PodRunnerTimeoutError extends PodRunnerError {
   override type = "pod-runner-timeout"
 
   //


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a workaround for a failure mode where we receive valid skopeo JSON output via the websocket connection, which
indicates that the image exists, but we never receive the message that the command has completed, which leads to a timeout.

The skopeo command output indicates that the image exists, but the Kubernetes API did not signal command completion.
This might indicate a network problem, e.g. an issue with Path MTU discovery that leads to packets being dropped, or another problem in the client or server implementation.

We don't know what the problem is yet, it might be the client, the
server or the network in between, the kernel etc.

the Websocket client code in the Kubernetes Client library is quite complex (See https://github.com/kubernetes-client/javascript/blob/release-1.x/src/web-socket-handler.ts), and a bug in there can’t be ruled out.
I found two issues that sound relevant on GitHub:
- https://github.com/kubernetes-client/javascript/issues/714
- https://github.com/kubernetes-client/javascript/issues/478

That said, what takes me aback here is that the issue started appearing suddenly without upgrading Garden, which suggests that this is either not a bug in the client, or the client bug is shadowed by another condition we are not aware of at the moment.

