### PR TITLE
improvement: improve cli startup performance using v8 cache

### DIFF
--- a/garden-sea/src/node.rs
+++ b/garden-sea/src/node.rs
@@ -39,9 +39,9 @@ where
     #[cfg(all(target_os = "linux"))]
     command.env("GARDEN_SEA_TARGET_ENV", TARGET_ENV);
 
-    // Experimental compile cache feature. Defaults to false for now, but we can enable it by default later if it works well.
+    // Enable v8 compilation cache by default. That saves ~10-30ms on an M2 mac and we've seen 2 seconds startup time shaved off on Windows.
     // See also https://nodejs.org/api/cli.html#node_compile_cachedir
-    let enable_compile_cache = env::var("GARDEN_COMPILE_CACHE").unwrap_or("false".into());
+    let enable_compile_cache = env::var("GARDEN_COMPILE_CACHE").unwrap_or("true".into());
     if enable_compile_cache == "true" || enable_compile_cache == "1" {
         let cache_dir = path.join("v8cache");
         fs::create_dir_all(cache_dir.clone())?;

--- a/garden-sea/src/node.rs
+++ b/garden-sea/src/node.rs
@@ -39,6 +39,18 @@ where
     #[cfg(all(target_os = "linux"))]
     command.env("GARDEN_SEA_TARGET_ENV", TARGET_ENV);
 
+    // Experimental compile cache feature. Defaults to false for now, but we can enable it by default later if it works well.
+    // See also https://nodejs.org/api/cli.html#node_compile_cachedir
+    let enable_compile_cache = env::var("GARDEN_COMPILE_CACHE").unwrap_or("false".into());
+    if enable_compile_cache == "true" || enable_compile_cache == "1" {
+        let cache_dir = path.join("v8cache");
+        fs::create_dir_all(cache_dir.clone())?;
+        command.env(
+            "NODE_COMPILE_CACHE",
+            OsString::from(cache_dir),
+        );
+    }
+
     // Allow users to override the heap size if needed.
     let max_old_space_size = env::var("GARDEN_MAX_OLD_SPACE_SIZE").unwrap_or("4096".into());
     let max_semi_space_size = env::var("GARDEN_MAX_SEMI_SPACE_SIZE").unwrap_or("64".into());


### PR DESCRIPTION
Use the V8 cache feature introduced in Node v22.1.0 to improve the CLI command startup time.

This feature is enabled by default, and `GARDEN_COMPILE_CACHE=0` can be used if it causes a problem as escape hatch.

On my M2 mac it saves ~11-30ms when running `garden --help`; On CircleCI Windows runner it saves 2 seconds for each CLI command invocation, so the difference can be really significant.
