### PR TITLE
chore(images) use latest `k8s-reverse-proxy` image

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -51,7 +51,7 @@ export function getK8sSyncUtilImageName(): DockerImageWithDigest {
 }
 
 export const k8sReverseProxyImageName: DockerImageWithDigest =
-  "gardendev/k8s-reverse-proxy:0.1.0@sha256:df2976dc67c237114bd9c70e32bfe4d7131af98e140adf6dac29b47b85e07232"
+  "gardendev/k8s-reverse-proxy:0.1.1@sha256:2dff2275fc8c32cc0eba50eebd7ace6fdb007d9b3f4bd48d94355057324b2394"
 export const buildkitImageName: DockerImageWithDigest =
   "gardendev/buildkit:v0.12.2-1@sha256:5b30f6fa46e1fdb89b2255b4290dd3f9072b8f91fd6927b8d428e92498fbf8d0"
 export const buildkitRootlessImageName: DockerImageWithDigest =

--- a/examples/local-mode-k8s/backend/garden.yml
+++ b/examples/local-mode-k8s/backend/garden.yml
@@ -2,16 +2,15 @@ kind: Deploy
 name: backend
 description: Backend service container
 type: kubernetes
-dependencies:
-  - build.backend-image
-  - "${this.mode == 'local' ? ['run.build-backend-local'] : []}"
+
+dependencies: "${this.mode == 'local' ? ['run.build-backend-local'] : ['build.backend-image']}"
+
 spec:
-  image: ${actions.build.backend-image.outputs.deployment-image-id}
   localMode:
     ports:
       - local: 8090
         remote: 8080
-    command: ["../backend-local/main"]
+    command: [ "../backend-local/main" ]
     target:
       kind: Deployment
       name: backend-deployment

--- a/examples/local-mode/backend-1/garden.yml
+++ b/examples/local-mode/backend-1/garden.yml
@@ -12,7 +12,6 @@ type: container
 
 dependencies: "${this.mode == 'local' ? ['run.build-backend-local-1'] : ['build.backend-1']}"
 
-# You can specify variables here at the action level
 variables:
   ingressPath: /hello-backend-1
 
@@ -33,7 +32,6 @@ spec:
   ports:
     - name: http
       containerPort: 8080
-      # Maps service:80 -> container:8080
       servicePort: 80
   ingresses:
     - path: ${var.ingressPath}

--- a/examples/local-mode/backend-2/garden.yml
+++ b/examples/local-mode/backend-2/garden.yml
@@ -4,21 +4,25 @@ description: Backend 2 service container image
 type: container
 
 ---
+
 kind: Deploy
 name: backend-2
 description: Backend 2 service container
 type: container
-dependencies:
-  - build.backend-2
-  - "${this.mode == 'local' ? ['run.build-backend-local-2'] : []}"
+
+dependencies: "${this.mode == 'local' ? ['run.build-backend-local-2'] : ['build.backend-2']}"
+
 variables:
   ingressPath: /hello-backend-2
+
 spec:
+  image: ${actions.build.backend-2.outputs.deploymentImageId}
   localMode:
     ports:
       - remote: 8081
         local: 8091
-    command: ["../backend-local-2/main"]
+    # starts the local application
+    command: [ "../backend-local-2/main" ]
   healthCheck:
     httpGet:
       path: ${var.ingressPath}
@@ -30,4 +34,3 @@ spec:
   ingresses:
     - path: ${var.ingressPath}
       port: http
-  image: ${actions.build.backend-2.outputs.deploymentImageId}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR also fixes some broken local mode examples.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

A follow-up PR for #6072. The [linuxserver/openssh-server:version-9.6_p1-r0](https://hub.docker.com/layers/linuxserver/openssh-server/version-9.6_p1-r0/images/sha256-81bcc076d4365b7498cd63384688e4301b0f99304780d1b74e9795255c62c74a?context=explore) tag seems to be rewritable, so the `k8s-reverse-proxy` got a new base image in the version `0.1.1`. This PR takes the latest `k8s-reverse-proxy` into use.

Maybe we should consider sticking to `-ls...` builds like [this](https://hub.docker.com/layers/linuxserver/openssh-server/9.6_p1-r0-ls157/images/sha256-81bcc076d4365b7498cd63384688e4301b0f99304780d1b74e9795255c62c74a?context=explore). Just to keep the base image info transparent and clear.

That can be done in a separate PR later. The local mode doesn't seem to be used too often.