### PR TITLE
chore(dockerhub): stick to Alpine 3.19 for Python compatibility

### DIFF
--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -4,7 +4,7 @@ ARG VARIANT=root
 
 # NOTE: This is not the node version Garden itself will run in. Garden binaries have node "built in" and the version installed on the system does not matter.
 # The main reason we base these images off of the Node image is for Azure DevOps Support.
-FROM node:22.2.0-alpine@sha256:9e8f45fc08c709b1fd87baeeed487977f57585f85f3838c01747602cd85a64bb as garden-base-root
+FROM node:22.2.0-alpine3.19@sha256:e6d449575e1696cbaee6ec1adce2ac220dc138c4b7bc053379b53c68a6bd2799 as garden-base-root
 
 RUN apk add --no-cache \
   bash \


### PR DESCRIPTION
**What this PR does / why we need it**:

Supersedes #6163

**Special notes for your reviewer**:

We can switch to Python 3.12 when all SDKs (GCP, AWS and Azure) support it properly. Afaik, Azure has no Python 3.12 support yet, see https://github.com/Azure/azure-cli/issues/27673