### PR TITLE
ci: use namespace remote builder for dockerhub images

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -28,6 +28,10 @@ parameters:
     UV_USE_IO_URING: "0"
 
 
+  ubuntu-vm-runner-nocache: &ubuntu-vm-runner-nocache
+    image: "ubuntu-2204:2023.10.1"
+    docker_layer_caching: false
+
   ubuntu-vm-runner: &ubuntu-vm-runner
     image: "ubuntu-2204:2023.10.1"
     docker_layer_caching: true
@@ -356,9 +360,16 @@ commands:
           path: dist
           destination: dist
 
-  update_buildx:
-    description: Update buildx to a version that supports syntax in bakefile
+  setup_namespace_builder:
+    description: Setup remote building using Namespace Remote Builder
     steps:
+      - run:
+          name: Install latest nsc and set up access to Namespace
+          command: |
+            curl -H 'CI: true' -fsSL https://get.namespace.so/cloud/install.sh | NS_ROOT=/tmp/nsc sh
+            echo 'export PATH="/tmp/nsc/bin:$PATH"' >> "$BASH_ENV" && source "$BASH_ENV"
+      
+            nsc auth exchange-circleci-token
       - run:
           name: Update buildx
           command: |
@@ -366,6 +377,11 @@ commands:
             wget -O ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.11.1/buildx-v0.11.1.linux-amd64
             echo "34927047282ef9052f57809fe94783b2dc0ab556fdd60c2c0b7f4e6e5f05a53b  ${HOME}/.docker/cli-plugins/docker-buildx" | sha256sum -c
             chmod +x ~/.docker/cli-plugins/docker-buildx
+      - run:
+        name: Install nsc remote builder
+        command: |
+          nsc docker buildx setup --background --use
+
   fail_fast:
     description: Fail the whole workflow if this job fails in the merge queue
     steps:
@@ -558,14 +574,14 @@ jobs:
 
   test-dockerhub:
     machine:
-      <<: *ubuntu-vm-runner
+      <<: *ubuntu-vm-runner-nocache
     resource_class: xlarge
     steps:
       # Only run test-dockerhub if path-filter noticed changes in ./support/*
       - when:
           condition: <<pipeline.parameters.run-test-dockerhub>>
           steps:
-            - update_buildx
+            - setup_namespace_builder
             - checkout
             # This is to copy the pre-built code from a previous step
             - *attach-workspace
@@ -581,10 +597,10 @@ jobs:
 
   dockerhub-release:
     machine:
-      <<: *ubuntu-vm-runner
+      <<: *ubuntu-vm-runner-nocache
     resource_class: xlarge
     steps:
-      - update_buildx
+      - setup_namespace_builder
       - checkout
       # This is to copy the pre-built code from a previous step
       - *attach-workspace

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -378,9 +378,9 @@ commands:
             echo "34927047282ef9052f57809fe94783b2dc0ab556fdd60c2c0b7f4e6e5f05a53b  ${HOME}/.docker/cli-plugins/docker-buildx" | sha256sum -c
             chmod +x ~/.docker/cli-plugins/docker-buildx
       - run:
-        name: Install nsc remote builder
-        command: |
-          nsc docker buildx setup --background --use
+          name: Install nsc remote builder
+          command: |
+            nsc docker buildx setup --background --use
 
   fail_fast:
     description: Fail the whole workflow if this job fails in the merge queue

--- a/support/docker-bake-test.sh
+++ b/support/docker-bake-test.sh
@@ -65,9 +65,11 @@ TEST() {
   before_each
 }
 
+docker_buildx_bake="docker buildx bake --progress=plain -f --set='*.output=type=docker' $(dirname "$0")/docker-bake.hcl"
+
 TEST "test cloud provider tool availability"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" all
+    $docker_buildx_bake all
 
   # aws
   for variant in bonsai{-alpine,-buster}{,-rootless}
@@ -99,7 +101,7 @@ TEST "test cloud provider tool availability"
 
 TEST "run all binaries"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" all
+    $docker_buildx_bake all
 
   for variant in bonsai{-alpine,-buster}{,-rootless}
     do
@@ -131,7 +133,7 @@ TEST "run all binaries"
 
 TEST "edge tags for debian"
   MAJOR_VERSION=0 MINOR_VERSION=13 PRERELEASE=edge CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" buster
+    $docker_buildx_bake buster
 
   for image in gardendev/garden{,-aws,-azure,-gcloud,-aws-gcloud,-aws-gcloud-azure}
     do
@@ -146,7 +148,7 @@ TEST "edge tags for debian"
 
 TEST "edge tags for alpine"
   MAJOR_VERSION=0 MINOR_VERSION=13 PRERELEASE=edge CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" alpine
+    $docker_buildx_bake alpine
 
   for image in gardendev/garden{,-aws,-azure,-gcloud,-aws-gcloud,-aws-gcloud-azure}
     do
@@ -161,7 +163,7 @@ TEST "edge tags for alpine"
 
 TEST "prerelase tags for debian"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 PRERELEASE=alpha1 CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" buster
+    $docker_buildx_bake buster
 
 
   for image in gardendev/garden{,-aws,-azure,-gcloud,-aws-gcloud,-aws-gcloud-azure}
@@ -179,7 +181,7 @@ TEST "prerelase tags for debian"
 
 TEST "prerelease tags for alpine"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 PRERELEASE=alpha1 CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" alpine
+    $docker_buildx_bake alpine
 
   for image in gardendev/garden{,-aws,-azure,-gcloud,-aws-gcloud,-aws-gcloud-azure}
     do
@@ -196,7 +198,7 @@ TEST "prerelease tags for alpine"
 
 TEST "production release tags for debian"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" buster
+    $docker_buildx_bake buster
 
 
   for image in gardendev/garden{,-aws,-azure,-gcloud,-aws-gcloud,-aws-gcloud-azure}
@@ -216,7 +218,7 @@ TEST "production release tags for debian"
 
 TEST "production release tags for alpine"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 CODENAME=bonsai \
-    docker buildx bake --progress=plain -f "$(dirname "$0")/docker-bake.hcl" alpine
+    $docker_buildx_bake alpine
 
   for image in gardendev/garden{,-aws,-azure,-gcloud,-aws-gcloud,-aws-gcloud-azure}
     do

--- a/support/docker-bake-test.sh
+++ b/support/docker-bake-test.sh
@@ -65,7 +65,7 @@ TEST() {
   before_each
 }
 
-docker_buildx_bake="docker buildx bake --progress=plain --set='*.output=type=docker' -f $(dirname "$0")/docker-bake.hcl"
+docker_buildx_bake="docker buildx bake --progress=plain --set=*.output=type=docker -f $(dirname "$0")/docker-bake.hcl"
 
 TEST "test cloud provider tool availability"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 CODENAME=bonsai \

--- a/support/docker-bake-test.sh
+++ b/support/docker-bake-test.sh
@@ -65,7 +65,7 @@ TEST() {
   before_each
 }
 
-docker_buildx_bake="docker buildx bake --progress=plain -f --set='*.output=type=docker' $(dirname "$0")/docker-bake.hcl"
+docker_buildx_bake="docker buildx bake --progress=plain --set='*.output=type=docker' -f $(dirname "$0")/docker-bake.hcl"
 
 TEST "test cloud provider tool availability"
   MAJOR_VERSION=0 MINOR_VERSION=13 PATCH_VERSION=0 CODENAME=bonsai \


### PR DESCRIPTION
**What this PR does / why we need it**:
Let's benefit from faster local caching using namespace builders
