### PR TITLE
test: increase timeouts for CLI tests

### DIFF
--- a/cli/.mocharc.yml
+++ b/cli/.mocharc.yml
@@ -3,6 +3,6 @@ require:
   - build/test/setup.js
 spec:
   - build/test/**/*.js
-timeout: 10000
+timeout: 20000
 watch-files:
   - build/**/*.js


### PR DESCRIPTION
**What this PR does / why we need it**:

Package build tests can take longer than 10 seconds. Let's put 20 seconds for it.

This should prevent CI failures like [this](https://app.circleci.com/pipelines/github/garden-io/garden/25091/workflows/b3f52529-4b88-41ee-91f9-0c329aa6e0b0/jobs/518388).