### PR TITLE
revert: chore(deps-dev): bump markdown-link-check from 3.11.2 to 3.12…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "husky": "^4.2.5",
         "inquirer": "^8.2.6",
         "lodash-es": "^4.17.21",
-        "markdown-link-check": "^3.12.1",
+        "markdown-link-check": "^3.11.2",
         "minimatch": "^3.0.4",
         "minimist": "^1.2.6",
         "node-jsonl": "^0.1.0",
@@ -34512,20 +34512,18 @@
       "license": "MIT"
     },
     "node_modules/markdown-link-check": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.12.1.tgz",
-      "integrity": "sha512-qjaopy0tcZFKMhr+wAOQf7KyValRXygTOaZQ3Ka1rf+nyObIUdU9hUVY93gYysz8+hx92YnXnKh1dmNRPO/5bA==",
+      "version": "3.11.2",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "async": "^3.2.5",
+        "async": "^3.2.4",
         "chalk": "^5.2.0",
         "commander": "^10.0.1",
-        "link-check": "^5.3.0",
+        "link-check": "^5.2.0",
         "lodash": "^4.17.21",
-        "markdown-link-extractor": "^4.0.2",
-        "needle": "^3.3.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0"
+        "markdown-link-extractor": "^3.1.0",
+        "needle": "^3.2.0",
+        "progress": "^2.0.3"
       },
       "bin": {
         "markdown-link-check": "markdown-link-check"
@@ -34540,23 +34538,20 @@
       }
     },
     "node_modules/markdown-link-check/node_modules/link-check": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/link-check/-/link-check-5.3.0.tgz",
-      "integrity": "sha512-Jhb7xueDgQgBaZzkfOtAyOZEZAIMJQIjUpYD2QY/zEB+LKTY1tWiBwZg8QIDbzQdPBOcqzg7oLQDNcES/tQmXg==",
+      "version": "5.2.0",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-relative-url": "^4.0.0",
         "isemail": "^3.2.0",
         "ms": "^2.1.3",
-        "needle": "^3.3.1",
-        "proxy-agent": "^6.4.0"
+        "needle": "^3.1.0"
       }
     },
     "node_modules/markdown-link-check/node_modules/link-check/node_modules/is-relative-url": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-4.0.0.tgz",
-      "integrity": "sha512-PkzoL1qKAYXNFct5IKdKRH/iBQou/oCC85QhXj6WKtUQBliZ4Yfd3Zk27RHu9KQG8r6zgvAA2AQKC9p+rqTszg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-absolute-url": "^4.0.1"
       },
@@ -34569,9 +34564,8 @@
     },
     "node_modules/markdown-link-check/node_modules/link-check/node_modules/is-relative-url/node_modules/is-absolute-url": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -34581,9 +34575,8 @@
     },
     "node_modules/markdown-link-check/node_modules/link-check/node_modules/isemail": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "punycode": "2.x.x"
       },
@@ -34593,18 +34586,16 @@
     },
     "node_modules/markdown-link-check/node_modules/link-check/node_modules/isemail/node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/markdown-link-check/node_modules/link-check/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-link-check/node_modules/lodash": {
       "version": "4.17.21",
@@ -34612,29 +34603,26 @@
       "license": "MIT"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-4.0.2.tgz",
-      "integrity": "sha512-5cUOu4Vwx1wenJgxaudsJ8xwLUMN7747yDJX3V/L7+gi3e4MsCm7w5nbrDQQy8nEfnl4r5NV3pDXMAjhGXYXAw==",
+      "version": "3.1.0",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "html-link-extractor": "^1.0.5",
-        "marked": "^12.0.1"
+        "marked": "^4.1.0"
       }
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/html-link-extractor/-/html-link-extractor-1.0.5.tgz",
-      "integrity": "sha512-ADd49pudM157uWHwHQPUSX4ssMsvR/yHIswOR5CUfBdK9g9ZYGMhVSE6KZVHJ6kCkR0gH4htsfzU6zECDNVwyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10"
       }
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -34653,9 +34641,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/cheerio-select": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -34670,15 +34657,13 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/cheerio-select/node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/cheerio-select/node_modules/css-select": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -34692,9 +34677,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/cheerio-select/node_modules/css-select/node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -34704,9 +34688,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/cheerio-select/node_modules/css-what": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -34716,21 +34699,19 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/cheerio-select/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -34742,21 +34723,19 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/dom-serializer/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/dom-serializer/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -34766,9 +34745,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -34781,21 +34759,19 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/domhandler/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/domutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -34807,20 +34783,17 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/domutils/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/htmlparser2": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -34829,6 +34802,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -34838,21 +34812,19 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/htmlparser2/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/htmlparser2/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -34862,9 +34834,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/parse5": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -34874,9 +34845,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
@@ -34887,9 +34857,8 @@
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/html-link-extractor/node_modules/cheerio/node_modules/parse5/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -34898,23 +34867,22 @@
       }
     },
     "node_modules/markdown-link-check/node_modules/markdown-link-extractor/node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "version": "4.3.0",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 12"
       }
     },
     "node_modules/markdown-link-check/node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "version": "3.2.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "debug": "^3.2.6",
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
       },
@@ -34925,11 +34893,23 @@
         "node": ">= 4.4.x"
       }
     },
+    "node_modules/markdown-link-check/node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/needle/node_modules/debug/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/markdown-link-check/node_modules/needle/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -34939,15 +34919,13 @@
     },
     "node_modules/markdown-link-check/node_modules/needle/node_modules/iconv-lite/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-link-check/node_modules/needle/node_modules/sax": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/markdown-link-check/node_modules/progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "husky": "^4.2.5",
     "inquirer": "^8.2.6",
     "lodash-es": "^4.17.21",
-    "markdown-link-check": "^3.12.1",
+    "markdown-link-check": "^3.11.2",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.6",
     "node-jsonl": "^0.1.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts the `markdown-link-check` version update made in #5986.

Versions `3.12.0` and `3.12.1` has some regression that causes issues with anchor links, see https://github.com/tcort/markdown-link-check/issues/304 for details.

It causes false-positive failures of our `check-docs` CI step quite often, see e.g. https://app.circleci.com/pipelines/github/garden-io/garden/24696/workflows/c8833bc1-39cb-4b81-88c0-3a8d27c450b5/jobs/509277.

Reverting the `markdown-link-check` to the last known working version. Let's follow up on the original issue.