### PR TITLE
improvement: allow for more concurrency when using cloud builder

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -646,6 +646,31 @@ export abstract class BaseAction<
     })
   }
 
+  get statusConcurrencyLimit(): number | undefined {
+    return this._config.internal.statusConcurrencyLimit
+  }
+
+  /**
+   * Allows plugins to control the concurrency limit of action status task nodes.
+   *
+   * Falls back to default concurrency limit defined in the Task class.
+   */
+  set statusConcurrencyLimit(limit: number | undefined) {
+    this._config.internal.statusConcurrencyLimit = limit
+  }
+
+  /**
+   * Allows plugins to control the concurrency limit of action execution task nodes.
+   *
+   * Falls back to default concurrency limit defined in the Task class.
+   */
+  set executeConcurrencyLimit(limit: number | undefined) {
+    this._config.internal.executeConcurrencyLimit = limit
+  }
+  get executeConcurrencyLimit(): number | undefined {
+    return this._config.internal.executeConcurrencyLimit
+  }
+
   abstract getExecuteTask(baseParams: Omit<BaseActionTaskParams, "action">): ExecuteTask
 }
 

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -69,6 +69,9 @@ export interface BaseActionConfig<K extends ActionKind = ActionKind, T = string,
     remoteClonePath?: string
     moduleName?: string
     moduleVersion?: ModuleVersion
+
+    statusConcurrencyLimit?: number
+    executeConcurrencyLimit?: number
   }
 
   // Flow/execution control

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -215,7 +215,7 @@ export interface TaskRequestParams<T extends Task = Task> extends TaskNodeParams
 
 @Profile()
 export class RequestTaskNode<TaskType extends Task = Task> extends TaskNode<TaskType> {
-  executionType = "request" as NodeType
+  executionType: NodeType = "request"
 
   override get concurrencyLimit() {
     return gardenEnv.GARDEN_HARD_CONCURRENCY_LIMIT
@@ -267,7 +267,7 @@ export class RequestTaskNode<TaskType extends Task = Task> extends TaskNode<Task
 
 @Profile()
 export class ProcessTaskNode<T extends Task = Task> extends TaskNode<T> {
-  executionType = "process" as NodeType
+  executionType: NodeType = "process"
 
   override get concurrencyLimit() {
     return this.task.executeConcurrencyLimit
@@ -342,7 +342,7 @@ export class ProcessTaskNode<T extends Task = Task> extends TaskNode<T> {
 
 @Profile()
 export class StatusTaskNode<T extends Task = Task> extends TaskNode<T> {
-  executionType = "status" as NodeType
+  executionType: NodeType = "status"
 
   override get concurrencyLimit() {
     return this.task.statusConcurrencyLimit

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -14,6 +14,7 @@ import type { GraphSolver } from "./solver.js"
 import { metadataForLog } from "./common.js"
 import { Profile } from "../util/profiling.js"
 import { styles } from "../logger/styles.js"
+import { gardenEnv } from "../constants.js"
 
 export interface InternalNodeTypes {
   status: StatusTaskNode
@@ -36,11 +37,13 @@ export interface TaskNodeParams<T extends Task> {
 @Profile()
 export abstract class TaskNode<T extends Task = Task> {
   abstract readonly executionType: NodeType
-
   public readonly type: string
   public startedAt?: Date
   public readonly task: T
   public readonly statusOnly: boolean
+
+  public abstract readonly concurrencyLimit: number
+  public abstract readonly concurrencyGroupKey: string
 
   protected solver: GraphSolver
   protected dependants: { [key: string]: TaskNode }
@@ -212,8 +215,15 @@ export interface TaskRequestParams<T extends Task = Task> extends TaskNodeParams
 
 @Profile()
 export class RequestTaskNode<TaskType extends Task = Task> extends TaskNode<TaskType> {
-  // FIXME: this is a bit of a TS oddity, but it does work...
-  executionType = <NodeType>"request"
+  executionType = "request" as NodeType
+
+  override get concurrencyLimit() {
+    return gardenEnv.GARDEN_HARD_CONCURRENCY_LIMIT
+  }
+
+  override get concurrencyGroupKey() {
+    return this.executionType
+  }
 
   public readonly requestedAt: Date
   public readonly batchId: string
@@ -257,7 +267,20 @@ export class RequestTaskNode<TaskType extends Task = Task> extends TaskNode<Task
 
 @Profile()
 export class ProcessTaskNode<T extends Task = Task> extends TaskNode<T> {
-  executionType = <NodeType>"process"
+  executionType = "process" as NodeType
+
+  override get concurrencyLimit() {
+    return this.task.executeConcurrencyLimit
+  }
+
+  /**
+   * Tasks with different limits will be grouped in separate concurrency groups.
+   *
+   * E.g. if 50 build tasks have limit of 5, and 30 build tasks have limit of 10, then 15 build tasks will execute concurrently.
+   */
+  override get concurrencyGroupKey() {
+    return `${this.executionType}-${this.task.type}-${this.task.executeConcurrencyLimit}`
+  }
 
   describe() {
     return `processing ${this.task.getDescription()}`
@@ -319,7 +342,20 @@ export class ProcessTaskNode<T extends Task = Task> extends TaskNode<T> {
 
 @Profile()
 export class StatusTaskNode<T extends Task = Task> extends TaskNode<T> {
-  executionType = <NodeType>"status"
+  executionType = "status" as NodeType
+
+  override get concurrencyLimit() {
+    return this.task.statusConcurrencyLimit
+  }
+
+  /**
+   * Tasks with different limits will be grouped in separate concurrency groups.
+   *
+   * E.g. if 50 build tasks have limit of 5, and 30 build tasks have limit of 10, then 15 build tasks will execute concurrently.
+   */
+  override get concurrencyGroupKey() {
+    return `${this.executionType}-${this.task.type}-${this.task.executeConcurrencyLimit}`
+  }
 
   describe() {
     return `resolving status for ${this.task.getDescription()}`

--- a/core/src/graph/solver.ts
+++ b/core/src/graph/solver.ts
@@ -312,10 +312,10 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
       const inProgressByGroup = groupBy(inProgressNodes, "type")
 
       // Enforce concurrency limits per task type
-      const grouped = groupBy(pending, (n) => n.task.type)
+      const grouped = groupBy(pending, (n) => n.concurrencyGroupKey)
       const limitedByGroup = Object.values(grouped).flatMap((nodes) => {
         // Note: We can be sure there is at least one node in the array
-        const groupLimit = nodes[0].task.concurrencyLimit
+        const groupLimit = nodes[0].concurrencyLimit
         const inProgress = inProgressByGroup[nodes[0].type] || []
         return nodes.slice(0, groupLimit - inProgress.length)
       })

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -38,7 +38,7 @@ const cloudBuilderAvailability = new LRUCache<string, CloudBuilderAvailability>(
 
 // public API
 export const cloudbuilder = {
-  async isConfiguredAndAvailable(ctx: PluginContext, action: Resolved<ContainerBuildAction>) {
+  isConfigured(ctx: PluginContext): boolean {
     const { isCloudBuilderEnabled } = getConfiguration(ctx)
     if (!isCloudBuilderEnabled) {
       return false
@@ -55,8 +55,15 @@ export const cloudbuilder = {
       return false
     }
 
-    const availability = await getAvailability(ctx, action)
+    return true
+  },
 
+  async isConfiguredAndAvailable(ctx: PluginContext, action: Resolved<ContainerBuildAction>) {
+    if (!cloudbuilder.isConfigured(ctx)) {
+      return false
+    }
+
+    const availability = await getAvailability(ctx, action)
     return availability.available
   },
 

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -48,6 +48,9 @@ import { kubernetesPodRunDefinition, kubernetesPodTestDefinition } from "./kuber
 import { kubernetesExecRunDefinition, kubernetesExecTestDefinition } from "./kubernetes-type/kubernetes-exec.js"
 import { makeDocsLinkPlain, makeDocsLinkStyled } from "../../docs/common.js"
 
+export const CONTAINER_BUILD_CONCURRENCY_LIMIT_REMOTE_KUBERNETES = 5
+export const CONTAINER_STATUS_CONCURRENCY_LIMIT_REMOTE_KUBERNETES = 20
+
 export async function configureProvider({
   namespace,
   projectName,

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -107,8 +107,19 @@ interface TaskEvents<O extends ValidResultType> {
 export abstract class BaseTask<O extends ValidResultType = ValidResultType> extends TypedEventEmitter<TaskEvents<O>> {
   abstract type: string
 
-  // How many tasks of this exact type are allowed to run concurrently
-  concurrencyLimit = 10
+  /**
+   * How many execute task nodes of this exact type are allowed to run concurrently
+   *
+   * Children can override this to set a custom concurrency limit.
+   */
+  abstract executeConcurrencyLimit: number
+
+  /**
+   * How many get-status task nodes of this exact type are allowed to run concurrently
+   *
+   * Children can override this to set a custom concurrency limit.
+   */
+  abstract statusConcurrencyLimit: number
 
   public readonly garden: Garden
   public readonly log: Log
@@ -624,6 +635,17 @@ export abstract class ExecuteActionTask<
   },
 > extends BaseActionTask<T, O & ExecuteActionOutputs<T>> {
   override executeTask = true
+  protected defaultExecuteConcurrencyLimit = 10
+  protected defaultStatusConcurrencyLimit = 10
+
+  override get executeConcurrencyLimit(): number {
+    return this.action.executeConcurrencyLimit || this.defaultExecuteConcurrencyLimit
+  }
+
+  override get statusConcurrencyLimit(): number {
+    return this.action.statusConcurrencyLimit || this.defaultStatusConcurrencyLimit
+  }
+
   abstract override type: Lowercase<T["kind"]>
 
   abstract override getStatus(params: ActionTaskStatusParams<T>): Promise<O & ExecuteActionOutputs<T>>

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -20,7 +20,8 @@ import { wrapActiveSpan } from "../util/open-telemetry/spans.js"
 @Profile()
 export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
   type = "build" as const
-  override concurrencyLimit = 5
+  override defaultStatusConcurrencyLimit = 5
+  override defaultExecuteConcurrencyLimit = 5
   eventName = "buildStatus" as const
 
   getDescription() {

--- a/core/src/tasks/delete-deploy.ts
+++ b/core/src/tasks/delete-deploy.ts
@@ -27,7 +27,9 @@ export interface DeleteDeployTaskParams extends BaseActionTaskParams<DeployActio
 
 export class DeleteDeployTask extends BaseActionTask<DeployAction, DeployStatus> {
   type = "delete-deploy"
-  override concurrencyLimit = 10
+  override executeConcurrencyLimit = 10
+  override statusConcurrencyLimit = 10
+
   dependantsFirst: boolean
   deleteDeployNames: string[]
 

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -32,7 +32,8 @@ function printIngresses(status: DeployStatus, log: ActionLog) {
 @Profile()
 export class DeployTask extends ExecuteActionTask<DeployAction, DeployStatus> {
   type = "deploy" as const
-  override concurrencyLimit = 10
+  override defaultStatusConcurrencyLimit = 10
+  override defaultExecuteConcurrencyLimit = 10
 
   events?: PluginEventBroker
   startSync: boolean

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -28,7 +28,8 @@ export interface PublishTaskParams extends BaseActionTaskParams<BuildAction> {
 
 export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult> {
   type = "publish"
-  override concurrencyLimit = 5
+  override executeConcurrencyLimit = 5
+  override statusConcurrencyLimit = 5
 
   /**
    * Only defined if --tag option is used in the garden publish command.

--- a/core/src/tasks/resolve-action.ts
+++ b/core/src/tasks/resolve-action.ts
@@ -40,6 +40,10 @@ export interface ResolveActionResults<T extends Action> extends ValidResultType 
 export class ResolveActionTask<T extends Action> extends BaseActionTask<T, ResolveActionResults<T>> {
   type = "resolve-action"
 
+  // TODO: resolving template strings is CPU bound, does single-threaded concurrent execution make it faster or slower?
+  override executeConcurrencyLimit = 10
+  override statusConcurrencyLimit = 10
+
   getDescription() {
     return `resolve ${this.action.longDescription()}`
   }

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -75,7 +75,8 @@ const defaultCacheTtl = 3600 // 1 hour
 @Profile()
 export class ResolveProviderTask extends BaseTask<Provider> {
   type = "resolve-provider"
-  override concurrencyLimit = 20
+  override statusConcurrencyLimit = 20
+  override executeConcurrencyLimit = 20
 
   private config: GenericProviderConfig
   private plugin: GardenPluginSpec

--- a/core/test/unit/src/graph/solver.ts
+++ b/core/test/unit/src/graph/solver.ts
@@ -40,6 +40,9 @@ interface TestTaskResult extends ValidResultType {
 // TODO-G2: Implement equivalent test cases for the new graph
 
 export class TestTask extends BaseTask<TestTaskResult> {
+  override statusConcurrencyLimit = 10
+  override executeConcurrencyLimit = 10
+
   type = "test"
 
   name: string

--- a/core/test/unit/src/tasks/base.ts
+++ b/core/test/unit/src/tasks/base.ts
@@ -25,6 +25,9 @@ describe("BaseActionTask", () => {
   const projectRoot = getDataDir("test-project-test-deps")
 
   class TestTask extends BaseActionTask<TestAction, ValidResultType> {
+    override statusConcurrencyLimit = 10
+    override executeConcurrencyLimit = 10
+
     type = "test"
 
     getDescription() {

--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -224,6 +224,9 @@ export type PulumiCommandResult = ValidResultType
 
 @Profile()
 class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiCommandResult> {
+  override statusConcurrencyLimit: number
+  override executeConcurrencyLimit: number
+
   pulumiParams: PulumiBaseParams
   commandName: string
   commandDescription: string
@@ -256,7 +259,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
     this.runFn = runFn
     this.pulumiParams = pulumiParams
     const provider = <PulumiProvider>pulumiParams.ctx.provider
-    this.concurrencyLimit = provider.config.pluginTaskConcurrencyLimit
+    this.statusConcurrencyLimit = this.executeConcurrencyLimit = provider.config.pluginTaskConcurrencyLimit
     this.resolvedProviders = resolvedProviders
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Allow more fine-grained status and execute task node concurrency control in the
plugins using setters on the action.
- Assign concurrency group by node execution type (status, execute), action type
(exec, container) and the concurrency setting (assuming that actions with a separate
max concurrency setting are a different workload class).
- Fine-tune the build concurrency settings in the container and kubernetes plugins in the
`validate` and `getStatus` handlers for every action.
- This speeds up `garden build -f` in an internal project from ~40 seconds to ~14 seconds.

