### PR TITLE
perf(vcs): cache the hashes of untracked files when possible

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -41,6 +41,7 @@ import type { AnalyticsHandler } from "../analytics/analytics.js"
 import { withSessionContext } from "../util/open-telemetry/context.js"
 import { wrapActiveSpan } from "../util/open-telemetry/spans.js"
 import { styles } from "../logger/styles.js"
+import { setUntrackedFileHashCaching } from "../vcs/git-sub-tree.js"
 
 export interface CommandConstructor {
   new (parent?: CommandGroup): Command
@@ -158,6 +159,7 @@ type DataCallback = (data: string) => void
 export type CommandArgsType<C extends Command> = C extends Command<infer Args, any> ? Args : never
 export type CommandOptionsType<C extends Command> = C extends Command<any, infer Opts> ? Opts : never
 export type CommandResultType<C extends Command> = C extends Command<any, any, infer R> ? R : never
+
 export abstract class Command<
   A extends ParameterObject = ParameterObject,
   O extends ParameterObject = ParameterObject,
@@ -268,6 +270,10 @@ export abstract class Command<
       parentSessionId,
       overrideLogLevel,
     } = params
+
+    // Do not allow untracked files' hashes caching in dev console and in persistent commands
+    const cacheUntrackedFiles = !this.maybePersistent(params) && !params.parentCommand
+    setUntrackedFileHashCaching(cacheUntrackedFiles)
 
     return withSessionContext({ sessionId, parentSessionId }, () =>
       wrapActiveSpan(this.getFullName(), async () => {


### PR DESCRIPTION
Now Garden scans all the untracked files twice:
* While looking for Garden config files
* While actions/modules resolution

For big projects with a large amount of untracked files that can cause performance downgrade.

For non-persistent commands and commands that are running outside the fev console it seems to be possible to cache the hashes of the untracked files.

Fixes #5844