### PR TITLE
refactor(secrets): payload creation for `secrets update` command

### DIFF
--- a/core/test/unit/src/commands/cloud/secrets/secrets-update.ts
+++ b/core/test/unit/src/commands/cloud/secrets/secrets-update.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../../../src/commands/cloud/secrets/secrets-update.js"
 import { deline } from "../../../../../../src/util/string.js"
 import { expectError, getDataDir, makeTestGarden } from "../../../../../helpers.js"
-import type { Secret } from "../../../../../../src/cloud/api.js"
+import type { Secret, SingleUpdateSecretRequest } from "../../../../../../src/cloud/api.js"
 
 describe("SecretsUpdateCommand", () => {
   const projectRoot = getDataDir("test-project-b")
@@ -93,7 +93,7 @@ describe("SecretsUpdateCommand", () => {
     const garden = await makeTestGarden(projectRoot)
     const log = garden.log
     const inputSecrets: Secret[] = [{ name: "secret2", value: "foo" }]
-    const actual = await getSecretsToUpdateByName({
+    const actualSecret = await getSecretsToUpdateByName({
       allSecrets,
       environmentName: undefined,
       userId: undefined,
@@ -101,13 +101,15 @@ describe("SecretsUpdateCommand", () => {
       log,
     })
 
-    const expectedSecret = allSecrets.find((a) => a.id === "2")
-    expect(actual).to.eql([
-      {
-        ...expectedSecret,
-        newValue: "foo",
-      },
-    ])
+    const matchingSecret = allSecrets.find((a) => a.id === "2")!
+    const expectedSecret: SingleUpdateSecretRequest = {
+      id: matchingSecret.id,
+      environmentId: matchingSecret.environment?.id,
+      userId: matchingSecret.user?.id,
+      name: matchingSecret.name,
+      value: "foo",
+    }
+    expect(actualSecret).to.eql([expectedSecret])
   })
 
   it(`should throw an error when multiple secrets of same name are found, and user and env scopes are not set`, async () => {
@@ -138,7 +140,7 @@ describe("SecretsUpdateCommand", () => {
     const log = garden.log
     const inputSecrets: Secret[] = [{ name: "secret1", value: "foo" }]
 
-    const actual = await getSecretsToUpdateByName({
+    const actualSecret = await getSecretsToUpdateByName({
       allSecrets,
       environmentName: "env1",
       userId: "u1",
@@ -146,14 +148,15 @@ describe("SecretsUpdateCommand", () => {
       log,
     })
 
-    const expectedSecret = allSecrets.find((a) => a.id === "4")
-
-    expect(actual).to.eql([
-      {
-        ...expectedSecret,
-        newValue: "foo",
-      },
-    ])
+    const matchingSecret = allSecrets.find((a) => a.id === "4")!
+    const expectedSecret: SingleUpdateSecretRequest = {
+      id: matchingSecret.id,
+      environmentId: matchingSecret.environment?.id,
+      userId: matchingSecret.user?.id,
+      name: matchingSecret.name,
+      value: "foo",
+    }
+    expect(actualSecret).to.eql([expectedSecret])
   })
 
   it(`should get correct difference between new secrets and existing secrets for upsert`, async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

A follow-up PR to fix some bugs introduced in  #6068.

This also gets rid of unnecessary type `UpdateSecretBody`. Its `newValue` field was set but never read. The secrets to be updated did never get updated values.

Moreover, the `UpdateSecretBody.newValue` was set incorrectly, because it used  index-based access on array with the secret id/name used as an index value. That resulted to `undefined` value.

**Which issue(s) this PR fixes**:

Patches #6068

**Special notes for your reviewer**:

* The secrets updating logic is still a bit complicated and will be simplified in the next PRs.
* This has `refactor` commit header because it's a follow-up PR, not a bug fix for an issue that exists in an official release.
* The changes were tested manually by updating secrets by names and ids