### PR TITLE
chore: remove unneeded ci step to save 50 seconds

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -458,9 +458,6 @@ jobs:
     steps:
       - checkout
       - install_rust
-      - run:
-          name: "Install rollup linux"
-          command: npm install --save-dev @rollup/rollup-linux-x64-gnu
       - run_npm_dist:
           version: <<parameters.version>>
           targets: "linux-amd64 linux-arm64 alpine-amd64 windows-amd64"


### PR DESCRIPTION
We use rollup wasm build since
https://github.com/garden-io/garden/pull/5400 so no need to install
linux build of rollup in CI anymore.
