### PR TITLE
improvement(cloud): consistent validation order in `cloud` commands

### DIFF
--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -86,6 +86,11 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
       })
     }
 
+    const api = garden.cloudApi
+    if (!api) {
+      throw new ConfigurationError({ message: noApiMsg("create", "secrets") })
+    }
+
     const cmdLog = log.createLog({ name: "secrets-command" })
 
     const secrets = await readInputKeyValueResources({
@@ -94,11 +99,6 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
       resourceName: "secret",
       log: cmdLog,
     })
-
-    const api = garden.cloudApi
-    if (!api) {
-      throw new ConfigurationError({ message: noApiMsg("create", "secrets") })
-    }
 
     const project = await api.getProjectByIdOrThrow({
       projectId: garden.projectId,

--- a/core/src/commands/cloud/secrets/secrets-update.ts
+++ b/core/src/commands/cloud/secrets/secrets-update.ts
@@ -100,6 +100,11 @@ export class SecretsUpdateCommand extends Command<Args, Opts> {
       })
     }
 
+    const api = garden.cloudApi
+    if (!api) {
+      throw new ConfigurationError({ message: noApiMsg("update", "secrets") })
+    }
+
     const cmdLog = log.createLog({ name: "secrets-command" })
 
     const inputSecrets = await readInputKeyValueResources({
@@ -108,11 +113,6 @@ export class SecretsUpdateCommand extends Command<Args, Opts> {
       resourceName: "secret",
       log: cmdLog,
     })
-
-    const api = garden.cloudApi
-    if (!api) {
-      throw new ConfigurationError({ message: noApiMsg("update", "secrets") })
-    }
 
     const project = await api.getProjectByIdOrThrow({
       projectId: garden.projectId,

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -83,6 +83,11 @@ export class UsersCreateCommand extends Command<Args, Opts> {
     const addToGroups: string[] = opts["add-to-groups"] || []
     const usersFilePath = opts["from-file"] as string | undefined
 
+    const api = garden.cloudApi
+    if (!api) {
+      throw new ConfigurationError({ message: noApiMsg("create", "users") })
+    }
+
     const cmdLog = log.createLog({ name: "users-command" })
 
     const users = await readInputKeyValueResources({
@@ -91,11 +96,6 @@ export class UsersCreateCommand extends Command<Args, Opts> {
       resourceName: "user",
       log: cmdLog,
     })
-
-    const api = garden.cloudApi
-    if (!api) {
-      throw new ConfigurationError({ message: noApiMsg("create", "users") })
-    }
 
     const usersToCreate = Object.entries(users).map(([vcsUsername, name]) => ({
       name,


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure the same order of semantically different validation steps across all `cloud` commands.

Stick to the following order:
1. Sanity and consistency of args and opts (like all necessary flags are passed), without any runtime resolution and processing
2. Existence of CloudAPI - it makes no sense to continue without it
3. Runtime errors while args and opts resolution, e.g.: - I/O errors reading input files - Runtime errors evaluating necessary resources user and environment scope - And so on
4. Runtime errors while results evaluation: - Missing target resources (users, secrets, etc.)

Preliminary refactoring for fixing https://github.com/garden-io/garden/issues/6048.

**Special notes for your reviewer**:
