### PR TITLE
fix(git): fix repo scan result caching

### DIFF
--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -60,7 +60,7 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GitRepoGetFilesParams, 
   return { include, exclude, augmentedIncludes, augmentedExcludes }
 }
 
-function getHashedFilterParams({
+export function getHashedFilterParams({
   filter,
   augmentedIncludes,
   augmentedExcludes,

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -45,7 +45,7 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GitRepoGetFilesParams, 
   // Make sure action config is not mutated.
   let exclude = !params.exclude ? [] : [...params.exclude]
 
-  // Do the same normalization of the excluded paths like in `GitHandler`.
+  // Do the same normalization of the excluded paths like in "subtree" scanning mode.
   // This might be redundant because the non-normalized paths will be handled by `augmentGlobs` below.
   // But this brings no harm and makes the implementation more clear.
   exclude = exclude.map(normalize)
@@ -90,7 +90,7 @@ export class GitRepoHandler extends AbstractGitHandler {
   }
 
   /**
-   * This has the same signature as the GitHandler super class method but instead of scanning the individual directory
+   * This has the same signature as the `GitSubTreeHandler` class method but instead of scanning the individual directory
    * path directly, we scan the entire enclosing git repository, cache that file list and then filter down to the
    * sub-path. This results in far fewer git process calls but in turn collects more data in memory.
    */

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -72,8 +72,8 @@ export function getHashedFilterParams({
   return hashString(
     stableStringify({
       filter: filter ? filter.toString() : undefined, // We hash the source code of the filter function if provided.
-      augmentedIncludes,
-      augmentedExcludes,
+      augmentedIncludes: augmentedIncludes.sort(),
+      augmentedExcludes: augmentedExcludes.sort(),
     })
   )
 }

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -22,6 +22,7 @@ import { FileTree } from "./file-tree.js"
 import { normalize, sep } from "path"
 import { stableStringify } from "../util/string.js"
 import { hashString } from "../util/util.js"
+import { Profile } from "../util/profiling.js"
 
 const { pathExists } = fsExtra
 
@@ -78,7 +79,7 @@ export function getHashedFilterParams({
   )
 }
 
-// @Profile()
+@Profile()
 export class GitRepoHandler extends AbstractGitHandler {
   private readonly gitHandlerDelegate: GitSubTreeHandler
   override readonly name = "git-repo"

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -25,7 +25,7 @@ import { hashString } from "../util/util.js"
 
 const { pathExists } = fsExtra
 
-type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt" | "exclude">
+type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt">
 
 interface GitRepoGetFilesParams extends GetFilesParams {
   scanFromProjectRoot: boolean

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -470,7 +470,7 @@ export function describeConfig(config: ModuleConfig | BaseActionConfig): ActionD
  * Checks if the {@code subPathCandidate} is a sub-path of {@code basePath}.
  * Sub-path means that a candidate must be located inside a reference path.
  *
- * Both {@basePath} and {@ subPathCandidate} must be absolute paths
+ * Both {@code basePath} and {@code subPathCandidate} must be absolute paths
  *
  * @param basePath the reference path (absolute)
  * @param subPathCandidate the path to be checked (absolute)

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -41,6 +41,7 @@ import { defaultDotIgnoreFile, fixedProjectExcludes } from "../../../../src/util
 import { createActionLog } from "../../../../src/logger/log-entry.js"
 import type { BaseActionConfig } from "../../../../src/actions/types.js"
 import { TreeCache } from "../../../../src/cache.js"
+import { getHashedFilterParams } from "../../../../src/vcs/git-repo.js"
 
 export class TestVcsHandler extends VcsHandler {
   override readonly name = "test"
@@ -662,6 +663,46 @@ describe("helpers", () => {
     it("returns true for the same path with tailing file separator", () => {
       const subPath = isSubPath(join(sep, "volume", "dir"), join(sep, "volume", "dir", sep))
       expect(subPath).to.be.true
+    })
+  })
+
+  describe("getHashedFilterParams", () => {
+    it("should return the same hashes for fully equal objects", () => {
+      const params1 = { filter: undefined, augmentedIncludes: ["yes.txt"], augmentedExcludes: ["no.txt"] }
+      const hash1 = getHashedFilterParams(params1)
+
+      const params2 = { filter: undefined, augmentedIncludes: ["yes.txt"], augmentedExcludes: ["no.txt"] }
+      const hash2 = getHashedFilterParams(params2)
+
+      expect(hash1).to.eql(hash2)
+    })
+
+    it("should return the different hashes for non-equal objects", () => {
+      const params1 = { filter: undefined, augmentedIncludes: ["yes1.txt"], augmentedExcludes: ["no1.txt"] }
+      const hash1 = getHashedFilterParams(params1)
+
+      const params2 = { filter: undefined, augmentedIncludes: ["yes2.txt"], augmentedExcludes: ["no2.txt"] }
+      const hash2 = getHashedFilterParams(params2)
+
+      expect(hash1).not.to.eql(hash2)
+    })
+
+    it("should not depend on the order of the include/exclude file lists", () => {
+      const params1 = {
+        filter: undefined,
+        augmentedIncludes: ["yes1.txt", "yes2.txt"],
+        augmentedExcludes: ["no1.txt", "no2.txt"],
+      }
+      const hash1 = getHashedFilterParams(params1)
+
+      const params2 = {
+        filter: undefined,
+        augmentedIncludes: ["yes2.txt", "yes1.txt"],
+        augmentedExcludes: ["no2.txt", "no1.txt"],
+      }
+      const hash2 = getHashedFilterParams(params2)
+
+      expect(hash1).to.eql(hash2)
     })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes cache key construction in `GitRepoHandler` that accounts for different includes/excludes and filter functions for the same path.

Originally, the caching was implemented in #5710. This PR makes sure that 2 filter-objects are considered tom have the equal cache keys if the difference is only in the order of the `augmentedExcludes` and `augmentedIncludes` arrays, ad there is no difference between the sets of values of both arrays.

**Which issue(s) this PR fixes**:

A follow-up PR for #5526 and #5710

**Special notes for your reviewer**:

~The changes made #5710 make the caching in `GitRepoHandler.scanRoot(...)` unnecessary. That caching logic will be removed in a separate PR.~ The caching in `GitRepoHandler.scanRoot(...)` might still make sense. It caches the results for the whole path, without taking include/exclude filters into account.