### PR TITLE
chore(deps): bump `segment/analytics-node` to `2.1.2`

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/sdk-trace-base": "^1.21.0",
     "@opentelemetry/semantic-conventions": "^1.21.0",
     "@scg82/exit-hook": "^3.4.1",
-    "@segment/analytics-node": "^1.1.3",
+    "@segment/analytics-node": "^2.1.2",
     "@types/ws": "^8.5.10",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,7 +1271,7 @@
         "@opentelemetry/sdk-trace-base": "^1.21.0",
         "@opentelemetry/semantic-conventions": "^1.21.0",
         "@scg82/exit-hook": "^3.4.1",
-        "@segment/analytics-node": "^1.1.3",
+        "@segment/analytics-node": "^2.1.2",
         "@types/ws": "^8.5.10",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -2331,23 +2331,26 @@
       }
     },
     "core/node_modules/@segment/analytics-node": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.1.2.tgz",
+      "integrity": "sha512-CIqWH5G0pB/LAFAZEZtntAxujiYIpdk0F+YGhfM6N/qt4/VLWjFcd4VZXVLW7xqaxig64UKWGQhe8bszXDRXXw==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.4.1",
-        "@segment/analytics-generic-utils": "1.1.1",
+        "@segment/analytics-core": "1.6.0",
+        "@segment/analytics-generic-utils": "1.2.0",
         "buffer": "^6.0.3",
+        "jose": "^5.1.0",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "core/node_modules/@segment/analytics-node/node_modules/@lukeed/uuid": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
       },
@@ -2357,31 +2360,35 @@
     },
     "core/node_modules/@segment/analytics-node/node_modules/@lukeed/uuid/node_modules/@lukeed/csprng": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "engines": {
         "node": ">=8"
       }
     },
     "core/node_modules/@segment/analytics-node/node_modules/@segment/analytics-core": {
-      "version": "1.4.1",
-      "license": "MIT",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.6.0.tgz",
+      "integrity": "sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-generic-utils": "1.1.1",
+        "@segment/analytics-generic-utils": "1.2.0",
         "dset": "^3.1.2",
         "tslib": "^2.4.1"
       }
     },
     "core/node_modules/@segment/analytics-node/node_modules/@segment/analytics-core/node_modules/dset": {
       "version": "3.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
       "engines": {
         "node": ">=4"
       }
     },
     "core/node_modules/@segment/analytics-node/node_modules/@segment/analytics-generic-utils": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
       "dependencies": {
         "tslib": "^2.4.1"
       }
@@ -2444,6 +2451,14 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "core/node_modules/@segment/analytics-node/node_modules/jose": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.3.0.tgz",
+      "integrity": "sha512-IChe9AtAE79ru084ow8jzkN2lNrG3Ntfiv65Cvj9uOCE2m5LNsdHG+9EbxWxAoWRF9TgDOqLN5jm08++owDVRg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "core/node_modules/@segment/analytics-node/node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
@@ -2480,7 +2495,8 @@
     },
     "core/node_modules/@segment/analytics-node/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "core/node_modules/@types/chai": {
       "version": "4.3.9",


### PR DESCRIPTION
**What this PR does / why we need it**:

Update `segment/analytics-node` to the latest available version. Cloud still uses `2.1.0` - it's better to update that too.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
