### PR TITLE
chore(images): [0.12] restore `skopeo` image

### DIFF
--- a/images/skopeo/Dockerfile
+++ b/images/skopeo/Dockerfile
@@ -1,0 +1,10 @@
+FROM danifernandezs/skopeo:1.41.0-alpine3.10.3
+
+RUN apk add --no-cache curl
+RUN cd /usr/local/bin && \
+  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-amd64/docker-credential-ecr-login && \
+  chmod +x docker-credential-ecr-login
+
+RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz" \
+  | tar xz --to-stdout ./docker-credential-gcr \
+  > /usr/local/bin/docker-credential-gcr && chmod +x /usr/local/bin/docker-credential-gcr

--- a/images/skopeo/garden.yml
+++ b/images/skopeo/garden.yml
@@ -1,0 +1,7 @@
+kind: Module
+type: container
+name: skopeo
+description: Used by the kubernetes provider for interacting with container registries within a cluster
+image: gardendev/skopeo:1.41.0-3
+dockerfile: Dockerfile
+extraFlags: [ "--platform", "linux/amd64" ]


### PR DESCRIPTION
Partially reverts #6132.

The `skopeo` image is used by some components in `static/kubernetes/system`. So, let's restore it to see what exactly is used in the system namespace.

The `skopeo` image is not used in the code, so it's not necessary to revert the dead code deletion. 