### PR TITLE
docs(command): fix typo in `garden util profile-project` command

### DIFF
--- a/core/src/commands/util/profile-project.ts
+++ b/core/src/commands/util/profile-project.ts
@@ -17,7 +17,7 @@ import type { BaseActionConfig } from "../../actions/types.js"
 
 export class ProfileProjectCommand extends Command {
   name = "profile-project"
-  help = "Renders a high-level sumamry of actions and modules in your project."
+  help = "Renders a high-level summary of actions and modules in your project."
   emoji = "📊"
 
   override description = dedent`

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -5924,7 +5924,7 @@ Examples:
 
 ### garden util profile-project
 
-**Renders a high-level sumamry of actions and modules in your project.**
+**Renders a high-level summary of actions and modules in your project.**
 
 Useful for diagnosing slow init performance for projects with lots of actions and modules and/or lots of files.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in the help output of garden `garden util` command.

**Which issue(s) this PR fixes**:

Fixes #6202

**Special notes for your reviewer**:
