### PR TITLE
chore(deps): update ink to 5.0.0

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -218,7 +218,6 @@
     "@types/unzip-stream": "^0.3.4",
     "@types/uuid": "^9.0.8",
     "@types/which": "^1.3.2",
-    "@types/wrap-ansi": "^8.1.0",
     "@types/write-file-atomic": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.16.0",

--- a/core/package.json
+++ b/core/package.json
@@ -81,7 +81,7 @@
     "http-status-codes": "^2.2.0",
     "humanize-string": "^3.0.0",
     "indent-string": "^4.0.0",
-    "ink": "^4.4.1",
+    "ink": "^5.0.0",
     "ink-spinner": "^5.0.0",
     "inquirer": "^7.3.3",
     "is-glob": "^4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,7 +1450,6 @@
         "@types/unzip-stream": "^0.3.4",
         "@types/uuid": "^9.0.8",
         "@types/which": "^1.3.2",
-        "@types/wrap-ansi": "^8.1.0",
         "@types/write-file-atomic": "^4.0.3",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.16.0",
@@ -16137,16 +16136,6 @@
       "version": "9.0.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-Pt0qXwu5s9KKODY8bB93mwgOsUvkCOGt//kvHGMaUZi0u//Yge5X5/iME08eSU+Oxf9sZlwAFaJwORDSIjd8pw==",
-      "deprecated": "This is a stub types definition. wrap-ansi provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "wrap-ansi": "*"
-      }
     },
     "node_modules/@types/write-file-atomic": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1313,7 +1313,7 @@
         "http-status-codes": "^2.2.0",
         "humanize-string": "^3.0.0",
         "indent-string": "^4.0.0",
-        "ink": "^4.4.1",
+        "ink": "^5.0.0",
         "ink-spinner": "^5.0.0",
         "inquirer": "^7.3.3",
         "is-glob": "^4.0.3",
@@ -5016,37 +5016,37 @@
       }
     },
     "core/node_modules/ink": {
-      "version": "4.4.1",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.0.0.tgz",
+      "integrity": "sha512-9tv2QeX1pQ4QIZ6wR0Nq2kPRkUBZxRnTTMkSyGxLIO1UZzRVAx8jiVGDt5YfjXWLvJkESHTgI/mlHvc5wmpUhg==",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.1.3",
         "ansi-escapes": "^6.0.0",
+        "ansi-styles": "^6.2.1",
         "auto-bind": "^5.0.1",
-        "chalk": "^5.2.0",
+        "chalk": "^5.3.0",
         "cli-boxes": "^3.0.0",
         "cli-cursor": "^4.0.0",
-        "cli-truncate": "^3.1.0",
+        "cli-truncate": "^4.0.0",
         "code-excerpt": "^4.0.0",
         "indent-string": "^5.0.0",
-        "is-ci": "^3.0.1",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
+        "is-in-ci": "^0.1.0",
         "lodash": "^4.17.21",
         "patch-console": "^2.0.0",
         "react-reconciler": "^0.29.0",
         "scheduler": "^0.23.0",
         "signal-exit": "^3.0.7",
-        "slice-ansi": "^6.0.0",
+        "slice-ansi": "^7.1.0",
         "stack-utils": "^2.0.6",
-        "string-width": "^5.1.2",
-        "type-fest": "^0.12.0",
-        "widest-line": "^4.0.1",
-        "wrap-ansi": "^8.1.0",
-        "ws": "^8.12.0",
+        "string-width": "^7.0.0",
+        "type-fest": "^4.8.3",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.15.0",
         "yoga-wasm-web": "~0.3.3"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@types/react": ">=18.0.0",
@@ -5097,16 +5097,6 @@
         "node": ">=14.13.1"
       }
     },
-    "core/node_modules/ink/node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "core/node_modules/ink/node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
       "license": "MIT",
@@ -5138,6 +5128,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "core/node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "core/node_modules/ink/node_modules/auto-bind": {
@@ -5207,54 +5208,6 @@
         "node": ">=6"
       }
     },
-    "core/node_modules/ink/node_modules/cli-truncate": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "core/node_modules/ink/node_modules/cli-truncate/node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "core/node_modules/ink/node_modules/cli-truncate/node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "core/node_modules/ink/node_modules/cli-truncate/node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "core/node_modules/ink/node_modules/code-excerpt": {
       "version": "4.0.0",
       "license": "MIT",
@@ -5282,37 +5235,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "core/node_modules/ink/node_modules/is-ci": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
+    "core/node_modules/ink/node_modules/is-in-ci": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
+      "integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
       "bin": {
-        "is-ci": "bin.js"
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "core/node_modules/ink/node_modules/is-lower-case": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "core/node_modules/ink/node_modules/is-lower-case/node_modules/tslib": {
-      "version": "2.6.2",
-      "license": "0BSD"
-    },
-    "core/node_modules/ink/node_modules/is-upper-case": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "core/node_modules/ink/node_modules/is-upper-case/node_modules/tslib": {
-      "version": "2.6.2",
-      "license": "0BSD"
     },
     "core/node_modules/ink/node_modules/lodash": {
       "version": "4.17.21",
@@ -5378,40 +5313,6 @@
       "version": "3.0.7",
       "license": "ISC"
     },
-    "core/node_modules/ink/node_modules/slice-ansi": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "core/node_modules/ink/node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "core/node_modules/ink/node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "core/node_modules/ink/node_modules/stack-utils": {
       "version": "2.0.6",
       "license": "MIT",
@@ -5429,75 +5330,29 @@
         "node": ">=8"
       }
     },
-    "core/node_modules/ink/node_modules/string-width": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "core/node_modules/ink/node_modules/string-width/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "license": "MIT"
-    },
-    "core/node_modules/ink/node_modules/string-width/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "license": "MIT"
-    },
     "core/node_modules/ink/node_modules/type-fest": {
-      "version": "0.12.0",
-      "license": "(MIT OR CC0-1.0)",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "core/node_modules/ink/node_modules/widest-line": {
-      "version": "4.0.1",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
       "dependencies": {
-        "string-width": "^5.0.1"
+        "string-width": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "core/node_modules/ink/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "core/node_modules/ink/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "core/node_modules/ink/node_modules/yoga-wasm-web": {


### PR DESCRIPTION
**What this PR does / why we need it**:

* remove redundant `@types/wrap-ansi`
* update `ink` to `5.0.0` to get rid of deprecated transitive dependency on `@types/wrap-ansi`