### PR TITLE
improvement(helm): use --wait when deploying

### DIFF
--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -166,13 +166,19 @@ const objHandlers: { [kind: string]: StatusHandler } = {
 /**
  * Check if the specified Kubernetes objects are deployed and fully rolled out
  */
-export async function checkResourceStatuses(
-  api: KubeApi,
-  namespace: string,
-  manifests: KubernetesResource[],
-  log: Log,
+export async function checkResourceStatuses({
+  api,
+  namespace,
+  manifests,
+  log,
+  waitForJobs,
+}: {
+  api: KubeApi
+  namespace: string
+  manifests: KubernetesResource[]
+  log: Log
   waitForJobs?: boolean
-): Promise<ResourceStatus[]> {
+}): Promise<ResourceStatus[]> {
   return Promise.all(
     manifests.map(async (manifest) => {
       return checkResourceStatus({ api, namespace, manifest, log, waitForJobs })
@@ -310,7 +316,13 @@ export async function waitForResources({
     await sleep(2000 + 500 * loops)
     loops += 1
 
-    const statuses = await checkResourceStatuses(api, namespace, Object.values(pendingResources), log, waitForJobs)
+    const statuses = await checkResourceStatuses({
+      api,
+      namespace,
+      manifests: Object.values(pendingResources),
+      log,
+      waitForJobs,
+    })
 
     for (const status of statuses) {
       const key = getResourceKey(status.resource)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

The `--wait` option for `helm deploy` and `helm upgrade` is now applied by default for `helm` Deploys.

We had previously used `waitForResources` for this (since Helm's rollout statuses weren't reliable enough when using `--wait`).

In the `helm` deploy handler, we now only use `waitForResources` to wait for resources updated for local or sync mode.


**Which issue(s) this PR fixes**:

Fixes #6053.