### PR TITLE
refactor: cloud builder availability

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -1051,13 +1051,12 @@ type RegisterCloudBuilderBuildResponse =
   | V1RegisterCloudBuilderBuildResponse
   | UnsupportedRegisterCloudBuilderBuildResponse
 
-type CloudBuilderAvailable = {
+export type CloudBuilderAvailable = {
   available: true
-  builder: string
   token: string
   region: "eu" // location of the builder. Currently only eu is supported
 }
-type CloudBuilderNotAvailable = {
+export type CloudBuilderNotAvailable = {
   available: false
   reason: string
 }

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -18,19 +18,21 @@ import fsExtra from "fs-extra"
 const { mkdirp, rm } = fsExtra
 import { join } from "path"
 import { tmpdir } from "node:os"
-import type { CloudBuilderAvailability } from "../../cloud/api.js"
+import type { CloudBuilderAvailability, CloudBuilderAvailable } from "../../cloud/api.js"
 import { emitNonRepeatableWarning } from "../../warnings.js"
 import { LRUCache } from "lru-cache"
 import { getPlatform } from "../../util/arch-platform.js"
 import { gardenEnv } from "../../constants.js"
 import type { ActionRuntime, ActionRuntimeKind } from "../../plugin/base.js"
+import { getPackageVersion } from "../../util/util.js"
 
 type CloudBuilderConfiguration = {
   isInClusterBuildingConfigured: boolean
   isCloudBuilderEnabled: boolean
 }
 
-// TODO: consider if it's useful to make this tunable e.g. via an environment variable.
+// This means that Core will ask Cloud for availability every 5 minutes.
+// It might well be that we plan to use Cloud Builder for an action, and then we fall back to building locally.
 const cloudBuilderAvailability = new LRUCache<string, CloudBuilderAvailability>({
   max: 1000,
   // 5 minutes
@@ -45,6 +47,28 @@ export const cloudBuilder = {
       return false
     }
 
+    return true
+  },
+
+  /**
+   * @returns false if Cloud Builder is not configured or not available, otherwise it returns the availability (a required parameter for withBuilder)
+   */
+  async getAvailability(ctx: PluginContext, action: Resolved<ContainerBuildAction>): Promise<CloudBuilderAvailability> {
+    if (!cloudBuilder.isConfigured(ctx)) {
+      return {
+        available: false,
+        reason: "Cloud Builder is not configured",
+      }
+    }
+
+    const { isInClusterBuildingConfigured } = getConfiguration(ctx)
+
+    // Cache the Cloud Builder availability response from Backend for 5 minutes in LRU cache
+    const fromCache = cloudBuilderAvailability.get(action.uid)
+    if (fromCache) {
+      return fromCache
+    }
+
     if (getPlatform() === "windows") {
       emitNonRepeatableWarning(
         ctx.log,
@@ -53,22 +77,71 @@ export const cloudBuilder = {
 
         Please contact our customer support and tell us more if you're interested in Windows support.`
       )
-      return false
+      const unsupported: CloudBuilderAvailability = {
+        available: false,
+        reason: `Cloud Builder is not available on Windows with Garden version ${getPackageVersion()}`,
+      }
+      cloudBuilderAvailability.set(action.uid, unsupported)
+      return unsupported
     }
 
-    return true
-  },
+    if (!ctx.cloudApi) {
+      const fallbackDescription = isInClusterBuildingConfigured
+        ? `This forces Garden to use the fall-back option to build images within your Kubernetes cluster, as in-cluster building is configured in the Kubernetes provider settings.`
+        : `This forces Garden to use the fall-back option to build images locally.`
 
-  async isConfiguredAndAvailable(ctx: PluginContext, action: Resolved<ContainerBuildAction>) {
-    if (!cloudBuilder.isConfigured(ctx)) {
-      return false
+      throw new ConfigurationError({
+        message: dedent`
+        You are not logged in. Run ${styles.command("garden login")} so Garden Cloud Builder can speed up your container builds.
+
+        If you can't log in right now, disable Garden Cloud Builder using the environment variable ${styles.bold("GARDEN_CLOUD_BUILDER=0")}. ${fallbackDescription}`,
+      })
     }
 
-    const availability = await getAvailability(ctx, action)
-    return availability.available
+    const res = await ctx.cloudApi.registerCloudBuilderBuild({
+      // TODO: send requested platforms and action version
+      actionUid: action.uid,
+      actionName: action.name,
+      coreSessionId: ctx.sessionId,
+    })
+
+    if (res.data.version !== "v1") {
+      emitNonRepeatableWarning(
+        ctx.log,
+        dedent`
+          ${styles.bold("Update Garden to continue to benefit from Garden Cloud Builder.")}
+
+          Your current Garden version is not supported anymore by Garden Cloud Builder. Please update Garden to the latest version.
+
+          Falling back to ${isInClusterBuildingConfigured ? "in-cluster building" : "building the image locally"}, which may be slower.
+
+          Run ${styles.command("garden self-update")} to update Garden to the latest version.`
+      )
+      const unsupported: CloudBuilderAvailability = { available: false, reason: "Unsupported client version" }
+      cloudBuilderAvailability.set(action.uid, unsupported)
+      return unsupported
+    }
+
+    // availability is supported
+    const availability = res.data.availability
+    cloudBuilderAvailability.set(action.uid, availability)
+
+    if (!availability.available) {
+      emitNonRepeatableWarning(
+        ctx.log,
+        dedent`
+          ${styles.bold("Garden Cloud Builder is not available.")}
+
+          Falling back to ${isInClusterBuildingConfigured ? "in-cluster building" : "building the image locally"}, which may be slower.
+
+          ${styles.italic(`Reason: ${availability.reason}`)}`
+      )
+    }
+
+    return availability
   },
 
-  async getActionRuntime(ctx: PluginContext, action: Resolved<ContainerBuildAction>): Promise<ActionRuntime> {
+  getActionRuntime(ctx: PluginContext, availability: CloudBuilderAvailability): ActionRuntime {
     const config = getConfiguration(ctx)
 
     const fallback: ActionRuntimeKind = config.isInClusterBuildingConfigured
@@ -91,15 +164,14 @@ export const cloudBuilder = {
         fallback
 
     // if cloud builder is configured AND available, that's our actual runtime. Otherwise we fall back to whatever is configured in the plugin.
-    const actual = (await cloudBuilder.isConfiguredAndAvailable(ctx, action)) ? preferred : fallback
+    const actual = availability.available ? preferred : fallback
 
     if (actual === preferred) {
       return {
         actual,
       }
     } else {
-      const unavailable = await getAvailability(ctx, action)
-      if (unavailable.available) {
+      if (availability.available) {
         throw new InternalError({
           message: `Inconsistent state: Should only fall back if Cloud Builder is not available`,
         })
@@ -107,25 +179,18 @@ export const cloudBuilder = {
       return {
         actual,
         preferred,
-        fallbackReason: unavailable.reason,
+        fallbackReason: availability.reason,
       }
     }
   },
 
   async withBuilder<T>(
     ctx: PluginContext,
-    action: Resolved<ContainerBuildAction>,
+    availability: CloudBuilderAvailable,
     performBuild: (builder: string) => Promise<T>
   ) {
-    const cb = await getAvailability(ctx, action)
-    if (!cb.available) {
-      throw new InternalError({
-        message: `Must call isConfiguredAndAvailable before calling withBuilder.`,
-      })
-    }
-
     // Docker only accepts builder names that start with a letter
-    const buildxBuilderName = `cb${uuidv4()}-${cb.builder}`
+    const buildxBuilderName = `cb${uuidv4()}-garden-cloud-builder`
 
     // Temp dir needs to be as short as possible, otherwise docker fails to connect
     // (ERROR: no valid drivers found: unix socket path "..." is too long)
@@ -138,8 +203,8 @@ export const cloudBuilder = {
         // See https://namespace.so/docs/cli/docker-buildx-setup
         args: ["docker", "buildx", "setup", "--name", buildxBuilderName, "--state", stateDir, "--background"],
         ctx,
-        nscAuthToken: cb.token,
-        nscRegion: cb.region,
+        nscAuthToken: availability.token,
+        nscRegion: availability.region,
       })
       ctx.log.debug(
         `buildx proxy setup process for ${buildxBuilderName} exited with code ${result.exitCode}${result.all?.length ? ` (output: ${result.all})` : ""}`
@@ -151,8 +216,8 @@ export const cloudBuilder = {
       await nscCli({
         args: ["docker", "buildx", "cleanup", "--state", stateDir],
         ctx,
-        nscAuthToken: cb.token,
-        nscRegion: cb.region,
+        nscAuthToken: availability.token,
+        nscRegion: availability.region,
       })
       ctx.log.debug(`Removing ${stateDir}...`)
       await rm(stateDir, { recursive: true, force: true })
@@ -232,72 +297,4 @@ function getConfiguration(ctx: PluginContext): CloudBuilderConfiguration {
     isInClusterBuildingConfigured,
     isCloudBuilderEnabled,
   }
-}
-
-async function getAvailability(
-  ctx: PluginContext,
-  action: Resolved<ContainerBuildAction>
-): Promise<CloudBuilderAvailability> {
-  const { isInClusterBuildingConfigured } = getConfiguration(ctx)
-
-  // Cache the Cloud Builder availability response from Backend for 5 minutes in LRU cache
-  const fromCache = cloudBuilderAvailability.get(action.uid)
-  if (fromCache) {
-    return fromCache
-  }
-
-  if (!ctx.cloudApi) {
-    const fallbackDescription = isInClusterBuildingConfigured
-      ? `This forces Garden to use the fall-back option to build images within your Kubernetes cluster, as in-cluster building is configured in the Kubernetes provider settings.`
-      : `This forces Garden to use the fall-back option to build images locally.`
-
-    throw new ConfigurationError({
-      message: dedent`
-      You are not logged in. Run ${styles.command("garden login")} so Garden Cloud Builder can speed up your container builds.
-
-      If you can't log in right now, disable Garden Cloud Builder using the environment variable ${styles.bold("GARDEN_CLOUD_BUILDER=0")}. ${fallbackDescription}`,
-    })
-  }
-
-  const res = await ctx.cloudApi.registerCloudBuilderBuild({
-    // TODO: send requested platforms and action version
-    actionUid: action.uid,
-    actionName: action.name,
-    coreSessionId: ctx.sessionId,
-  })
-
-  if (res.data.version !== "v1") {
-    emitNonRepeatableWarning(
-      ctx.log,
-      dedent`
-        ${styles.bold("Update Garden to continue to benefit from Garden Cloud Builder.")}
-
-        Your current Garden version is not supported anymore by Garden Cloud Builder. Please update Garden to the latest version.
-
-        Falling back to ${isInClusterBuildingConfigured ? "in-cluster building" : "building the image locally"}, which may be slower.
-
-        Run ${styles.command("garden self-update")} to update Garden to the latest version.`
-    )
-    const unsupported: CloudBuilderAvailability = { available: false, reason: "Unsupported client version" }
-    cloudBuilderAvailability.set(action.uid, unsupported)
-    return unsupported
-  }
-
-  // availability is supported
-  const availability = res.data.availability
-  cloudBuilderAvailability.set(action.uid, availability)
-
-  if (!availability.available) {
-    emitNonRepeatableWarning(
-      ctx.log,
-      dedent`
-        ${styles.bold("Garden Cloud Builder is not available.")}
-
-        Falling back to ${isInClusterBuildingConfigured ? "in-cluster building" : "building the image locally"}, which may be slower.
-
-        ${styles.italic(`Reason: ${availability.reason}`)}`
-    )
-  }
-
-  return availability
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
During review of #6153, Anna rightfully pointed out that the availability code is quite confusing (https://github.com/garden-io/garden/pull/6153#discussion_r1633020040 ). We've looked a little more closely at it together and concluded that the code even has potential for weird race conditions, where we are reporting building in cloud builder but actually built the image locally.

Worse yet, builds might fail with an InternalError if the user is unlucky ("You must call isConfiguredAndAvailable before calling withBuilder").

This refactor eliminates these weird races and also makes the code easier to understand and reason about at the same time.

Thanks Anna :)



