### PR TITLE
refactor(vcs): less coupling between `VcsHandler` and `Garden` classes

### DIFF
--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -94,7 +94,7 @@ export class GitRepoHandler extends AbstractGitHandler {
       scanRoot = await this.getRepoRoot(log, path, failOnPrompt)
     }
 
-    const scanFromProjectRoot = scanRoot === this.garden?.projectRoot
+    const scanFromProjectRoot = scanRoot === this.projectRoot
     const { augmentedExcludes, augmentedIncludes } = await getIncludeExcludeFiles({ ...params, scanFromProjectRoot })
 
     const hashedFilterParams = hashString(

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -119,23 +119,23 @@ export abstract class AbstractGitHandler extends VcsHandler {
   private readonly repoRoots: Map<string, string>
   protected readonly lock: AsyncLock
 
-  constructor(params: VcsHandlerParams) {
+  protected constructor(params: VcsHandlerParams) {
     super(params)
     this.repoRoots = new Map<string, string>()
     this.lock = new AsyncLock()
   }
 
   async getRepoRoot(log: Log, path: string, failOnPrompt = false): Promise<string> {
-    const repoRoot = this.repoRoots.get(path)
-    if (!!repoRoot) {
-      return repoRoot
+    let cachedRepoRoot = this.repoRoots.get(path)
+    if (!!cachedRepoRoot) {
+      return cachedRepoRoot
     }
 
     // Make sure we're not asking concurrently for the same root
     return this.lock.acquire(`repo-root:${path}`, async () => {
-      const repoRoot = this.repoRoots.get(path)
-      if (!!repoRoot) {
-        return repoRoot
+      cachedRepoRoot = this.repoRoots.get(path)
+      if (!!cachedRepoRoot) {
+        return cachedRepoRoot
       }
 
       try {

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -164,7 +164,9 @@ export interface VcsHandlerParams {
 
 @Profile()
 export abstract class VcsHandler {
-  private readonly projectRoot: string
+  protected readonly projectRoot: string
+  // TODO: this is used only in 1 place to emit a warning;
+  //  consider moving warning machinery outside Garden class to remove the reference to Garden from here
   protected readonly garden?: Garden
   protected readonly gardenDirPath: string
   protected readonly ignoreFile: string


### PR DESCRIPTION
Class `VcsHandler` already stores the same `projectRoot` as `Garden` does. No need to read the project root from Garden.
Thus, the `VcsHandler` references `Garden` only to use its warning-emitting machinery. That can be decoupled as well.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
