### PR TITLE
tool(mutagen): update to version `0.17.6`

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -904,7 +904,7 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
 }
 
 const mutagenVersionLegacy = "0.15.0"
-const mutagenVersionNative = "0.17.5"
+const mutagenVersionNative = "0.17.6"
 
 export const mutagenVersion = gardenEnv.GARDEN_ENABLE_NEW_SYNC ? mutagenVersionNative : mutagenVersionLegacy
 
@@ -982,7 +982,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
         platform: "darwin",
         architecture: "amd64",
         url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_darwin_amd64_v${mutagenVersionNative}.tar.gz`,
-        sha256: "5b963b3dab36ac8a3d2a87ca162717bf2172fd8ca7410d477a78affd7631a45d",
+        sha256: "f082eef2ae405a6bf5effdbcd000bb5fe2bc7b0968f86b2b54d9d3260c48c739",
         extract: {
           format: "tar",
           targetPath: "mutagen",
@@ -992,7 +992,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
         platform: "darwin",
         architecture: "arm64",
         url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_darwin_arm64_v${mutagenVersionNative}.tar.gz`,
-        sha256: "4dbbbc222a3986705a998343ff23d69e62bfe1c4e341ef9f1cdf39d25a37c324",
+        sha256: "b6c35942ca9cbbbf726bfa249da554d829a8a28cad620a55e02d098d692121d1",
         extract: {
           format: "tar",
           targetPath: "mutagen",
@@ -1002,7 +1002,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
         platform: "linux",
         architecture: "amd64",
         url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_linux_amd64_v${mutagenVersionNative}.tar.gz`,
-        sha256: "cabee0af590faf822cb5542437e254406b0f037df43781c02bf6eeac267911f6",
+        sha256: "1b826e121be59506e133d90dc2b8a0c820b92f480d9b2b230d8b389d6178a6cf",
         extract: {
           format: "tar",
           targetPath: "mutagen",
@@ -1012,7 +1012,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
         platform: "linux",
         architecture: "arm64",
         url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_linux_arm64_v${mutagenVersionNative}.tar.gz`,
-        sha256: "bbe92496c2bad6424a879490ca5b49da36c80e28e7b866201fcaf7a959037237",
+        sha256: "2a383cb572a1bdad83f7c4be3cc4a541a58e6c9e11e326ee4cc2d0e14f9d003a",
         extract: {
           format: "tar",
           targetPath: "mutagen",
@@ -1022,7 +1022,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
         platform: "windows",
         architecture: "amd64",
         url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_windows_amd64_v${mutagenVersionNative}.zip`,
-        sha256: "63ed4b217f798f49039cae5db4b63f592217be5685282e3669a9b6a4ae18cb64",
+        sha256: "3019ccb556afb39cf2213adcacab97576c4419f8d08d3a55d063a5c773ec6d35",
         extract: {
           format: "zip",
           targetPath: "mutagen.exe",

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -35,7 +35,7 @@ export const defaultIngressClass = "nginx"
 export const k8sUtilImageNameLegacy: DockerImageWithDigest =
   "gardendev/k8s-util:0.5.7@sha256:522da245a5e6ae7c711aa94f84fc83f82a8fdffbf6d8bc48f4d80fee0e0e631b"
 export const k8sUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-util:0.6.0-2@sha256:a1d81c49312166a292a4d5262e6006b28c76923b7d56029316cf52b4695a7e88"
+  "gardendev/k8s-util:0.6.1@sha256:e48d67309f97ac698bea4ae270d36884af1b6df0a2ac9a5c40e6acb27a2a6fb2"
 
 export function getK8sUtilImageName(): DockerImageWithDigest {
   return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sUtilImageName : k8sUtilImageNameLegacy
@@ -44,7 +44,7 @@ export function getK8sUtilImageName(): DockerImageWithDigest {
 export const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
   "gardendev/k8s-sync:0.1.5@sha256:28263cee5ac41acebb8c08f852c4496b15e18c0c94797d7a949a4453b5f91578"
 export const k8sSyncUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-sync:0.2.0-2@sha256:20dae30e3973d14b311046168bc0a00e5aee943764ae11e36f0f914ecee2edf4"
+  "gardendev/k8s-sync:0.2.1@sha256:90a583672c63e61031a036900753cb6a8a6b0b7dc20909e2abcc079a1120127b"
 
 export function getK8sSyncUtilImageName(): DockerImageWithDigest {
   return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sSyncUtilImageName : k8sSyncUtilImageNameLegacy

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -4,13 +4,13 @@ RUN apk add --no-cache wget
 
 ARG TARGETARCH
 # Get mutagen agent
-RUN MUTAGEN_VERSION="0.17.5" && \
+RUN MUTAGEN_VERSION="0.17.6" && \
   mutagen_distr_name="mutagen_linux_${TARGETARCH}_v${MUTAGEN_VERSION}.tar.gz" && \
   wget "https://github.com/mutagen-io/mutagen/releases/download/v${MUTAGEN_VERSION}/${mutagen_distr_name}" && \
   if [ "$TARGETARCH" = "amd64" ]; then \
-    echo "cabee0af590faf822cb5542437e254406b0f037df43781c02bf6eeac267911f6 ${mutagen_distr_name}" | sha256sum -c; \
+    echo "1b826e121be59506e133d90dc2b8a0c820b92f480d9b2b230d8b389d6178a6cf ${mutagen_distr_name}" | sha256sum -c; \
   elif [ "$TARGETARCH" = "arm64" ]; then \
-    echo "bbe92496c2bad6424a879490ca5b49da36c80e28e7b866201fcaf7a959037237 ${mutagen_distr_name}" | sha256sum -c; \
+    echo "2a383cb572a1bdad83f7c4be3cc4a541a58e6c9e11e326ee4cc2d0e14f9d003a ${mutagen_distr_name}" | sha256sum -c; \
   fi && \
   tar xzf ${mutagen_distr_name} --to-stdout mutagen-agents.tar.gz \
   | tar xz --to-stdout linux_amd64 > /usr/local/bin/mutagen-agent && \

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -6,7 +6,7 @@ variables:
   publish: false
   image_name: gardendev/k8s-sync
   image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: 0.2.0-2 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
+  release_tag: 0.2.1 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
 spec:
   localId: ${var.image_name}
   dockerfile: Dockerfile

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -7,7 +7,7 @@ variables:
   publish: false
   image_name: gardendev/k8s-util
   image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: 0.6.0-2 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
+  release_tag: 0.6.1 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
 spec:
   localId: ${var.image_name}
   dockerfile: Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated the native Mutagen client to the latest available stable version `0.17.6`.
The native Mutagen client is still available via `GARDEN_ENABLE_NEW_SYNC=1` feature flag.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
