### PR TITLE
chore(deps): update Python deps in tests and examples

### DIFF
--- a/core/test/data/test-projects/helm/api-image/Dockerfile
+++ b/core/test/data/test-projects/helm/api-image/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 
 # Install our requirements.txt
 ADD requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/core/test/data/test-projects/helm/api-image/Dockerfile
+++ b/core/test/data/test-projects/helm/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/core/test/data/test-projects/helm/api-image/Dockerfile
+++ b/core/test/data/test-projects/helm/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/core/test/data/test-projects/helm/api-image/requirements.txt
+++ b/core/test/data/test-projects/helm/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/core/test/data/test-projects/helm/api-image/requirements.txt
+++ b/core/test/data/test-projects/helm/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/core/test/data/test-projects/kubernetes-type/api-image/Dockerfile
+++ b/core/test/data/test-projects/kubernetes-type/api-image/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 
 # Install our requirements.txt
 ADD requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/core/test/data/test-projects/kubernetes-type/api-image/Dockerfile
+++ b/core/test/data/test-projects/kubernetes-type/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/core/test/data/test-projects/kubernetes-type/api-image/Dockerfile
+++ b/core/test/data/test-projects/kubernetes-type/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/core/test/data/test-projects/kubernetes-type/api-image/requirements.txt
+++ b/core/test/data/test-projects/kubernetes-type/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/core/test/data/test-projects/kubernetes-type/api-image/requirements.txt
+++ b/core/test/data/test-projects/kubernetes-type/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/e2e/projects/vote-helm-modules/api-image/Dockerfile
+++ b/e2e/projects/vote-helm-modules/api-image/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 
 # Install our requirements.txt
 ADD requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/e2e/projects/vote-helm-modules/api-image/Dockerfile
+++ b/e2e/projects/vote-helm-modules/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/e2e/projects/vote-helm-modules/api-image/Dockerfile
+++ b/e2e/projects/vote-helm-modules/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/e2e/projects/vote-helm-modules/api-image/requirements.txt
+++ b/e2e/projects/vote-helm-modules/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/e2e/projects/vote-helm-modules/api-image/requirements.txt
+++ b/e2e/projects/vote-helm-modules/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/e2e/projects/vote-modules/api/Dockerfile
+++ b/e2e/projects/vote-modules/api/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 
 # Install our requirements.txt
 ADD requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/e2e/projects/vote-modules/api/Dockerfile
+++ b/e2e/projects/vote-modules/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/e2e/projects/vote-modules/api/Dockerfile
+++ b/e2e/projects/vote-modules/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/e2e/projects/vote-modules/api/requirements.txt
+++ b/e2e/projects/vote-modules/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/e2e/projects/vote-modules/api/requirements.txt
+++ b/e2e/projects/vote-modules/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-config-templates/api/Dockerfile
+++ b/examples/k8s-deploy-config-templates/api/Dockerfile
@@ -8,6 +8,10 @@ RUN apk add --no-cache entr postgresql-dev musl-dev gcc
 
 # Install our requirements.txt
 COPY requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/examples/k8s-deploy-config-templates/api/Dockerfile
+++ b/examples/k8s-deploy-config-templates/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/k8s-deploy-config-templates/api/Dockerfile
+++ b/examples/k8s-deploy-config-templates/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/k8s-deploy-config-templates/api/requirements.txt
+++ b/examples/k8s-deploy-config-templates/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-config-templates/api/requirements.txt
+++ b/examples/k8s-deploy-config-templates/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-config-templates/api/requirements.txt
+++ b/examples/k8s-deploy-config-templates/api/requirements.txt
@@ -2,4 +2,6 @@ Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1
+requests==2.31.0
+urllib3==1.26.17
 psycopg2

--- a/examples/k8s-deploy-patch-resources/api/Dockerfile
+++ b/examples/k8s-deploy-patch-resources/api/Dockerfile
@@ -8,6 +8,10 @@ RUN apk add --no-cache entr postgresql-dev musl-dev gcc
 
 # Install our requirements.txt
 COPY requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/examples/k8s-deploy-patch-resources/api/Dockerfile
+++ b/examples/k8s-deploy-patch-resources/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/k8s-deploy-patch-resources/api/Dockerfile
+++ b/examples/k8s-deploy-patch-resources/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/k8s-deploy-patch-resources/api/requirements.txt
+++ b/examples/k8s-deploy-patch-resources/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-patch-resources/api/requirements.txt
+++ b/examples/k8s-deploy-patch-resources/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-patch-resources/api/requirements.txt
+++ b/examples/k8s-deploy-patch-resources/api/requirements.txt
@@ -2,4 +2,6 @@ Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1
+requests==2.31.0
+urllib3==1.26.17
 psycopg2

--- a/examples/k8s-deploy-shared-manifests/api/Dockerfile
+++ b/examples/k8s-deploy-shared-manifests/api/Dockerfile
@@ -8,6 +8,10 @@ RUN apk add --no-cache entr postgresql-dev musl-dev gcc
 
 # Install our requirements.txt
 COPY requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/examples/k8s-deploy-shared-manifests/api/Dockerfile
+++ b/examples/k8s-deploy-shared-manifests/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/k8s-deploy-shared-manifests/api/Dockerfile
+++ b/examples/k8s-deploy-shared-manifests/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/k8s-deploy-shared-manifests/api/requirements.txt
+++ b/examples/k8s-deploy-shared-manifests/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-shared-manifests/api/requirements.txt
+++ b/examples/k8s-deploy-shared-manifests/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/k8s-deploy-shared-manifests/api/requirements.txt
+++ b/examples/k8s-deploy-shared-manifests/api/requirements.txt
@@ -2,4 +2,6 @@ Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1
+requests==2.31.0
+urllib3==1.26.17
 psycopg2

--- a/examples/vote-helm/api-image/Dockerfile
+++ b/examples/vote-helm/api-image/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 
 # Install our requirements.txt
 ADD requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/examples/vote-helm/api-image/Dockerfile
+++ b/examples/vote-helm/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/vote-helm/api-image/Dockerfile
+++ b/examples/vote-helm/api-image/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/vote-helm/api-image/requirements.txt
+++ b/examples/vote-helm/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/vote-helm/api-image/requirements.txt
+++ b/examples/vote-helm/api-image/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/vote/api/Dockerfile
+++ b/examples/vote/api/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 
 # Install our requirements.txt
 ADD requirements.txt /app/requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+
 RUN pip install -r requirements.txt
 
 # Copy our code from the current folder to /app inside the container

--- a/examples/vote/api/Dockerfile
+++ b/examples/vote/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.10.5-alpine3.16
+FROM python:3.11-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/vote/api/Dockerfile
+++ b/examples/vote/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:3.11-alpine3.19
+FROM python:3.12-alpine3.19
 
 # Set the application directory
 WORKDIR /app

--- a/examples/vote/api/requirements.txt
+++ b/examples/vote/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==2.3.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1

--- a/examples/vote/api/requirements.txt
+++ b/examples/vote/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.3
 redis==4.4.4
 gunicorn==22.0.0
 flask-cors==4.0.1


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR:

* Update Python Docker images to be the latest Python-3.12 Alpine ones in tests and examples
* Update `Flask` versions across tests and examples
* Align `requests` and `urllib3` versions across tests and examples

**Special notes for your reviewer**:

The `psycopg2` dependency should also have an explicit version. Some image build errors occurred while trying to use the latest available version. That library can get an explicit version in a separate PR, it not urgent to do it now.