### PR TITLE
fix(git): increase max proc buffer size and fix error handling

### DIFF
--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -77,7 +77,7 @@ export function isEAddrInUseException(err: any): err is EAddrInUseException {
 }
 
 export function isExecaError(err: any): err is ExecaError {
-  return err.exitCode !== undefined
+  return err.exitCode !== undefined && err.exitCode !== null
 }
 
 export type StackTraceMetadata = {

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -17,6 +17,7 @@ import { constants } from "os"
 import dns from "node:dns"
 import { styles } from "./logger/styles.js"
 import type { ObjectPath } from "./config/base.js"
+import { ExecaError } from "execa"
 
 // Unfortunately, NodeJS does not provide a list of all error codes, so we have to maintain this list manually.
 // See https://nodejs.org/docs/latest-v18.x/api/dns.html#error-codes
@@ -73,6 +74,10 @@ export function isErrnoException(err: any): err is NodeJSErrnoException {
 
 export function isEAddrInUseException(err: any): err is EAddrInUseException {
   return isErrnoException(err) && err.code === "EADDRINUSE"
+}
+
+export function isExecaError(err: any): err is ExecaError {
+  return err.exitCode !== undefined
 }
 
 export type StackTraceMetadata = {

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -17,7 +17,7 @@ import { constants } from "os"
 import dns from "node:dns"
 import { styles } from "./logger/styles.js"
 import type { ObjectPath } from "./config/base.js"
-import { ExecaError } from "execa"
+import type { ExecaError } from "execa"
 
 // Unfortunately, NodeJS does not provide a list of all error codes, so we have to maintain this list manually.
 // See https://nodejs.org/docs/latest-v18.x/api/dns.html#error-codes

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -84,7 +84,7 @@ export function gitCli(log: Log, cwd: string, failOnPrompt = false): GitCli {
     log.silly(`Calling git with args '${args.join(" ")}' in ${cwd}`)
     const { stdout } = await exec("git", args, {
       cwd,
-      maxBuffer: 10 * 1024 * 1024,
+      maxBuffer: 100 * 1024 * 1024,
       env: failOnPrompt ? { GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "true" } : undefined,
     })
     return stdout.split("\n").filter((line) => line.length > 0)

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -138,6 +138,7 @@ export interface GetTreeVersionParams {
   projectName: string
   config: ModuleConfig | BaseActionConfig
   scanRoot?: string // Set the scanning root instead of detecting, in order to optimize the scanning.
+  force?: boolean
 }
 
 export interface RemoteSourceParams {
@@ -205,13 +206,7 @@ export abstract class VcsHandler {
     config,
     force = false,
     scanRoot,
-  }: {
-    log: Log
-    projectName: string
-    config: ModuleConfig | BaseActionConfig
-    force?: boolean
-    scanRoot?: string
-  }): Promise<TreeVersion> {
+  }: GetTreeVersionParams): Promise<TreeVersion> {
     const cacheKey = getResourceTreeCacheKey(config)
     const description = describeConfig(config)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The project scan fails with the following error for large projects:
```console
Command "git --glob-pathspecs ls-files --ignored --cached --exclude /workspace/all-the-things/.garden --exclude **/.garden/**/* --exclude-per-directory .gardenignore" failed with code undefined:

Here are the last 100 lines of the output:

// the logs have been omitted, there were no actual error details
```

We run the underlying git command with some custom options, and we have used the 10MB buffer instead of the default 100MB. That can be the cause of the problem. Let's merge it and ask the issue reporter to try out the edge build.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
