### PR TITLE
ci(build-dist): use the latest stable pair of Rust and Cross

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -296,7 +296,8 @@ commands:
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
 
             # Cargo builds the other targets in Docker
-            cargo install cross --git https://github.com/cross-rs/cross
+            # Install the latest stable version of Cross
+            cargo install cross --git https://github.com/cross-rs/cross#v0.2.5
 
   run_npm_dist:
     description: Package built code into executables and persist to dist directory

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -295,8 +295,15 @@ commands:
             source "$HOME/.cargo/env"
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
 
+            # TODO: use the latest stable Rust version and apply the necessary fixes for the Windows build
+            # See the requirements change in https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html
+            RUST_VERSION="1.77.2"
+            rustup install $RUST_VERSION
+            rustup default $RUST_VERSION
+
             # Cargo builds the other targets in Docker
             # Install the latest stable version of Cross
+            # Make sure it's compatible with the Rust version installed above
             cargo install cross --git https://github.com/cross-rs/cross#v0.2.5
 
   run_npm_dist:


### PR DESCRIPTION
**What this PR does / why we need it**:

Our CI builds started failing at the [`build-dist-linux-windows` step](https://app.circleci.com/pipelines/github/garden-io/garden/24667/workflows/0006be7a-19c4-45d6-a1ba-b215b178f62b/jobs/508315) a few days ago.

That step uses Cross for cross-platform binary compilation.

It looks like [ghcr.io/cross-rs/x86_64-pc-windows-gnu:main](http://ghcr.io/cross-rs/x86_64-pc-windows-gnu:main) was published 5 days ago as an edge version.

The latest stable one is `0.2.5`: https://github.com/cross-rs/cross/pkgs/container/x86_64-pc-windows-gnu
and it was published about a year ago.

So, now our CI downloads the edge release as it can be seen from the [CI logs](https://app.circleci.com/pipelines/github/garden-io/garden/24667/workflows/0006be7a-19c4-45d6-a1ba-b215b178f62b/jobs/508315):
```
Digest: sha256:7a142695d4d4ceb49d7c44588ff6846e749fc5a3951e550b33508fd0b761b86a
Status: Downloaded newer image for ghcr.io/cross-rs/x86_64-pc-windows-gnu:main
```

Maybe, the edge release was published accidentally, because we haven't had any issues like that for a while. Or, there could be some breaking changes in the Cross in the last few days.

Another issue is the Rust `1.78.0` compatibility with Windows, see https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html

As a quick-fix, let's stick to the last known pair of working Rust and Cross versions:
* Cross `v0.2.5` (currently, it's the latest available stable version)
* Rust `1.77.2` (has less strict Windows compatibility requirements than `1.78.0`)

**This PR fixes the CI and unblocks the upcoming PRs and releases.**