### PR TITLE
refactor(commands): make `Command.parent` field accessible

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -195,7 +195,7 @@ export abstract class Command<
   // E.g: const cmd = new Command(); cmd["parent"] = parentCommand.
   // This is so that commands that are initialised via arguments can be cloned which is required
   // for the websocket server to work properly.
-  private parent?: CommandGroup
+  parent?: CommandGroup
 
   // FIXME: This is a little hack so that we can clone commands that are initialised with
   // arbitrary parameters.
@@ -558,7 +558,7 @@ export abstract class Command<
     // See: https://stackoverflow.com/a/64638986
     const clone = new (this.constructor as new (params?: any) => this)(this._params)
     if (this.parent) {
-      clone["parent"] = this.parent
+      clone.parent = this.parent
     }
     return clone
   }
@@ -648,7 +648,7 @@ export abstract class CommandGroup extends Command {
   getSubCommands(): Command[] {
     return this.subCommands.flatMap((cls) => {
       const cmd = new cls()
-      cmd["parent"] = this
+      cmd.parent = this
       if (cmd instanceof CommandGroup) {
         return cmd.getSubCommands()
       } else {

--- a/core/test/unit/src/commands/base.ts
+++ b/core/test/unit/src/commands/base.ts
@@ -124,7 +124,7 @@ describe("Command", () => {
 
       const cmd = new TestCommand(new TestGroup())
       // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
-      cmd["parent"] = new TestGroup()
+      cmd.parent = new TestGroup()
       expect(cmd.getPaths()).to.eql([["test-group", "test-command"]])
     })
 
@@ -150,7 +150,7 @@ describe("Command", () => {
 
       const cmd = new TestCommand(new TestGroup())
       // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
-      cmd["parent"] = new TestGroup()
+      cmd.parent = new TestGroup()
       expect(cmd.getPaths()).to.eql([
         ["test-group", "test-command"],
         ["group-alias", "test-command"],
@@ -179,7 +179,7 @@ describe("Command", () => {
 
       const cmd = new TestCommand(new TestGroup())
       // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
-      cmd["parent"] = new TestGroup()
+      cmd.parent = new TestGroup()
       expect(cmd.getPaths()).to.eql([
         ["test-group", "test-command"],
         ["test-group", "command-alias"],
@@ -209,7 +209,7 @@ describe("Command", () => {
 
       const cmd = new TestCommand(new TestGroup())
       // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
-      cmd["parent"] = new TestGroup()
+      cmd.parent = new TestGroup()
       expect(cmd.getPaths()).to.eql([
         ["test-group", "test-command"],
         ["test-group", "command-alias"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Just a minor refactoring a.k.a. code tidying.