### PR TITLE
ci: stop using x86 circleci macos runners, as they are not supported anymore

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1050,10 +1050,14 @@ jobs:
           command: ./bin/garden deploy --root examples/demo-project
       - fail_fast
 
-  test-macos:
+  test-macos-x86-rosetta:
     macos:
       xcode: "15.0.0"
+    # We are testing x86 binaries under rosetta because CircleCI stopped supporting x86 macs.
+    resource_class: macos.m1.medium.gen1
     steps:
+      # We are testing x86 binaries under rosetta because CircleCI stopped supporting x86 macs.
+      - macos/install-rosetta
       - checkout
       - *attach-workspace
       - run:
@@ -1211,7 +1215,7 @@ workflows:
           # Don't attempt to run dist tests for external PRs (they won't have access to the required keys)
           <<: *only-internal-prs
           requires: [build-dist-macos, build-dist-linux-windows]
-      - test-macos:
+      - test-macos-x86-rosetta:
           <<: *only-internal-prs
           requires: [build-dist-macos]
       - test-macos-arm:

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -55,20 +55,24 @@ interface TargetSpec {
   checksum: string
 }
 
-const rustArchMap: Record<TargetSpec["arch"], string> = {
-  x64: "x86_64",
-  arm64: "aarch64",
-}
-
-const rustOsMap: Record<TargetSpec["os"], string> = {
-  win: "pc-windows-gnu",
-  alpine: "unknown-linux-musl",
-  linux: "unknown-linux-gnu",
-  macos: "apple-darwin",
+const rustTargetMap: Record<`${TargetSpec["os"]}/${TargetSpec["arch"]}`, string | undefined> = {
+  "win/arm64": undefined,
+  "win/x64": "x86_64-pc-windows-gnu",
+  "alpine/arm64": "aarch64-unknown-linux-musl",
+  "alpine/x64": "x86_64-unknown-linux-musl",
+  "linux/arm64": "aarch64-unknown-linux-gnu",
+  "linux/x64": "x86_64-unknown-linux-gnu",
+  "macos/arm64": "aarch64-apple-darwin",
+  "macos/x64": "x86_64-apple-darwin",
 }
 
 function getRustTarget(spec: TargetSpec): string {
-  return `${rustArchMap[spec.arch]}-${rustOsMap[spec.os]}`
+  const targetSpec = `${spec.os}/${spec.arch}`
+  const target = rustTargetMap[targetSpec]
+  if (!target) {
+    throw new Error(`Target ${targetSpec} is unsupported / missing rustTargetMap declaration.`)
+  }
+  return target
 }
 
 export const nodeVersion = "22.2.0"


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes the CI due to the current brownout.
See also https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
