### PR TITLE
improvement(support): install docker-buildx-plugin in garden Docker images

### DIFF
--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
   bash \
   curl \
   docker-cli \
+  docker-cli-buildx \
   git \
   openssl \
   rsync \

--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" > /etc/apt/sources.list.d/docker.list && \
   apt-get update && \
-  apt-get install docker-ce-cli -y
+  apt-get install docker-ce-cli docker-buildx-plugin -y
 
 ENV USER=root
 ENV HOME=/root


### PR DESCRIPTION
**What this PR does / why we need it**:
Buildx plugin will be required for Garden Cloud Builder.
