### PR TITLE
tool(kuztomize): support version `5.4.2` and use it by default

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -346,8 +346,8 @@ async function readKustomizeManifests(
     return []
   }
 
-  const kustomizePath = spec.kustomize!.path
-  const kustomize = ctx.tools["kubernetes.kustomize"]
+  const kustomizePath = spec.kustomize.path
+  const kustomize = ctx.tools["kubernetes.kustomize-" + spec.kustomize.version]
 
   const extraArgs = spec.kustomize.extraArgs || []
 

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -95,7 +95,6 @@ export const kustomize4Spec: PluginToolSpec = {
   ],
 }
 
-
 export const kustomize5Version = "5.4.2"
 
 export const kustomize5Spec: PluginToolSpec = {

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -94,3 +94,66 @@ export const kustomize4Spec: PluginToolSpec = {
     },
   ],
 }
+
+
+export const kustomize5Version = "5.4.2"
+
+export const kustomize5Spec: PluginToolSpec = {
+  name: "kustomize",
+  version: kustomize5Version,
+  description: `The kustomize config management CLI, v${kustomize5Version}`,
+  type: "binary",
+  // _includeInGardenImage: true,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize5Version}/kustomize_v${kustomize5Version}_darwin_amd64.tar.gz`,
+      sha256: "d1dadf6d51058cdda6470344c95767e1c283cc5a36d5019eb32f8e43e63bd0df",
+      extract: {
+        format: "tar",
+        targetPath: "kustomize",
+      },
+    },
+    {
+      platform: "darwin",
+      architecture: "arm64",
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize5Version}/kustomize_v${kustomize5Version}_darwin_arm64.tar.gz`,
+      sha256: "9b7da623cb40542f2dd220fa31d906d9254759b4e27583706e4e846fccba9fab",
+      extract: {
+        format: "tar",
+        targetPath: "kustomize",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize5Version}/kustomize_v${kustomize5Version}_linux_amd64.tar.gz`,
+      sha256: "881c6e9007c7ea2b9ecc214d13f4cdd1f837635dcf4db49ce4479898f7d911a3",
+      extract: {
+        format: "tar",
+        targetPath: "kustomize",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "arm64",
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize5Version}/kustomize_v${kustomize5Version}_linux_arm64.tar.gz`,
+      sha256: "175af88af8a7d8d7d6b1f26659060950f0764d00b9979b4e11b61b8b212b7c22",
+      extract: {
+        format: "tar",
+        targetPath: "kustomize",
+      },
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize5Version}/kustomize_v${kustomize5Version}_windows_amd64.zip`,
+      sha256: "56a91ef90f2f3a9625004a053d002e15039dfe3c6222113d97be9568511a6ae4",
+      extract: {
+        format: "zip",
+        targetPath: "kustomize.exe",
+      },
+    },
+  ],
+}

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -11,6 +11,7 @@ import type { PluginToolSpec } from "../../../plugin/tools.js"
 
 export interface KubernetesKustomizeSpec {
   path: string
+  version: number
   extraArgs?: string[]
 }
 
@@ -25,6 +26,7 @@ export const kustomizeSpecSchema = () =>
         .description(
           "The directory path where the desired kustomization.yaml is, or a git repository URL. This could be the path to an overlay directory, for example. If it's a path, must be a relative POSIX-style path and must be within the action root. Defaults to the action root. If you set this to null, kustomize will not be run."
         ),
+      version: joi.number().integer().valid(4, 5).default(4).description("The Kustomize version to use."),
       extraArgs: joiSparseArray(joi.string()).description(
         "A list of additional arguments to pass to the `kustomize build` command. Note that specifying '-o' or '--output' is not allowed."
       ),
@@ -36,7 +38,7 @@ export const kustomizeSpecSchema = () =>
 export const kustomize4Version = "4.5.7"
 
 export const kustomize4Spec: PluginToolSpec = {
-  name: "kustomize",
+  name: "kustomize-4",
   version: kustomize4Version,
   description: `The kustomize config management CLI, v${kustomize4Version}`,
   type: "binary",
@@ -98,7 +100,7 @@ export const kustomize4Spec: PluginToolSpec = {
 export const kustomize5Version = "5.4.2"
 
 export const kustomize5Spec: PluginToolSpec = {
-  name: "kustomize",
+  name: "kustomize-5",
   version: kustomize5Version,
   description: `The kustomize config management CLI, v${kustomize5Version}`,
   type: "binary",

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -26,7 +26,7 @@ export const kustomizeSpecSchema = () =>
         .description(
           "The directory path where the desired kustomization.yaml is, or a git repository URL. This could be the path to an overlay directory, for example. If it's a path, must be a relative POSIX-style path and must be within the action root. Defaults to the action root. If you set this to null, kustomize will not be run."
         ),
-      version: joi.number().integer().valid(4, 5).default(4).description("The Kustomize version to use."),
+      version: joi.number().integer().valid(4, 5).default(5).description("The Kustomize version to use."),
       extraArgs: joiSparseArray(joi.string()).description(
         "A list of additional arguments to pass to the `kustomize build` command. Note that specifying '-o' or '--output' is not allowed."
       ),

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -33,19 +33,19 @@ export const kustomizeSpecSchema = () =>
       "Resolve the specified kustomization and include the resulting resources. Note that if you specify `files` or `manifests` as well, these are also included."
     )
 
-export const kustomizeVersion = "4.5.7"
+export const kustomize4Version = "4.5.7"
 
-export const kustomizeSpec: PluginToolSpec = {
+export const kustomize4Spec: PluginToolSpec = {
   name: "kustomize",
-  version: kustomizeVersion,
-  description: `The kustomize config management CLI, v${kustomizeVersion}`,
+  version: kustomize4Version,
+  description: `The kustomize config management CLI, v${kustomize4Version}`,
   type: "binary",
   _includeInGardenImage: true,
   builds: [
     {
       platform: "darwin",
       architecture: "amd64",
-      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomizeVersion}/kustomize_v${kustomizeVersion}_darwin_amd64.tar.gz`,
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize4Version}/kustomize_v${kustomize4Version}_darwin_amd64.tar.gz`,
       sha256: "6fd57e78ed0c06b5bdd82750c5dc6d0f992a7b926d114fe94be46d7a7e32b63a",
       extract: {
         format: "tar",
@@ -55,7 +55,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "arm64",
-      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomizeVersion}/kustomize_v${kustomizeVersion}_darwin_arm64.tar.gz`,
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize4Version}/kustomize_v${kustomize4Version}_darwin_arm64.tar.gz`,
       sha256: "3c1e8b95cef4ff6e52d5f4b8c65b8d9d06b75f42d1cb40986c1d67729d82411a",
       extract: {
         format: "tar",
@@ -65,7 +65,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomizeVersion}/kustomize_v${kustomizeVersion}_linux_amd64.tar.gz`,
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize4Version}/kustomize_v${kustomize4Version}_linux_amd64.tar.gz`,
       sha256: "701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9",
       extract: {
         format: "tar",
@@ -75,7 +75,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "arm64",
-      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomizeVersion}/kustomize_v${kustomizeVersion}_linux_arm64.tar.gz`,
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize4Version}/kustomize_v${kustomize4Version}_linux_arm64.tar.gz`,
       sha256: "65665b39297cc73c13918f05bbe8450d17556f0acd16242a339271e14861df67",
       extract: {
         format: "tar",
@@ -85,7 +85,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomizeVersion}/kustomize_v${kustomizeVersion}_windows_amd64.tar.gz`,
+      url: `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${kustomize4Version}/kustomize_v${kustomize4Version}_windows_amd64.tar.gz`,
       sha256: "79af25f97bb10df999e540def94e876555696c5fe42d4c93647e28f83b1efc55",
       extract: {
         format: "tar",

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -42,7 +42,6 @@ export const kustomize4Spec: PluginToolSpec = {
   version: kustomize4Version,
   description: `The kustomize config management CLI, v${kustomize4Version}`,
   type: "binary",
-  _includeInGardenImage: true,
   builds: [
     {
       platform: "darwin",
@@ -104,7 +103,7 @@ export const kustomize5Spec: PluginToolSpec = {
   version: kustomize5Version,
   description: `The kustomize config management CLI, v${kustomize5Version}`,
   type: "binary",
-  // _includeInGardenImage: true,
+  _includeInGardenImage: true,
   builds: [
     {
       platform: "darwin",

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -41,7 +41,7 @@ import {
 import { getHelmDeployDocs, helmDeployDefinition } from "./helm/action.js"
 import { jibContainerHandlers, k8sJibContainerBuildExtension } from "./jib-container.js"
 import { kubernetesDeployDefinition, kubernetesDeployDocs } from "./kubernetes-type/deploy.js"
-import { kustomize4Spec } from "./kubernetes-type/kustomize.js"
+import { kustomize4Spec, kustomize5Spec } from "./kubernetes-type/kustomize.js"
 import { syncPause, syncResume, syncStatus } from "./commands/sync.js"
 import { helmPodRunDefinition, helmPodTestDefinition } from "./helm/helm-pod.js"
 import { kubernetesPodRunDefinition, kubernetesPodTestDefinition } from "./kubernetes-type/kubernetes-pod.js"
@@ -221,6 +221,6 @@ export const gardenPlugin = () => {
         needsBuild: true,
       },
     ],
-    tools: [kubectlSpec, kustomize4Spec, helm3Spec, mutagenCliSpec],
+    tools: [kubectlSpec, kustomize4Spec, kustomize5Spec, helm3Spec, mutagenCliSpec],
   })
 }

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -41,7 +41,7 @@ import {
 import { getHelmDeployDocs, helmDeployDefinition } from "./helm/action.js"
 import { jibContainerHandlers, k8sJibContainerBuildExtension } from "./jib-container.js"
 import { kubernetesDeployDefinition, kubernetesDeployDocs } from "./kubernetes-type/deploy.js"
-import { kustomizeSpec } from "./kubernetes-type/kustomize.js"
+import { kustomize4Spec } from "./kubernetes-type/kustomize.js"
 import { syncPause, syncResume, syncStatus } from "./commands/sync.js"
 import { helmPodRunDefinition, helmPodTestDefinition } from "./helm/helm-pod.js"
 import { kubernetesPodRunDefinition, kubernetesPodTestDefinition } from "./kubernetes-type/kubernetes-pod.js"
@@ -221,6 +221,6 @@ export const gardenPlugin = () => {
         needsBuild: true,
       },
     ],
-    tools: [kubectlSpec, kustomizeSpec, helm3Spec, mutagenCliSpec],
+    tools: [kubectlSpec, kustomize4Spec, helm3Spec, mutagenCliSpec],
   })
 }

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -8,7 +8,7 @@
 
 import { mutagenCliSpecLegacy, mutagenCliSpecNative, mutagenFauxSshSpec } from "../../../src/mutagen.js"
 import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
-import { kustomize4Spec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
+import { kustomize4Spec, kustomize5Spec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helm3Spec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
 import { downloadBinariesAndVerifyHashes } from "../../../src/util/testing.js"
 import { dockerSpec, namespaceCliSpec } from "../../../src/plugins/container/container.js"
@@ -34,7 +34,13 @@ describe("Kubectl binaries", () => {
 })
 
 describe("Kustomize binaries", () => {
-  downloadBinariesAndVerifyHashes([kustomize4Spec])
+  describe("Version 4", () => {
+    downloadBinariesAndVerifyHashes([kustomize4Spec])
+  })
+
+  describe("Version 5", () => {
+    downloadBinariesAndVerifyHashes([kustomize5Spec])
+  })
 })
 
 describe("Helm binaries", () => {

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -8,7 +8,7 @@
 
 import { mutagenCliSpecLegacy, mutagenCliSpecNative, mutagenFauxSshSpec } from "../../../src/mutagen.js"
 import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
-import { kustomizeSpec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
+import { kustomize4Spec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helm3Spec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
 import { downloadBinariesAndVerifyHashes } from "../../../src/util/testing.js"
 import { dockerSpec, namespaceCliSpec } from "../../../src/plugins/container/container.js"
@@ -34,7 +34,7 @@ describe("Kubectl binaries", () => {
 })
 
 describe("Kustomize binaries", () => {
-  downloadBinariesAndVerifyHashes([kustomizeSpec])
+  downloadBinariesAndVerifyHashes([kustomize4Spec])
 })
 
 describe("Helm binaries", () => {

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -309,6 +309,16 @@ The directory path where the desired kustomization.yaml is, or a git repository 
 | --------------------- | ------- | -------- |
 | `posixPath \| string` | `"."`   | No       |
 
+### `spec.kustomize.version`
+
+[spec](#spec) > [kustomize](#speckustomize) > version
+
+The Kustomize version to use.
+
+| Type     | Allowed Values | Default | Required |
+| -------- | -------------- | ------- | -------- |
+| `number` | 4, 5           | `5`     | Yes      |
+
 ### `spec.kustomize.extraArgs[]`
 
 [spec](#spec) > [kustomize](#speckustomize) > extraArgs

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -428,6 +428,16 @@ The directory path where the desired kustomization.yaml is, or a git repository 
 | --------------------- | ------- | -------- |
 | `posixPath \| string` | `"."`   | No       |
 
+### `spec.kustomize.version`
+
+[spec](#spec) > [kustomize](#speckustomize) > version
+
+The Kustomize version to use.
+
+| Type     | Allowed Values | Default | Required |
+| -------- | -------------- | ------- | -------- |
+| `number` | 4, 5           | `5`     | Yes      |
+
 ### `spec.kustomize.extraArgs[]`
 
 [spec](#spec) > [kustomize](#speckustomize) > extraArgs

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -428,6 +428,16 @@ The directory path where the desired kustomization.yaml is, or a git repository 
 | --------------------- | ------- | -------- |
 | `posixPath \| string` | `"."`   | No       |
 
+### `spec.kustomize.version`
+
+[spec](#spec) > [kustomize](#speckustomize) > version
+
+The Kustomize version to use.
+
+| Type     | Allowed Values | Default | Required |
+| -------- | -------------- | ------- | -------- |
+| `number` | 4, 5           | `5`     | Yes      |
+
 ### `spec.kustomize.extraArgs[]`
 
 [spec](#spec) > [kustomize](#speckustomize) > extraArgs

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -186,6 +186,9 @@ kustomize:
   # root. Defaults to the action root. If you set this to null, kustomize will not be run.
   path: .
 
+  # The Kustomize version to use.
+  version: 5
+
   # A list of additional arguments to pass to the `kustomize build` command. Note that specifying '-o' or '--output'
   # is not allowed.
   extraArgs: []
@@ -945,6 +948,16 @@ The directory path where the desired kustomization.yaml is, or a git repository 
 | Type                  | Default | Required |
 | --------------------- | ------- | -------- |
 | `posixPath \| string` | `"."`   | No       |
+
+### `kustomize.version`
+
+[kustomize](#kustomize) > version
+
+The Kustomize version to use.
+
+| Type     | Allowed Values | Default | Required |
+| -------- | -------------- | ------- | -------- |
+| `number` | 4, 5           | `5`     | Yes      |
 
 ### `kustomize.extraArgs[]`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for the latest available major version of `kustomize`, and uses it by default in the code and Docker images.

**Which issue(s) this PR fixes**:

Fixes #6128

**Special notes for your reviewer**:

Multi-version tool lookup still requires some hard-coding and manual lookup-key construction. So, a few files should be modified at once despite there is no obvious connection between them.

This is how it's done in nother multi-version tools. It would be nice to refactor that approach, but nice things are nice :)
The refactoring can be done for all tools in separate PR(s).