### PR TITLE
fix(commands): use statusOnly provider resolution for several read-only commands

### DIFF
--- a/core/src/commands/get/get-actions.ts
+++ b/core/src/commands/get/get-actions.ts
@@ -152,7 +152,7 @@ export class GetActionsCommand extends Command {
       actionsFilter = [opts.kind + ".*"]
     }
 
-    const graph = await garden.getResolvedConfigGraph({ log, emit: false, actionsFilter })
+    const graph = await garden.getResolvedConfigGraph({ log, emit: false, actionsFilter, statusOnly: true })
 
     const kindOpt = opts["kind"]?.toLowerCase()
     let actions: ResolvedActionWithState[] = []

--- a/core/src/commands/get/get-files.ts
+++ b/core/src/commands/get/get-files.ts
@@ -43,7 +43,7 @@ export class GetFilesCommand extends Command<Args, Opts> {
   }
 
   async action({ garden, log, args }: CommandParams<Args, Opts>): Promise<CommandResult<Result>> {
-    const graph = await garden.getConfigGraph({ log, emit: false })
+    const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })
     const actions = graph.getActions({ refs: args.keys?.length ? args.keys : undefined })
 
     const result = fromPairs(

--- a/core/src/commands/get/get-graph.ts
+++ b/core/src/commands/get/get-graph.ts
@@ -25,7 +25,7 @@ export class GetGraphCommand extends Command {
   }
 
   async action({ garden, log }: CommandParams): Promise<CommandResult<GraphOutput>> {
-    const graph = await garden.getConfigGraph({ log, emit: false })
+    const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })
     const renderedGraph = graph.render()
     const output: GraphOutput = {
       nodes: renderedGraph.nodes,

--- a/core/src/commands/get/get-modules.ts
+++ b/core/src/commands/get/get-modules.ts
@@ -86,7 +86,7 @@ export class GetModulesCommand extends Command {
       actionsFilter = args.modules.map((name) => `build.${name}`)
     }
 
-    const graph = await garden.getConfigGraph({ log, emit: false, actionsFilter })
+    const graph = await garden.getConfigGraph({ log, emit: false, actionsFilter, statusOnly: true })
 
     const modules = sortBy(
       graph.getModules({ names: args.modules, includeDisabled: !opts["exclude-disabled"] }),

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -150,7 +150,7 @@ export class LogsCommand extends Command<Args, Opts> {
       }
     }
 
-    const graph = await garden.getConfigGraph({ log, emit: false })
+    const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })
     const allDeploys = graph.getDeploys()
     const actions = args.names ? allDeploys.filter((s) => args.names?.includes(s.name)) : allDeploys
 

--- a/core/src/commands/update-remote/actions.ts
+++ b/core/src/commands/update-remote/actions.ts
@@ -91,7 +91,7 @@ export async function updateRemoteActions({
   opts: ParameterValues<Opts>
 }) {
   const { actions: keys } = args
-  const graph = await garden.getConfigGraph({ log, emit: false })
+  const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })
   const actions = graph.getActions({ refs: keys })
 
   const actionSources = <SourceConfig[]>actions

--- a/core/src/commands/update-remote/modules.ts
+++ b/core/src/commands/update-remote/modules.ts
@@ -90,7 +90,7 @@ export async function updateRemoteModules({
   opts: ParameterValues<Opts>
 }) {
   const { modules: moduleNames } = args
-  const graph = await garden.getConfigGraph({ log, emit: false })
+  const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })
   const modules = graph.getModules({ names: moduleNames })
 
   const moduleSources = <SourceConfig[]>modules

--- a/core/src/commands/util/profile-project.ts
+++ b/core/src/commands/util/profile-project.ts
@@ -29,7 +29,7 @@ export class ProfileProjectCommand extends Command {
   }
 
   async action({ garden, log }: CommandParams): Promise<CommandResult> {
-    const graph = await garden.getConfigGraph({ log, emit: false })
+    const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })
     summarizeGraph(log, garden, graph)
 
     log.info(renderDivider())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Applies the `statusOnly` option for provider resolution for all kinds of read-only commands:
* get-actions
* get-modules
* get-files
* get-graph
* update-remote
* profile-project
* logs

**Which issue(s) this PR fixes**:

Fixes #3327

**Special notes for your reviewer**:

Based on the changes made in #6051.