### PR TITLE
fix(secrets): skip already existing secrets while creating

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -947,7 +947,7 @@ export class CloudApi {
         if (err.response.statusCode === 409) {
           errors.push({
             identifier: name,
-            message: err.message,
+            message: "Secret already exists",
           })
         } else {
           throw err

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -42,7 +42,7 @@ import { LogLevel } from "../logger/logger.js"
 import { makeAuthHeader } from "./auth.js"
 import type { StringMap } from "../config/common.js"
 import { styles } from "../logger/styles.js"
-import { RequestError } from "got"
+import { HTTPError, RequestError } from "got"
 import type { Garden } from "../garden.js"
 import type { ApiCommandError } from "../commands/cloud/helpers.js"
 import { enumerate } from "../util/enumerate.js"
@@ -939,13 +939,19 @@ export class CloudApi {
         const res = await this.createSecret(body)
         results.push(res.data)
       } catch (err) {
-        if (!(err instanceof GardenError)) {
+        if (!(err instanceof HTTPError)) {
           throw err
         }
-        errors.push({
-          identifier: name,
-          message: err.message,
-        })
+
+        // skip already existing secret and continue the loop
+        if (err.response.statusCode === 409) {
+          errors.push({
+            identifier: name,
+            message: err.message,
+          })
+        } else {
+          throw err
+        }
       }
     }
 

--- a/core/src/commands/cloud/helpers.ts
+++ b/core/src/commands/cloud/helpers.ts
@@ -70,7 +70,7 @@ export function handleBulkOperationResult<T>({
           ? `with ID ${e.identifier} `
           : e.identifier === ""
             ? ""
-            : `"${e.identifier} "`
+            : `"${e.identifier}" `
         return `→ ${capitalize(actionVerb)} ${resource} ${identifier}failed with error: ${e.message}`
       })
       .join("\n")


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip already existing secrets instead of failing in `garden cloud secrets create` command.

This behaviour applies to all input secret sources, i.e. when those are passed as CLI args or from an input file.

**Which issue(s) this PR fixes**:

Fixes #6048

**Special notes for your reviewer**:

Behaviour of secrets creation is now aligned with users creation.

The `--upsert` flag has not been implemented for `secrets create` command yet. It's available in the `secrets update` which, in turn, could be refactored and optimized; to avoid fetching all secrets and to share some secrets create/update/upsert machinery with the `secrets create` command.

It's better to refactor the `secrets update` command first, and the support the `--upsert` flag in the `secrets create` command too.