### PR TITLE
feat(images): add multi-platform images for garden deployed services

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -2,4 +2,13 @@
 
 Here we place container images that we maintain and reference when using Garden.
 
-To build, just use `garden build`, and to publish, `garden publish`.
+We are building all images except the circleci image multi-platform for linux/arm64 and linux/amd64. To setup building multi-platform with buildx locally check instructions for:
+
+* Docker Desktop: https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images
+* Orbstack: https://docs.orbstack.dev/docker/images#multiplatform
+
+Please note that the images are not available in your local docker images store, because they are build in the docker-container buildx builder. They are always pushed to DockerHub. If you want to inspect and run them locally pull them down.
+
+To build and push to DockerHub with a tag `dev` use `garden build`, and to publish a new image with a version tag specified in the `release_tag` variable run `garden build --var publish=true`.
+
+This is an intermediate step to allow multi platform builds and publish them to DockerHub until multi-platform builds are integrated more natively into garden and work with the publish command.

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -1,23 +1,31 @@
-kind: Module
+kind: Build
 type: container
 name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
-image: gardendev/buildkit:v0.12.2-1
-dockerfile: Dockerfile
-build:
-  targetImage: buildkit
-extraFlags: [ "--platform", "linux/amd64" ]
-
+variables:
+  publish: false
+  image_name: gardendev/buildkit
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: v0.12.2-2
+spec:
+  localId: ${var.image_name}
+  dockerfile: Dockerfile
+  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
 ---
 
-kind: Module
+kind: Build
 type: container
 name: buildkit-rootless
 description: Used for the cluster-buildkit build mode in the kubernetes provider, rootless variant
-image: gardendev/buildkit:v0.12.2-1-rootless
-dockerfile: Dockerfile
-build:
-  dependencies:
-    - buildkit
-  targetImage: buildkit-rootless
-extraFlags: [ "--platform", "linux/amd64" ]
+dependencies:
+  - build.buildkit
+variables:
+  publish: false
+  image_name: gardendev/buildkit
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: v0.12.2-2-rootless
+spec:
+  localId: ${var.image_name}
+  dockerfile: Dockerfile
+  targetStage: buildkit-rootless
+  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -1,6 +1,12 @@
-kind: Module
+kind: Build
 type: container
 name: circleci-runner
 description: Used for the core pipeline in CircleCI
-image: gardendev/circleci-runner:22.1.0-1
-extraFlags: ["--platform", "linux/amd64"]
+variables:
+  publish: false
+  image_name: gardendev/circleci-runner
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: 22.1.0-2
+spec:
+  localId: gardendev/circleci-runner
+  extraFlags: [ "--platform", "linux/amd64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]

--- a/images/k8s-reverse-proxy/garden.yml
+++ b/images/k8s-reverse-proxy/garden.yml
@@ -1,7 +1,13 @@
-kind: Module
+kind: Build
 type: container
 name: k8s-reverse-proxy
 description: Used in local deployment mode as a reversed proxy in k8s cluster to replace an actual service and to route its traffic to a local service.
-image: gardendev/k8s-reverse-proxy:0.1.0
-dockerfile: Dockerfile
-extraFlags: [ "--platform", "linux/amd64" ]
+variables:
+  publish: false
+  image_name: gardendev/k8s-reverse-proxy
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: 0.1.1
+spec:
+  localId: ${var.image_name}
+  dockerfile: Dockerfile
+  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -1,7 +1,13 @@
-kind: Module
+kind: Build
 type: container
 name: k8s-sync
 description: Used by the kubernetes provider for sync setup
-image: gardendev/k8s-sync:0.2.0 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
-dockerfile: Dockerfile
-extraFlags: [ "--platform", "linux/amd64" ]
+variables:
+  publish: false
+  image_name: gardendev/k8s-sync
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: 0.2.0-1 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
+spec:
+  localId: ${var.image_name}
+  dockerfile: Dockerfile
+  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -1,11 +1,16 @@
-kind: Module
+kind: Build
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.6.0 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
-dockerfile: Dockerfile
-build:
-  dependencies: [k8s-sync]
-buildArgs:
-  BASE_IMAGE: ${modules.k8s-sync.outputs.local-image-id}
-extraFlags: [ "--platform", "linux/amd64" ]
+dependencies: [build.k8s-sync]
+variables:
+  publish: false
+  image_name: gardendev/k8s-util
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: 0.6.0-1 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
+spec:
+  localId: ${var.image_name}
+  dockerfile: Dockerfile
+  buildArgs:
+    BASE_IMAGE: ${actions.build.k8s-sync.var.image_name}:${actions.build.k8s-sync.var.image_tag}
+  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]

--- a/images/skopeo/garden.yml
+++ b/images/skopeo/garden.yml
@@ -1,7 +1,13 @@
-kind: Module
+kind: Build
 type: container
 name: skopeo
 description: Used by the kubernetes provider for interacting with container registries within a cluster
-image: gardendev/skopeo:1.41.0-4
-dockerfile: Dockerfile
-extraFlags: [ "--platform", "linux/amd64" ]
+variables:
+  publish: false
+  image_name: gardendev/skopeo
+  image_tag: "${var.publish ? var.release_tag : 'dev'}"
+  release_tag: 1.41.0-5
+spec:
+  localId: ${var.image_name}
+  dockerfile: Dockerfile
+  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds multi-platform builds for all the garden deployed containers like `buildkit`, `skopeo`, `k8s-sync`, etc. This allows users to run garden on arm64 native kubernetes.

We can not use the publish command any longer to publish the images to dockerhub, since the docker-container buildx runner is not able to load the images in the default local docker image store. To facilitate this, we now always push to DockerHub when running `garden build` in this project, but with a `dev` tag. When running `garden build --var publish=true` we push them with the specified production tag in `release_tag`.  This is a temporary workaround until we have properly integrated mutli-platform building into garden.

Also moves the images project from modules to actions ;-)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
