### PR TITLE
chore: stricter return type in `ConfigStore.get(...)`

### DIFF
--- a/core/src/config-store/base.ts
+++ b/core/src/config-store/base.ts
@@ -7,6 +7,7 @@
  */
 
 import fsExtra from "fs-extra"
+
 const { ensureFile, readFile } = fsExtra
 import type { z, ZodType } from "zod"
 import { lock } from "proper-lockfile"
@@ -22,6 +23,7 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
   abstract schema: T
 
   abstract getConfigPath(): string
+
   protected abstract initConfig(migrate: boolean): Promise<I<T>>
 
   /**
@@ -29,8 +31,11 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
    */
   async get(): Promise<I<T>>
   async get<S extends keyof I<T>>(section: S): Promise<I<T>[S]>
-  async get<S extends keyof I<T>, K extends keyof I<T>[S]>(section: S, key: K): Promise<I<T>[S][K]>
-  async get<S extends keyof I<T>, K extends keyof I<T>[S]>(section?: S, key?: K) {
+  async get<S extends keyof I<T>, K extends keyof I<T>[S]>(section: S, key: K): Promise<I<T>[S][K] | undefined>
+  async get<S extends keyof I<T>, K extends keyof I<T>[S]>(
+    section?: S,
+    key?: K
+  ): Promise<I<T> | I<T>[S] | I<T>[S][K] | undefined> {
     const config = await this.readConfig()
     if (section === undefined) {
       return config

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -32,6 +32,7 @@ import { registerProcess } from "../../../../src/process.js"
 import { ServeCommand } from "../../../../src/commands/serve.js"
 import { GardenInstanceManager } from "../../../../src/server/instance-manager.js"
 import fsExtra from "fs-extra"
+
 const { mkdirp } = fsExtra
 import { uuidv4 } from "../../../../src/util/random.js"
 import { makeDummyGarden } from "../../../../src/garden.js"
@@ -476,7 +477,8 @@ describe("cli", () => {
         override printHeader() {}
 
         async action({ garden }: CommandParams) {
-          const record = await globalConfigStore.get("activeProcesses", String(processRecord.pid))
+          const record = (await globalConfigStore.get("activeProcesses", String(processRecord.pid)))!
+          expect(record).to.exist
 
           expect(record.command).to.equal(this.name)
           expect(record.sessionId).to.exist
@@ -530,7 +532,8 @@ describe("cli", () => {
         override printHeader() {}
 
         async action({ garden }: CommandParams) {
-          const record = await globalConfigStore.get("activeProcesses", String(processRecord.pid))
+          const record = (await globalConfigStore.get("activeProcesses", String(processRecord.pid)))!
+          expect(record).to.exist
 
           expect(record.command).to.equal(this.name)
           expect(record.sessionId).to.exist

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -5405,7 +5405,8 @@ describe("Garden", () => {
     describe("hideWarning", () => {
       it("should flag a warning key as hidden", async () => {
         await garden.hideWarning(key)
-        const record = await garden.localConfigStore.get("warnings", key)
+        const record = (await garden.localConfigStore.get("warnings", key))!
+        expect(record).to.exist
         expect(record.hidden).to.be.true
       })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The signature `get<S extends keyof I<T>, K extends keyof I<T>[S]>(section: S, key: K)` may return `undefined` because the `key` parameter is a dynamic value, that might not exist in the config store.

See `CloudApi.getStoredAuthToken()`.
It can return `undefined` and we check it in `CloudApi.factory()`.

**Which issue(s) this PR fixes**:

Prevents potential runtime `undefined`-errors.

**Special notes for your reviewer**:

I figured this out while reviewing #5502.