### PR TITLE
fix(terraform): prevent deadlock by consuming stdout

### DIFF
--- a/plugins/terraform/src/helpers.ts
+++ b/plugins/terraform/src/helpers.ts
@@ -205,6 +205,10 @@ export async function applyStack(params: TerraformParamsWithVariables) {
     })
   }
 
+  if (proc.stdout) {
+    proc.stdout.pipe(logStream)
+  }
+
   logStream.on("data", (line: Buffer) => {
     statusLine.info(styles.primary("→ " + line.toString()))
   })


### PR DESCRIPTION
Nodejs spawn will cease to emit error or close events when stdout hasn't been consumed.

See also from official docs:

> By default, pipes for stdin, stdout, and stderr are established between the parent Node.js process and the spawned subprocess. These pipes have limited (and platform-specific) capacity. If the subprocess writes to stdout in excess of that limit without the output being captured, the subprocess blocks waiting for the pipe buffer to accept more data. This is identical to the behavior of pipes in the shell. Use the { stdio: 'ignore' } option if the output will not be consumed.

Source: https://nodejs.org/api/child_process.html#optionsstdio

We used to consume the stdout, but in the ESM PR (https://github.com/garden-io/garden/commit/0f535ddfc156494236028eb292860c458cc37b7c) we accidentally removed the pipe to logStream which can cause deadlocks for terraform users.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
