### PR TITLE
fix(cli): do not render hidden commands

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -109,6 +109,7 @@ export class GardenCli {
   async renderHelp(log: Log, workingDir: string) {
     const commands = Object.values(this.commands)
       .sort()
+      .filter((cmd) => !cmd.hidden)
       .filter((cmd) => cmd.getPath().length === 1)
 
     // `dedent` has a bug where it doesn't indent correctly

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -605,6 +605,10 @@ export abstract class Command<
   }
 
   renderHelp() {
+    if (this.hidden) {
+      return ""
+    }
+
     let out = this.description
       ? `\n${cliStyles.heading("DESCRIPTION")}\n\n${styles.secondary(this.description.trim())}\n\n`
       : ""
@@ -674,7 +678,11 @@ export abstract class CommandGroup extends Command {
   }
 
   override renderHelp() {
-    const commands = this.getSubCommands()
+    const commands = this.getSubCommands().filter((cmd) => !cmd.hidden)
+
+    if (commands.length === 0) {
+      return ""
+    }
 
     return `
 ${cliStyles.heading("USAGE")}

--- a/core/src/commands/set.ts
+++ b/core/src/commands/set.ts
@@ -34,6 +34,7 @@ export class SetDefaultEnvCommand extends Command<SetDefaultEnvArgs, {}> {
   name = "default-env"
 
   help = "Locally override the default environment for the project."
+  override hidden = true
 
   override description = dedent`
     Override the default environment for the project for this working copy.

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -1177,6 +1177,45 @@ describe("cli", () => {
     })
   })
 
+  describe("renderHelp", () => {
+    it("should skip hidden commands", async () => {
+      class TestCommand extends Command {
+        name = "test-command"
+        help = "halp!"
+        override noProject = true
+
+        override printHeader() {}
+
+        async action({ args }) {
+          return { result: { args } }
+        }
+      }
+      class HiddenTestCommand extends Command {
+        name = "hidden-test-command"
+        help = "halp!"
+        override noProject = true
+        override hidden = true
+
+        override printHeader() {}
+
+        async action({ args }) {
+          return { result: { args } }
+        }
+      }
+
+      const cmd = new TestCommand()
+      const hiddenCmd = new HiddenTestCommand()
+      cli.addCommand(cmd)
+      cli.addCommand(hiddenCmd)
+
+      const { code, consoleOutput } = await cli.run({ args: ["--help"], exitOnError: false })
+
+      expect(code).to.equal(0)
+      expect(consoleOutput).to.include("test-command")
+      expect(consoleOutput).to.not.include("hidden-test-command")
+    })
+  })
+
   describe("makeDummyGarden", () => {
     it("should initialise and resolve config graph in a directory with no project", async () => {
       const path = join(GARDEN_CORE_ROOT, "tmp", "foobarbas")

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -4986,30 +4986,6 @@ Examples:
 Note! If you use a non-stable version (i.e. pre-release, or draft, or edge), then the latest possible major version will be installed.
 
 
-### garden set default-env
-
-**Locally override the default environment for the project.**
-
-Override the default environment for the project for this working copy.
-
-Examples:
-
-  garden set default-env remote       # Set the default env to remote (with the configured default namespace)
-  garden set default-env dev.my-env   # Set the default env to dev.my-env
-  garden set default-env              # Clear any previously set override
-
-#### Usage
-
-    garden set default-env [env] 
-
-#### Arguments
-
-| Argument | Required | Description |
-| -------- | -------- | ----------- |
-  | `env` | No | The default environment to set for the current project
-
-
-
 ### garden sync start
 
 **Start any configured syncs to the given Deploy action(s).**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, hidden commands (and subcommands) were visible when running the help command and in our docs.

This fixes that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
