### PR TITLE
chore(dockerhub): bump Google Cloud SDK to `479.0.0` in `debian.Dockerfile`

### DIFF
--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -80,8 +80,8 @@ RUN ./aws/install
 # garden-gcloud-base
 #
 FROM garden-base as garden-gcloud-base
-ENV GCLOUD_VERSION=478.0.0
-ENV GCLOUD_SHA256="225c3a1f9b47241467a4ad8da0f432a57bade10c8d44158920003ae698f6d195"
+ENV GCLOUD_VERSION=479.0.0
+ENV GCLOUD_SHA256="82b01bc36bd60ea9ce0284de3e424f7b09f54acc9118b353f15951d33c5fe15c"
 
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN echo "${GCLOUD_SHA256}  google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" | sha256sum -c


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports #6164 to `debian.Dockerfile`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
