### PR TITLE
fix: `garden publish` command to respect `publishId`

### DIFF
--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -210,13 +210,14 @@ async function buildContainerInCloudBuilder(params: {
 
 export function getContainerBuildActionOutputs(action: Resolved<ContainerBuildAction>): ContainerBuildOutputs {
   const localId = action.getSpec("localId")
-  const explicitImage = action.getSpec("publishId")
+  const publishImageId = action.getSpec("publishId")
   let imageId = localId
-  if (explicitImage) {
+  if (publishImageId) {
     // override imageId if publishId is set
-    const parsedImage = containerHelpers.parseImageId(explicitImage)
-    const tag = parsedImage.tag || action.versionString()
-    imageId = containerHelpers.unparseImageId({ ...parsedImage, tag })
+    const parsedPublishImage = containerHelpers.parseImageId(publishImageId)
+    // use internal version tag if publishId doesn't have its own
+    const tag = parsedPublishImage.tag || action.versionString()
+    imageId = containerHelpers.unparseImageId({ ...parsedPublishImage, tag })
   }
 
   const version = action.moduleVersion()

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -210,7 +210,6 @@ async function buildContainerInCloudBuilder(params: {
 }
 
 export function getContainerBuildActionOutputs(action: Resolved<ContainerBuildAction>): ContainerBuildOutputs {
-  const buildName = action.name
   const localId = action.getSpec("localId")
   const explicitImage = action.getSpec("publishId")
   let imageId = localId
@@ -221,7 +220,9 @@ export function getContainerBuildActionOutputs(action: Resolved<ContainerBuildAc
     const tag = imageTag || action.versionString()
     imageId = containerHelpers.unparseImageId({ ...parsedImage, tag })
   }
+
   const version = action.moduleVersion()
+  const buildName = action.name
 
   const localImageName = containerHelpers.getLocalImageName(buildName, localId)
   const localImageId = containerHelpers.getLocalImageId(buildName, localId, version)

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -16,7 +16,6 @@ import { defaultDockerfileName } from "./config.js"
 import { joinWithPosix } from "../../util/fs.js"
 import type { Resolved } from "../../actions/types.js"
 import dedent from "dedent"
-import { splitFirst } from "../../util/string.js"
 import {
   CONTAINER_BUILD_CONCURRENCY_LIMIT_CLOUD_BUILDER,
   CONTAINER_BUILD_CONCURRENCY_LIMIT_LOCAL,
@@ -215,9 +214,8 @@ export function getContainerBuildActionOutputs(action: Resolved<ContainerBuildAc
   let imageId = localId
   if (explicitImage) {
     // override imageId if publishId is set
-    const imageTag = splitFirst(explicitImage, ":")[1]
     const parsedImage = containerHelpers.parseImageId(explicitImage)
-    const tag = imageTag || action.versionString()
+    const tag = parsedImage.tag || action.versionString()
     imageId = containerHelpers.unparseImageId({ ...parsedImage, tag })
   }
 

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -209,38 +209,7 @@ async function buildContainerInCloudBuilder(params: {
 }
 
 export function getContainerBuildActionOutputs(action: Resolved<ContainerBuildAction>): ContainerBuildOutputs {
-  const localId = action.getSpec("localId")
-  const publishImageId = action.getSpec("publishId")
-  let imageId = localId
-  if (publishImageId) {
-    // override imageId if publishId is set
-    const parsedPublishImage = containerHelpers.parseImageId(publishImageId)
-    // use internal version tag if publishId doesn't have its own
-    const tag = parsedPublishImage.tag || action.versionString()
-    imageId = containerHelpers.unparseImageId({ ...parsedPublishImage, tag })
-  }
-
-  const version = action.moduleVersion()
-  const buildName = action.name
-
-  const localImageName = containerHelpers.getLocalImageName(buildName, localId)
-  const localImageId = containerHelpers.getLocalImageId(buildName, localId, version)
-
-  // Note: The deployment image name/ID outputs are overridden by the kubernetes provider, these defaults are
-  // generally not used.
-  const deploymentImageName = containerHelpers.getDeploymentImageName(buildName, imageId, undefined)
-  const deploymentImageId = containerHelpers.getBuildDeploymentImageId(buildName, imageId, version, undefined)
-
-  return {
-    localImageName,
-    localImageId,
-    deploymentImageName,
-    deploymentImageId,
-    "local-image-name": localImageName,
-    "local-image-id": localImageId,
-    "deployment-image-name": deploymentImageName,
-    "deployment-image-id": deploymentImageId,
-  }
+  return containerHelpers.getBuildActionOutputs(action, undefined)
 }
 
 export function getDockerBuildFlags(

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -8,8 +8,6 @@
 
 import { join, posix } from "path"
 import fsExtra from "fs-extra"
-
-const { readFile, pathExists, lstat } = fsExtra
 import semver from "semver"
 import type { CommandEntry } from "docker-file-parser"
 import { parse } from "docker-file-parser"
@@ -17,15 +15,15 @@ import isGlob from "is-glob"
 import { ConfigurationError, GardenError, RuntimeError } from "../../exceptions.js"
 import type { SpawnOutput } from "../../util/util.js"
 import { spawn } from "../../util/util.js"
-import type { ContainerRegistryConfig, ContainerModuleConfig } from "./moduleConfig.js"
-import { defaultTag as _defaultTag, defaultImageNamespace } from "./moduleConfig.js"
+import type { ContainerModuleConfig, ContainerRegistryConfig } from "./moduleConfig.js"
+import { defaultImageNamespace, defaultTag as _defaultTag } from "./moduleConfig.js"
 import type { Writable } from "stream"
-import { flatten, uniq, fromPairs, reduce } from "lodash-es"
+import { flatten, fromPairs, reduce, uniq } from "lodash-es"
 import type { ActionLog, Log } from "../../logger/log-entry.js"
 
 import isUrl from "is-url"
 import titleize from "titleize"
-import { deline, stripQuotes, splitLast, splitFirst } from "../../util/string.js"
+import { deline, splitFirst, splitLast, stripQuotes } from "../../util/string.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { ModuleVersion } from "../../vcs/vcs.js"
 import type { ContainerBuildAction } from "./config.js"
@@ -35,6 +33,8 @@ import type { Resolved } from "../../actions/types.js"
 import pMemoize from "../../lib/p-memoize.js"
 import { styles } from "../../logger/styles.js"
 import type { ContainerProviderConfig } from "./container.js"
+
+const { readFile, pathExists, lstat } = fsExtra
 
 interface DockerVersion {
   client?: string

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -127,13 +127,12 @@ const helpers = {
   ) {
     const localName = explicitImage || buildName
     const parsedId = helpers.parseImageId(localName)
-    const withoutVersion = helpers.unparseImageId({
-      ...parsedId,
-      tag: undefined,
-    })
 
     if (!registryConfig) {
-      return withoutVersion
+      return helpers.unparseImageId({
+        ...parsedId,
+        tag: undefined,
+      })
     }
 
     const host = registryConfig.port ? `${registryConfig.hostname}:${registryConfig.port}` : registryConfig.hostname

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -195,24 +195,14 @@ const helpers = {
     registryConfig: ContainerRegistryConfig | undefined
   ): ContainerBuildOutputs {
     const localId = action.getSpec("localId")
-    const publishImageId = action.getSpec("publishId")
-    let imageId = localId
-    if (publishImageId) {
-      // override imageId if publishId is set
-      const parsedPublishImage = containerHelpers.parseImageId(publishImageId)
-      // use internal version tag if publishId doesn't have its own
-      const tag = parsedPublishImage.tag || action.versionString()
-      imageId = containerHelpers.unparseImageId({ ...parsedPublishImage, tag })
-    }
-
     const version = action.moduleVersion()
     const buildName = action.name
 
     const localImageName = containerHelpers.getLocalImageName(buildName, localId)
     const localImageId = containerHelpers.getLocalImageId(buildName, localId, version)
 
-    const deploymentImageName = containerHelpers.getDeploymentImageName(buildName, imageId, registryConfig)
-    const deploymentImageId = containerHelpers.getBuildDeploymentImageId(buildName, imageId, version, registryConfig)
+    const deploymentImageName = containerHelpers.getDeploymentImageName(buildName, localId, registryConfig)
+    const deploymentImageId = containerHelpers.getBuildDeploymentImageId(buildName, localId, version, registryConfig)
 
     return {
       localImageName,

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -146,8 +146,9 @@ const helpers = {
   },
 
   /**
-   * Returns the image ID to be used when pushing to deployment registries. This always has the version
-   * set as the tag.
+   * Returns the image ID to be used when pushing to deployment registries.
+   * This always has the version set as the tag.
+   * Do not confuse this with the publishing image ID used by the `garden publish` command.
    */
   getBuildDeploymentImageId(
     buildName: string,

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -125,12 +125,12 @@ const helpers = {
     explicitImage: string | undefined,
     registryConfig: ContainerRegistryConfig | undefined
   ) {
-    const localName = explicitImage || buildName
-    const parsedId = helpers.parseImageId(localName)
+    const localImageName = explicitImage || buildName
+    const parsedImageId = helpers.parseImageId(localImageName)
 
     if (!registryConfig) {
       return helpers.unparseImageId({
-        ...parsedId,
+        ...parsedImageId,
         tag: undefined,
       })
     }
@@ -140,7 +140,7 @@ const helpers = {
     return helpers.unparseImageId({
       host,
       namespace: registryConfig.namespace,
-      repository: parsedId.repository,
+      repository: parsedImageId.repository,
       tag: undefined,
     })
   },

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -207,8 +207,6 @@ const helpers = {
     const localImageName = containerHelpers.getLocalImageName(buildName, localId)
     const localImageId = containerHelpers.getLocalImageId(buildName, localId, version)
 
-    // Note: The deployment image name/ID outputs are overridden by the kubernetes provider, these defaults are
-    // generally not used.
     const deploymentImageName = containerHelpers.getDeploymentImageName(buildName, imageId, registryConfig)
     const deploymentImageId = containerHelpers.getBuildDeploymentImageId(buildName, imageId, version, registryConfig)
 

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -171,16 +171,19 @@ const helpers = {
     // Requiring this parameter to avoid accidentally missing it
     registryConfig: ContainerRegistryConfig | undefined
   ): string {
+    // The `dockerfile` configuration always takes precedence over the `image`.
     if (helpers.moduleHasDockerfile(moduleConfig, version)) {
       return helpers.getBuildDeploymentImageId(moduleConfig.name, moduleConfig.spec.image, version, registryConfig)
-    } else if (moduleConfig.spec.image) {
-      // Otherwise, return the configured image ID.
-      return moduleConfig.spec.image
-    } else {
-      throw new ConfigurationError({
-        message: `Module ${moduleConfig.name} neither specifies image nor can a Dockerfile be found in the module directory.`,
-      })
     }
+
+    // Return the configured image ID if no Dockerfile is defined in the config.
+    if (moduleConfig.spec.image) {
+      return moduleConfig.spec.image
+    }
+
+    throw new ConfigurationError({
+      message: `Module ${moduleConfig.name} neither specifies image nor can a Dockerfile be found in the module directory.`,
+    })
   },
 
   /**

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -60,9 +60,9 @@ const helpers = {
    * Returns the image ID used locally, when building and deploying to local environments
    * (when we don't need to push to remote registries).
    */
-  getLocalImageId(buildName: string, explicitImage: string | undefined, version: ModuleVersion): string {
+  getLocalImageId(buildName: string, explicitImageId: string | undefined, version: ModuleVersion): string {
     const { versionString } = version
-    const name = helpers.getLocalImageName(buildName, explicitImage)
+    const name = helpers.getLocalImageName(buildName, explicitImageId)
     const parsedImage = helpers.parseImageId(name)
     return helpers.unparseImageId({ ...parsedImage, tag: versionString })
   },
@@ -71,9 +71,9 @@ const helpers = {
    * Returns the image name used locally (without tag/version), when building and deploying to local environments
    * (when we don't need to push to remote registries).
    */
-  getLocalImageName(buildName: string, explicitImage: string | undefined): string {
-    if (explicitImage) {
-      const parsedImage = helpers.parseImageId(explicitImage)
+  getLocalImageName(buildName: string, explicitImageId: string | undefined): string {
+    if (explicitImageId) {
+      const parsedImage = helpers.parseImageId(explicitImageId)
       return helpers.unparseImageId({ ...parsedImage, tag: undefined })
     } else {
       return buildName
@@ -122,10 +122,10 @@ const helpers = {
    */
   getDeploymentImageName(
     buildName: string,
-    explicitImage: string | undefined,
+    explicitImageId: string | undefined,
     registryConfig: ContainerRegistryConfig | undefined
   ) {
-    const localImageName = explicitImage || buildName
+    const localImageName = explicitImageId || buildName
     const parsedImageId = helpers.parseImageId(localImageName)
 
     if (!registryConfig) {

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -9,6 +9,7 @@
 import type { ContainerBuildAction } from "./moduleConfig.js"
 import { containerHelpers } from "./helpers.js"
 import type { BuildActionHandler } from "../../plugin/action-types.js"
+import { naturalList } from "../../util/string.js"
 
 export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuildAction> = async ({
   ctx,
@@ -20,10 +21,11 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
 
   if (localImageId !== remoteImageId) {
-    log.info({ msg: `Tagging image with ${localImageId} and ${remoteImageId}` })
+    const taggedImages = [localImageId, remoteImageId]
+    log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
     await containerHelpers.dockerCli({
       cwd: action.getBuildPath(),
-      args: ["tag", localImageId, remoteImageId],
+      args: ["tag", ...taggedImages],
       log,
       ctx,
     })

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -16,26 +16,26 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   log,
   tagOverride,
 }) => {
-  const localId = action.getOutput("localImageId")
-  const remoteId = containerHelpers.getPublicImageId(action, tagOverride)
+  const localImageId = action.getOutput("localImageId")
+  const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
 
-  if (localId !== remoteId) {
-    log.info({ msg: `Tagging image with ${localId} and ${remoteId}` })
+  if (localImageId !== remoteImageId) {
+    log.info({ msg: `Tagging image with ${localImageId} and ${remoteImageId}` })
     await containerHelpers.dockerCli({
       cwd: action.getBuildPath(),
-      args: ["tag", localId, remoteId],
+      args: ["tag", localImageId, remoteImageId],
       log,
       ctx,
     })
   }
 
-  log.info({ msg: `Publishing image ${remoteId}...` })
+  log.info({ msg: `Publishing image ${remoteImageId}...` })
   // TODO: stream output to log if at debug log level
-  await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["push", remoteId], log, ctx })
+  await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["push", remoteImageId], log, ctx })
 
   return {
     state: "ready",
-    detail: { published: true, message: `Published ${remoteId}` },
+    detail: { published: true, message: `Published ${remoteImageId}` },
     // TODO-0.13.1
     outputs: {},
   }

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -20,16 +20,14 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   const localImageId = action.getOutput("localImageId")
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
 
-  if (localImageId !== remoteImageId) {
-    const taggedImages = [localImageId, remoteImageId]
-    log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
-    await containerHelpers.dockerCli({
-      cwd: action.getBuildPath(),
-      args: ["tag", ...taggedImages],
-      log,
-      ctx,
-    })
-  }
+  const taggedImages = [localImageId, remoteImageId]
+  log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
+  await containerHelpers.dockerCli({
+    cwd: action.getBuildPath(),
+    args: ["tag", ...taggedImages],
+    log,
+    ctx,
+  })
 
   log.info({ msg: `Publishing image ${remoteImageId}...` })
   // TODO: stream output to log if at debug log level

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -36,7 +36,9 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   return {
     state: "ready",
     detail: { published: true, message: `Published ${remoteImageId}` },
-    // TODO-0.13.1
-    outputs: {},
+    outputs: {
+      localImageId,
+      remoteImageId,
+    },
   }
 }

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -9,12 +9,11 @@
 import fs from "fs"
 import tmp from "tmp-promise"
 import type { KubernetesPluginContext } from "../config.js"
-import { PluginError, ParameterError, GardenError } from "../../../exceptions.js"
+import { GardenError, ParameterError, PluginError, RuntimeError } from "../../../exceptions.js"
 import type { PluginCommand } from "../../../plugin/command.js"
 import { KubeApi } from "../api.js"
 import type { Log } from "../../../logger/log-entry.js"
 import { containerHelpers } from "../../container/helpers.js"
-import { RuntimeError } from "../../../exceptions.js"
 import { PodRunner } from "../run.js"
 import { dockerAuthSecretKey, getK8sUtilImageName, systemDockerAuthSecretName } from "../constants.js"
 import { getAppNamespace, getSystemNamespace } from "../namespace.js"
@@ -91,10 +90,7 @@ interface PullParams {
 }
 
 export async function pullBuild(params: PullParams) {
-  await pullFromExternalRegistry(params)
-}
-
-async function pullFromExternalRegistry({ ctx, log, localId, remoteId }: PullParams) {
+  const { ctx, log, localId, remoteId }: PullParams = params
   const api = await KubeApi.factory(log, ctx, ctx.provider)
   const buildMode = ctx.provider.config.buildMode
 

--- a/core/src/plugins/kubernetes/container/build/local.ts
+++ b/core/src/plugins/kubernetes/container/build/local.ts
@@ -18,6 +18,7 @@ import type { ContainerBuildAction } from "../../../container/moduleConfig.js"
 import type { BuildActionParams } from "../../../../plugin/action-types.js"
 import { k8sGetContainerBuildActionOutputs } from "../handlers.js"
 import { cloudBuilder } from "../../../container/cloudbuilder.js"
+import { naturalList } from "../../../../util/string.js"
 
 export const getLocalBuildStatus: BuildStatusHandler = async (params) => {
   const { ctx, action, log } = params
@@ -92,10 +93,13 @@ export const localBuild: BuildHandler = async (params) => {
 
   // Cloud Builder already pushes the image.
   if (!builtByCloudBuilder) {
-    log.info({ msg: `→ Pushing image ${remoteId} to remote...` })
-
     const buildPath = action.getBuildPath()
+    const taggedImages = [localId, remoteId]
+
+    log.info({ msg: `→ Tagging images ${naturalList(taggedImages)}` })
     await containerHelpers.dockerCli({ cwd: buildPath, args: ["tag", localId, remoteId], log, ctx })
+
+    log.info({ msg: `→ Pushing image ${remoteId} to remote...` })
     await containerHelpers.dockerCli({ cwd: buildPath, args: ["push", remoteId], log, ctx })
   }
 

--- a/core/src/plugins/kubernetes/container/handlers.ts
+++ b/core/src/plugins/kubernetes/container/handlers.ts
@@ -60,14 +60,15 @@ export function k8sGetContainerBuildActionOutputs({
   provider: KubernetesProvider
   action: Resolved<ContainerBuildAction>
 }): ContainerBuildOutputs {
-  const localId = action.getSpec("localId")
-  const explicitImage = action.getSpec("publishId")
-  let imageId = localId
-  if (explicitImage) {
+  const localImageId = action.getSpec("localId")
+  const publishImageId = action.getSpec("publishId")
+  let imageId = localImageId
+  if (publishImageId) {
     // override imageId if publishId is set
-    const parsedImage = containerHelpers.parseImageId(explicitImage)
-    const tag = parsedImage.tag || action.versionString()
-    imageId = containerHelpers.unparseImageId({ ...parsedImage, tag })
+    const parsedPublishImage = containerHelpers.parseImageId(publishImageId)
+    // use internal version tag if publishId doesn't have its own
+    const tag = parsedPublishImage.tag || action.versionString()
+    imageId = containerHelpers.unparseImageId({ ...parsedPublishImage, tag })
   }
 
   const outputs = getContainerBuildActionOutputs(action)

--- a/core/src/plugins/kubernetes/container/handlers.ts
+++ b/core/src/plugins/kubernetes/container/handlers.ts
@@ -21,7 +21,6 @@ import { containerHelpers } from "../../container/helpers.js"
 import { getContainerModuleOutputs } from "../../container/container.js"
 import { getContainerBuildActionOutputs } from "../../container/build.js"
 import type { Resolved } from "../../../actions/types.js"
-import { splitFirst } from "../../../util/string.js"
 
 async function configure(params: ConfigureModuleParams<ContainerModule>) {
   const { moduleConfig } = await params.base!(params)
@@ -66,9 +65,8 @@ export function k8sGetContainerBuildActionOutputs({
   let imageId = localId
   if (explicitImage) {
     // override imageId if publishId is set
-    const imageTag = splitFirst(explicitImage, ":")[1]
     const parsedImage = containerHelpers.parseImageId(explicitImage)
-    const tag = imageTag || action.versionString()
+    const tag = parsedImage.tag || action.versionString()
     imageId = containerHelpers.unparseImageId({ ...parsedImage, tag })
   }
 

--- a/core/src/plugins/kubernetes/container/handlers.ts
+++ b/core/src/plugins/kubernetes/container/handlers.ts
@@ -62,7 +62,6 @@ export function k8sGetContainerBuildActionOutputs({
   action: Resolved<ContainerBuildAction>
 }): ContainerBuildOutputs {
   const localId = action.getSpec("localId")
-  const outputs = getContainerBuildActionOutputs(action)
   const explicitImage = action.getSpec("publishId")
   let imageId = localId
   if (explicitImage) {
@@ -73,6 +72,7 @@ export function k8sGetContainerBuildActionOutputs({
     imageId = containerHelpers.unparseImageId({ ...parsedImage, tag })
   }
 
+  const outputs = getContainerBuildActionOutputs(action)
   outputs.deploymentImageName = outputs["deployment-image-name"] = containerHelpers.getDeploymentImageName(
     action.name,
     imageId,

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -21,23 +21,25 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
   const localImageId = action.getOutput("localImageId")
   // NOTE: this may contain a custom deploymentRegistry, from the kubernetes provider config
   // We cannot combine this publish method with the container plugin's publish method, because it won't have the context
-  const remoteImageId = action.getOutput("deploymentImageId")
+  const deploymentRegistryImageId = action.getOutput("deploymentImageId")
 
   if (provider.config.buildMode !== "local-docker") {
-    // First pull from the remote registry, then resume standard publish flow.
+    // First pull from the deployment registry, then resume standard publish flow.
     // This does mean we require a local docker as a go-between, but the upside is that we can rely on the user's
     // standard authentication setup, instead of having to re-implement or account for all the different ways the
     // user might be authenticating with their registries.
     // We also generally prefer this because the remote cluster very likely doesn't (and shouldn't) have
     // privileges to push to production registries.
-    log.info(`Pulling from remote registry...`)
-    await pullBuild({ ctx: k8sCtx, action, log, localId: localImageId, remoteId: remoteImageId })
+    log.info(`Pulling from deployment registry...`)
+    await pullBuild({ ctx: k8sCtx, action, log, localId: localImageId, remoteId: deploymentRegistryImageId })
   }
 
-  // optionally use the tag instead of the garden version, this requires that we tag the image locally
-  // before publishing to the remote registry
+  // Optionally use the tag instead of the garden version.
+  // This requires that we tag the image locally before publishing to the remote registry.
+  const remotePublishId = tagOverride
+    ? `${action.getOutput("deploymentImageName")}:${tagOverride}`
+    : deploymentRegistryImageId
 
-  const remotePublishId = tagOverride ? `${action.getOutput("deploymentImageName")}:${tagOverride}` : remoteImageId
   const taggedImages = [localImageId, remotePublishId]
   log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
   await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["tag", ...taggedImages], log, ctx })

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -11,6 +11,7 @@ import type { KubernetesPluginContext } from "../config.js"
 import { pullBuild } from "../commands/pull-image.js"
 import type { BuildActionHandler } from "../../../plugin/action-types.js"
 import { containerHelpers } from "../../container/helpers.js"
+import { naturalList } from "../../../util/string.js"
 
 export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBuildAction> = async (params) => {
   const { ctx, action, log, tagOverride } = params
@@ -37,8 +38,9 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
   // before publishing to the remote registry
 
   const remotePublishId = tagOverride ? `${action.getOutput("deploymentImageName")}:${tagOverride}` : remoteImageId
-
-  await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["tag", localImageId, remotePublishId], log, ctx })
+  const taggedImages = [localImageId, remotePublishId]
+  log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
+  await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["tag", ...taggedImages], log, ctx })
 
   log.info({ msg: `Publishing image ${remotePublishId}...` })
   // TODO: stream output to log if at debug log level

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -36,9 +36,7 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
 
   // Optionally use the tag instead of the garden version.
   // This requires that we tag the image locally before publishing to the remote registry.
-  const remoteImageId = tagOverride
-    ? `${action.getOutput("deploymentImageName")}:${tagOverride}`
-    : action.getOutput("deploymentImageName")
+  const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
 
   const taggedImages = [localImageId, remoteImageId]
   log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -34,8 +34,6 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
     await pullBuild({ ctx: k8sCtx, action, log, localId: localImageId, remoteId: deploymentRegistryImageId })
   }
 
-  // Optionally use the tag instead of the garden version.
-  // This requires that we tag the image locally before publishing to the remote registry.
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
 
   const taggedImages = [localImageId, remoteImageId]

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -49,7 +49,9 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
   return {
     state: "ready",
     detail: { published: true, message: `Published ${remoteImageId}` },
-    // TODO-0.13.1
-    outputs: {},
+    outputs: {
+      localImageId,
+      remoteImageId,
+    },
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the behavior of `garden publish` command. See #6050 for additional context and technical details.

**Which issue(s) this PR fixes**:

Fixes #6050
Fixes #4796

Reverts #4740 
Reopens #4095
Patches #4808

**Special notes for your reviewer**:

This PR does not address possible **Action Router** problems mentioned in #6050. There might be no issues at all in the Action Router. That should be considered separately, and another PR can be created if any fix is required.