### PR TITLE
fix(sync): fix typo in warning message

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -331,7 +331,7 @@ function logMutagenDaemonWarning(log: Log) {
   log.warn(
     dedent`
     It looks like you've changed to a different version of the sync daemon and therefore the sync daemon needs to be restarted.
-    Please see our Troubleshooting docs for instructions on how to restart the daemon for your platform: ${makeDocsLinkStyled("guides/code-synchronization", "#restarting-sync-daemon")}}`
+    Please see our Troubleshooting docs for instructions on how to restart the daemon for your platform: ${makeDocsLinkStyled("guides/code-synchronization", "#restarting-sync-daemon")}`
   )
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes a `}` char in a warning message that shouldn't be there.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
