### PR TITLE
improvement(k8s): allow volume mounts in runners

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -303,8 +303,6 @@ export async function prepareRunPodSpec({
       name: mainContainerName,
       image,
       env,
-      // TODO: consider supporting volume mounts in ad-hoc runs (would need specific logic and testing)
-      volumeMounts: [],
     },
   ]
 
@@ -317,7 +315,9 @@ export async function prepareRunPodSpec({
     imagePullSecrets,
   }
 
-  if (volumes) {
+  // This logic is only relevant for `container` Runs and Tests, which need to support mounting `persistentvolumeclaim`
+  // and `configmap` actions (which are only supported for `container` actions, and are currently discouraged).
+  if (volumes && volumes.length && action.type === "container") {
     configureVolumes(action, preparedPodSpec, volumes)
   }
 

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -688,12 +688,10 @@ describe("kubernetes Pod runner functions", () => {
                 value: helmAction.versionString(),
               },
             ],
-            volumeMounts: [],
             command: ["echo", "foo"],
           },
         ],
         imagePullSecrets: [],
-        volumes: [],
       })
     })
 
@@ -743,12 +741,10 @@ describe("kubernetes Pod runner functions", () => {
                 value: helmAction.versionString(),
               },
             ],
-            volumeMounts: [],
             command: ["echo", "foo"],
           },
         ],
         imagePullSecrets: [],
-        volumes: [],
       })
     })
 
@@ -799,13 +795,76 @@ describe("kubernetes Pod runner functions", () => {
                 value: helmAction.versionString(),
               },
             ],
-            volumeMounts: [],
             command: ["echo", "foo"],
           },
         ],
         imagePullSecrets: [],
-        volumes: [],
         shareProcessNamespace: true,
+      })
+    })
+
+    it("should include volume mounts for containers in the generated pod spec", async () => {
+      const volumeMounts = [
+        {
+          name: "some-volume",
+          mountPath: "/some-volume",
+        },
+      ]
+      const helmContainerWithVolumeMounts = {
+        ...helmContainer,
+        volumeMounts,
+      }
+      const generatedPodSpec = await prepareRunPodSpec({
+        podSpec: undefined,
+        getArtifacts: false,
+        api: helmApi,
+        provider: helmProvider,
+        log: helmLog,
+        action: helmAction,
+        args: ["sh", "-c"],
+        command: ["echo", "foo"],
+
+        envVars: {},
+        resources,
+        description: "Helm module",
+        mainContainerName: "main",
+        image: "foo",
+        container: helmContainerWithVolumeMounts,
+        namespace: helmNamespace,
+        // Note: We're not passing the `volumes` param here, since that's for `container` Runs/Tests.
+        // This test case is intended for `kubernetes-pod` Runs and Tests.
+      })
+
+      expect(pruneEmpty(generatedPodSpec)).to.eql({
+        containers: [
+          {
+            name: "main",
+            image: "foo",
+            imagePullPolicy: "IfNotPresent",
+            args: ["sh", "-c"],
+            ports: [
+              {
+                name: "http",
+                containerPort: 80,
+                protocol: "TCP",
+              },
+            ],
+            resources: getResourceRequirements(resources),
+            env: [
+              {
+                name: "GARDEN_ACTION_VERSION",
+                value: helmAction.versionString(),
+              },
+              {
+                name: "GARDEN_MODULE_VERSION",
+                value: helmAction.versionString(),
+              },
+            ],
+            volumeMounts, // <------
+            command: ["echo", "foo"],
+          },
+        ],
+        imagePullSecrets: [],
       })
     })
 
@@ -858,7 +917,6 @@ describe("kubernetes Pod runner functions", () => {
                 value: helmAction.versionString(),
               },
             ],
-            volumeMounts: [],
             command: ["echo", "foo"],
             securityContext: {
               privileged: true,
@@ -870,7 +928,6 @@ describe("kubernetes Pod runner functions", () => {
           },
         ],
         imagePullSecrets: [],
-        volumes: [],
       })
     })
 
@@ -944,12 +1001,10 @@ describe("kubernetes Pod runner functions", () => {
                 value: helmAction.versionString(),
               },
             ],
-            volumeMounts: [],
             command: ["echo", "foo"],
           },
         ],
         imagePullSecrets: [],
-        volumes: [],
       })
     })
 
@@ -1024,12 +1079,10 @@ describe("kubernetes Pod runner functions", () => {
                 value: helmAction.versionString(),
               },
             ],
-            volumeMounts: [],
             command: ["echo", "foo"],
           },
         ],
         imagePullSecrets: [],
-        volumes: [],
       })
     })
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

If a `kubernetes-pod` Run or Test includes `volumeMounts` on the first container in its `podSpec`, we now include this in the runner pod.

Previously, we omitted the `volumeMounts` field from the first container in the (optional) user-supplied `podSpec` field. This is because the relevant code assumed `container` Runs/Tests—it's now appropriate for `container` and `kubernetes-pod` Runs/Tests.

**Which issue(s) this PR fixes**:

Fixes #6069.