### PR TITLE
fix(actions): return all outputs of an action as a json string

### DIFF
--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -989,7 +989,6 @@ function dependenciesFromActionConfig({
 
     if (
       ref.fullRef[3] === "outputs" &&
-      outputKey &&
       !staticOutputKeys.includes(outputKey) &&
       !refStaticOutputKeys.includes(outputKey)
     ) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
To make it possible to return all outputs from actions as a json string, we need to allow setting the `needsExecutedOutputs` to `true`.   
When referencing `${actions.deploy.<name>.outputs}` without another key `outputKey` is `undefined` which without the change in this PR will cause `needsExecutedOutputs` to be `false`. This results in `${actions.deploy.<name>.outputs}` to always be an empty object.

**Which issue(s) this PR fixes**:

Fixes #6046

**Special notes for your reviewer**:
TODO:
* Need to adjust the joi schema for outputs, so this is also documented in the reference docs.
* Need to track down why provider outputs are returned as plain object, while action outputs are returned as json string.