### PR TITLE
fix: 🐛 load valuefiles from config file location

### DIFF
--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -294,7 +294,7 @@ export async function getValueArgs({
   // so it's added to the end of the list.
   const valueFiles = action
     .getSpec()
-    .valueFiles.map((f) => resolve(action.getBuildPath(), f))
+    .valueFiles.map((f) => resolve(action.effectiveConfigFileLocation(), f))
     .concat([valuesPath])
 
   const args = flatten(valueFiles.map((f) => ["--values", f]))

--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -298,18 +298,7 @@ export async function getValueArgs({
       const pathViaBuildPath = resolve(action.getBuildPath(), f)
       const pathViaEffectiveConfigFileLocation = resolve(action.effectiveConfigFileLocation(), f)
 
-      const path = pathExistsSync(pathViaBuildPath)
-        ? pathViaBuildPath
-        : pathExistsSync(pathViaEffectiveConfigFileLocation)
-          ? pathViaEffectiveConfigFileLocation
-          : null
-
-      if (!path) {
-        throw new ConfigurationError({
-          message: `${action.longDescription()} specifies a value file '${f}' that does not exist at '${pathViaBuildPath}' or '${pathViaEffectiveConfigFileLocation}'`,
-        })
-      }
-      return path
+      return pathExistsSync(pathViaBuildPath) ? pathViaBuildPath : pathViaEffectiveConfigFileLocation
     })
     .concat([valuesPath])
 

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -637,6 +637,18 @@ ${expectedIngressOutput}
         gardenValuesPath,
       ])
     })
+
+    it("should allow valueFiles relative to action config", async () => {
+      const action = await garden.resolveAction<HelmDeployAction>({ action: graph.getDeploy("api"), log, graph })
+      action["_config"].spec.valueFiles = ["./values.yaml"]
+
+      expect(await getValueArgs({ action, valuesPath: gardenValuesPath })).to.eql([
+        "--values",
+        resolve(action.effectiveConfigFileLocation(), "./values.yaml"),
+        "--values",
+        gardenValuesPath,
+      ])
+    })
   })
 
   describe("getReleaseName", () => {


### PR DESCRIPTION
What this PR does / why we need it:

fix read `valueFiles` in helm deployments with sources.repository.url

Which issue(s) this PR fixes:

Fixes https://github.com/garden-io/garden/issues/6146

Special notes for your reviewer:
It's same like #6147 just for `valueFiles` @stefreak 

---

I did test it against this (new uncommitted) example:

<details><summary>show example</summary>

examples/remote-helm/garden.yml
```yaml
apiVersion: garden.io/v1
kind: Project
name: remote-helm
environments:
  - name: local
    variables:
      baseHostname: remote-helm.local.demo.garden
providers:
  - name: local-kubernetes
    environments: [local]
variables:
  userId: ${kebabCase(local.username)}
```

examples/remote-helm/redis.garden.yml
```yaml
kind: Deploy
description: Redis service for queueing votes before they are aggregated
type: helm
name: redis
varfiles:
  - ./.env
source:
  repository: 
    url: https://github.com/bitnami/charts#main
spec:
  chart:
    path: bitnami/redis
  valueFiles:
    - values.yml
```


examples/remote-helm/values.yml
```yaml
auth:
  enabled: false
```

examples/remote-helm/.env
```env
TEST=test
```

</details>