### PR TITLE
chore: add commit header for bundled tool version updates

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -11,6 +11,7 @@ options:
         - fix
         - perf
         - improvement
+        - tool
     sort_by: Scope
   commit_groups:
     group_by: Type
@@ -21,6 +22,7 @@ options:
       perf: Performance Improvements
       improvement: Improvements
       refactor: Code Refactoring
+      tool: Bundled Tool Version Updates
   header:
     pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
     pattern_maps:

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
       "revert",
       "style",
       "test",
+      "tool",
     ]]
   }
 };

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -66,6 +66,7 @@ We follow the [Conventional Commits specification](https://www.conventionalcommi
 * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
   semi-colons, etc).
 * **test**: Adding missing or correcting existing tests.
+* **tool**: A version update for a bundled tool version used by Garden.
 
 When generating the changelog, we only include the following types: **feat**, **fix**, **refactor**, **improvement**, and **perf**. This means that any changes that the user should be aware of, should have one of these types.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Now we can use **tool** commit header for version updates of the Garden's embedded tools. Let's also expose these changes in the release notes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
