### PR TITLE
refactor(cloud): unify input key/value resource reading and mapping

### DIFF
--- a/core/src/commands/cloud/helpers.ts
+++ b/core/src/commands/cloud/helpers.ts
@@ -166,17 +166,20 @@ export async function readInputKeyValueResources({
 
   // Get input resources from positional arguments in no input file defined.
   if (resourcesFromArgs) {
-    const resourceDictionary = resourcesFromArgs.reduce((acc, keyValPair) => {
-      try {
-        const resourceEntry = dotenv.parse(keyValPair)
-        Object.assign(acc, resourceEntry)
-        return acc
-      } catch (err) {
-        throw new CommandError({
-          message: `Unable to read ${resourceName} from argument ${keyValPair}: ${err}`,
-        })
-      }
-    }, {})
+    const resourceDictionary = resourcesFromArgs.reduce(
+      (acc, keyValPair) => {
+        try {
+          const resourceEntry = dotenv.parse(keyValPair)
+          Object.assign(acc, resourceEntry)
+          return acc
+        } catch (err) {
+          throw new CommandError({
+            message: `Unable to read ${resourceName} from argument ${keyValPair}: ${err}`,
+          })
+        }
+      },
+      {} as Record<string, string>
+    )
     return Object.entries(resourceDictionary)
   }
 

--- a/core/src/commands/cloud/secrets/secrets-update.ts
+++ b/core/src/commands/cloud/secrets/secrets-update.ts
@@ -120,19 +120,19 @@ export class SecretsUpdateCommand extends Command<Args, Opts> {
 
     const cmdLog = log.createLog({ name: "secrets-command" })
 
-    const inputSecrets: Secret[] = (
-      await readInputKeyValueResources({
-        resourceFilePath: secretsFilePath,
-        resourcesFromArgs: args.secretNamesOrIds,
-        resourceName: "secret",
-        log: cmdLog,
-      })
-    ).map(([key, value]) => ({ name: key, value }))
+    const inputSecrets = await readInputKeyValueResources({
+      resourceFilePath: secretsFilePath,
+      resourcesFromArgs: args.secretNamesOrIds,
+      resourceName: "secret",
+      log: cmdLog,
+    })
 
     const api = garden.cloudApi
     if (!api) {
       throw new ConfigurationError({ message: noApiMsg("update", "secrets") })
     }
+
+    const typedInputSecrets: Secret[] = inputSecrets.map(([key, value]): Secret => ({ name: key, value }))
 
     const project = await api.getProjectByIdOrThrow({
       projectId: garden.projectId,
@@ -145,7 +145,7 @@ export class SecretsUpdateCommand extends Command<Args, Opts> {
       api,
       environmentId,
       environmentName,
-      inputSecrets,
+      inputSecrets: typedInputSecrets,
       log,
       projectId: project.id,
       updateById,

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -10,6 +10,7 @@ import { ConfigurationError, GardenError } from "../../../exceptions.js"
 import type {
   CreateUserBulkRequest,
   CreateUserBulkResponse,
+  UserRequestBulk,
   UserResult as UserResultApi,
 } from "@garden-io/platform-api-types"
 import { printHeader } from "../../../logger/util.js"
@@ -97,11 +98,13 @@ export class UsersCreateCommand extends Command<Args, Opts> {
       throw new ConfigurationError({ message: noApiMsg("create", "users") })
     }
 
-    const usersToCreate = users.map(([vcsUsername, name]) => ({
-      name,
-      vcsUsername,
-      serviceAccount: false,
-    }))
+    const usersToCreate: UserRequestBulk[] = users.map(
+      ([vcsUsername, name]): UserRequestBulk => ({
+        name,
+        vcsUsername,
+        serviceAccount: false,
+      })
+    )
     cmdLog.info("Creating users...")
 
     const batches = chunk(usersToCreate, MAX_USERS_PER_REQUEST)


### PR DESCRIPTION
**What this PR does / why we need it**:

Align the flow with the `users create` command. Stick to the same validation order.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
