### PR TITLE
feat: add building and publishing multi-platform images

### DIFF
--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -269,7 +269,6 @@ export function getDockerBuildFlags(
   if (targetStage) {
     args.push("--target", targetStage)
   }
-
   for (const platform of platforms || []) {
     args.push("--platform", platform)
   }

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -192,7 +192,7 @@ async function buildContainerLocally({
           Your local docker daemon does not support building multi-platform images.
           If you are using Docker Desktop, you can turn on the experimental containerd image store.
           To build multi-platform images locally with other local docker platforms,
-          you can add custom docker-container buildx builder.
+          you can add a custom buildx builder of type docker-container.
           Learn more at https://docs.docker.com/go/build-multi-platform/
         `,
       })

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -7,7 +7,7 @@
  */
 
 import { containerHelpers } from "./helpers.js"
-import { ConfigurationError } from "../../exceptions.js"
+import { ConfigurationError, toGardenError } from "../../exceptions.js"
 import type { PrimitiveMap } from "../../config/common.js"
 import split2 from "split2"
 import type { BuildActionHandler } from "../../plugin/action-types.js"
@@ -166,16 +166,39 @@ async function buildContainerLocally({
   }
 
   const cmdOpts = ["build", ...dockerFlags, "--file", dockerfilePath]
-
-  return await containerHelpers.dockerCli({
-    cwd: buildPath,
-    args: [...cmdOpts, buildPath],
-    log,
-    stdout: outputStream,
-    stderr: outputStream,
-    timeout,
-    ctx,
-  })
+  try {
+    return await containerHelpers.dockerCli({
+      cwd: buildPath,
+      args: [...cmdOpts, buildPath],
+      log,
+      stdout: outputStream,
+      stderr: outputStream,
+      timeout,
+      ctx,
+    })
+  } catch (e) {
+    const error = toGardenError(e)
+    if (error.message.includes("docker exporter does not currently support exporting manifest lists")) {
+      throw new ConfigurationError({
+        message: dedent`
+          Your local docker image store does not support loading multi-platform images.
+          If you are using Docker Desktop, you can turn on the experimental containerd image store.
+          Learn more at https://docs.docker.com/go/build-multi-platform/
+        `,
+      })
+    } else if (error.message.includes("Multi-platform build is not supported for the docker driver")) {
+      throw new ConfigurationError({
+        message: dedent`
+          Your local docker daemon does not support building multi-platform images.
+          If you are using Docker Desktop, you can turn on the experimental containerd image store.
+          To build multi-platform images locally with other local docker platforms,
+          you can add custom docker-container buildx builder.
+          Learn more at https://docs.docker.com/go/build-multi-platform/
+        `,
+      })
+    }
+    throw error
+  }
 }
 
 const BUILDKIT_LAYER_REGEX = /^#[0-9]+ \[[^ ]+ +[0-9]+\/[0-9]+\] [^F][^R][^O][^M]/
@@ -237,7 +260,7 @@ export function getDockerBuildFlags(
 ) {
   const args: string[] = []
 
-  const { targetStage, extraFlags, buildArgs } = action.getSpec()
+  const { targetStage, extraFlags, buildArgs, platforms } = action.getSpec()
 
   for (const arg of getDockerBuildArgs(action.versionString(), buildArgs)) {
     args.push("--build-arg", arg)
@@ -245,6 +268,10 @@ export function getDockerBuildFlags(
 
   if (targetStage) {
     args.push("--target", targetStage)
+  }
+
+  for (const platform of platforms || []) {
+    args.push("--platform", platform)
   }
 
   args.push(...(extraFlags || []))

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -42,6 +42,10 @@ const cloudBuilderAvailability = new LRUCache<string, CloudBuilderAvailability>(
 
 // public API
 export const cloudBuilder = {
+  isConfigured(ctx: PluginContext) {
+    const { isCloudBuilderEnabled } = getConfiguration(ctx)
+    return isCloudBuilderEnabled
+  },
   /**
    * @returns false if Cloud Builder is not configured or not available, otherwise it returns the availability (a required parameter for withBuilder)
    */

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -1016,6 +1016,7 @@ export interface ContainerBuildActionSpec {
   localId?: string
   publishId?: string
   targetStage?: string
+  platforms?: string[]
 }
 
 export type ContainerBuildActionConfig = BuildActionConfig<"container", ContainerBuildActionSpec>
@@ -1059,6 +1060,10 @@ export const containerCommonBuildSpecKeys = memoize(() => ({
   extraFlags: joi.sparseArray().items(joi.string()).description(deline`
     Specify extra flags to use when building the container image.
     Note that arguments may not be portable across implementations.`),
+  platforms: joi.sparseArray().items(joi.string()).description(dedent`
+    Specify the platforms to build the image for. This is useful when building multi-platform images.
+    The format is \`os/arch\`, e.g. \`linux/amd64\`, \`linux/arm64\`, etc.
+  `),
 }))
 
 export const containerBuildSpecSchema = createSchema({

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -252,7 +252,7 @@ export const regctlCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "arm64",
-      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-linux-armd64`,
+      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-linux-arm64`,
       sha256: "7c3d760925052f7dea4aa26b327e9d88f3ae30fadacc110ae03bd06df3fb696f",
     },
     {

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -51,6 +51,7 @@ import { joi } from "../../config/common.js"
 import { DEFAULT_DEPLOY_TIMEOUT_SEC, gardenEnv } from "../../constants.js"
 import type { ExecBuildConfig } from "../exec/build.js"
 import type { PluginToolSpec } from "../../plugin/tools.js"
+import type { PluginContext } from "../../plugin-context.js"
 
 export const CONTAINER_STATUS_CONCURRENCY_LIMIT = gardenEnv.GARDEN_HARD_CONCURRENCY_LIMIT
 export const CONTAINER_BUILD_CONCURRENCY_LIMIT_LOCAL = 5
@@ -97,6 +98,7 @@ export const configSchema = () =>
     .unknown(false)
 
 export type ContainerProvider = Provider<ContainerProviderConfig>
+export type ContainerPluginContext = PluginContext<ContainerProviderConfig>
 
 export const dockerVersion = "25.0.2"
 export const dockerSpec: PluginToolSpec = {
@@ -218,6 +220,47 @@ export const namespaceCliSpec: PluginToolSpec = {
     //     targetPath: "docker/docker.exe",
     //   },
     // },
+  ],
+}
+
+export const regctlCliVersion = "0.6.1"
+export const regctlCliSpec: PluginToolSpec = {
+  name: "regctl",
+  version: regctlCliVersion,
+  description: `Regctl CLI v${regctlCliVersion}`,
+  type: "binary",
+  _includeInGardenImage: true,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-darwin-amd64`,
+      sha256: "916e17019c36ff537555ad9989eb1fcda07403904bc70f808cee9ed9658d4107",
+    },
+    {
+      platform: "darwin",
+      architecture: "arm64",
+      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-darwin-arm64`,
+      sha256: "28833b2f0b42257e703bf75bfab7dd5baeb52d4a6e3ad8e7d33f754b36b8bb07",
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-linux-amd64`,
+      sha256: "e541327d14c8e6d3a2e4b0dfd76046425a1816879d4f5951042791435dec82e3",
+    },
+    {
+      platform: "linux",
+      architecture: "arm64",
+      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-linux-armd64`,
+      sha256: "7c3d760925052f7dea4aa26b327e9d88f3ae30fadacc110ae03bd06df3fb696f",
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `https://github.com/regclient/regclient/releases/download/v${regctlCliVersion}/regctl-windows-amd64.exe`,
+      sha256: "44b2d5e79ef457e575d2b09bc1f27500cf90b733651793f4e76e23c9b8fc1803",
+    },
   ],
 }
 
@@ -679,7 +722,7 @@ export const gardenPlugin = () =>
       },
     ],
 
-    tools: [dockerSpec, namespaceCliSpec],
+    tools: [dockerSpec, namespaceCliSpec, regctlCliSpec],
   })
 
 function validateRuntimeCommon(action: Resolved<ContainerRuntimeAction>) {

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -417,6 +417,49 @@ const helpers = {
     }
   },
 
+  async regctlCli({
+    cwd,
+    args,
+    log,
+    ctx,
+    ignoreError = false,
+    stdout,
+    stderr,
+    timeout,
+  }: {
+    cwd: string
+    args: string[]
+    log: Log
+    ctx: PluginContext<ContainerProviderConfig>
+    ignoreError?: boolean
+    stdout?: Writable
+    stderr?: Writable
+    timeout?: number
+  }) {
+    const regctl = ctx.tools["container.regctl"]
+
+    try {
+      const res = await regctl.spawnAndWait({
+        args,
+        cwd,
+        ignoreError,
+        log,
+        stdout,
+        stderr,
+        timeoutSec: timeout,
+      })
+      return res
+    } catch (err) {
+      if (!(err instanceof GardenError)) {
+        throw err
+      }
+      throw new RuntimeError({
+        message: `Unable to run regctl command "${args.join(" ")}" in ${cwd}: ${err.message}`,
+        wrappedErrors: [err],
+      })
+    }
+  },
+
   moduleHasDockerfile(config: ContainerModuleConfig, version: ModuleVersion): boolean {
     // If we explicitly set a Dockerfile, we take that to mean you want it to be built.
     // If the file turns out to be missing, this will come up in the build handler.

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -9,9 +9,7 @@
 import type { ContainerBuildAction } from "./moduleConfig.js"
 import { containerHelpers } from "./helpers.js"
 import type { BuildActionHandler } from "../../plugin/action-types.js"
-import type { ContainerPluginContext } from "./container.js"
 import { naturalList } from "../../util/string.js"
-import { cloudBuilder } from "./cloudbuilder.js"
 
 export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuildAction> = async ({
   ctx,
@@ -19,15 +17,13 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   log,
   tagOverride,
 }) => {
-  const containerCtx = ctx as ContainerPluginContext
   const localImageId = action.getOutput("localImageId")
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
-  const cloudBuilderConfigured = cloudBuilder.isConfigured(containerCtx)
   const dockerBuildExtraFlags = action.getSpec("extraFlags")
 
-  // If cloud builder is used or --push flag is set explicitly, use regctl to copy the image.
+  // If --push flag is set explicitly, use regctl to copy the image.
   // This does not require to pull the image locally.
-  if (cloudBuilderConfigured || dockerBuildExtraFlags?.includes("--push")) {
+  if (dockerBuildExtraFlags?.includes("--push")) {
     const regctlCopyCommand = ["image", "copy", localImageId, remoteImageId]
     log.info({ msg: `Publishing image ${remoteImageId}` })
     await containerHelpers.regctlCli({ cwd: action.getBuildPath(), args: regctlCopyCommand, log, ctx })

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -22,12 +22,12 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   const containerCtx = ctx as ContainerPluginContext
   const localImageId = action.getOutput("localImageId")
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
-  const cloudBuilderUsed = await cloudBuilder.getAvailability(containerCtx, action)
+  const cloudBuilderConfigured = cloudBuilder.isConfigured(containerCtx)
   const dockerBuildExtraFlags = action.getSpec("extraFlags")
 
   // If cloud builder is used or --push flag is set explicitly, use regctl to copy the image.
   // This does not require to pull the image locally.
-  if (cloudBuilderUsed.available || dockerBuildExtraFlags?.includes("--push")) {
+  if (cloudBuilderConfigured || dockerBuildExtraFlags?.includes("--push")) {
     const regctlCopyCommand = ["image", "copy", localImageId, remoteImageId]
     log.info({ msg: `Publishing image ${remoteImageId}` })
     await containerHelpers.regctlCli({ cwd: action.getBuildPath(), args: regctlCopyCommand, log, ctx })

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -314,6 +314,10 @@ export function getBuildkitFlags(action: Resolved<ContainerBuildAction>) {
     args.push("--opt", "target=" + spec.targetStage)
   }
 
+  for (const platform of spec.platforms || []) {
+    args.push("--opt", "platform=" + platform)
+  }
+
   args.push(...(spec.extraFlags || []))
 
   return args

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -97,6 +97,16 @@ export const kanikoBuild: BuildHandler = async (params) => {
   const deploymentImageId = outputs.deploymentImageId
   const dockerfile = spec.dockerfile || defaultDockerfileName
 
+  const platforms = action.getSpec().platforms
+  if (platforms && platforms.length > 1) {
+    throw new ConfigurationError({
+      message: dedent`Failed building ${styles.bold(action.name)}.
+          Kaniko does not support multi-platform builds.
+          Please consider a build method that supports multi-platform builds.
+          See: https://docs.garden.io/other-plugins/container#multi-platform-builds`,
+    })
+  }
+
   let { authSecret } = await ensureUtilDeployment({
     ctx,
     provider,

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -8,41 +8,37 @@
 
 import type { ContainerBuildAction } from "../../container/moduleConfig.js"
 import type { KubernetesPluginContext } from "../config.js"
-import { pullBuild } from "../commands/pull-image.js"
 import type { BuildActionHandler } from "../../../plugin/action-types.js"
 import { containerHelpers } from "../../container/helpers.js"
 import { naturalList } from "../../../util/string.js"
+import { cloudBuilder } from "../../container/cloudbuilder.js"
 
 export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBuildAction> = async (params) => {
   const { ctx, action, log, tagOverride } = params
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
 
+  const cloudBuilderUsed = await cloudBuilder.getAvailability(k8sCtx, action)
+
   const localImageId = action.getOutput("localImageId")
-
-  if (provider.config.buildMode !== "local-docker") {
-    // NOTE: this may contain a custom deploymentRegistry, from the kubernetes provider config
-    const deploymentRegistryImageId = action.getOutput("deploymentImageId")
-
-    // First pull from the deployment registry, then resume standard publish flow.
-    // This does mean we require a local docker as a go-between, but the upside is that we can rely on the user's
-    // standard authentication setup, instead of having to re-implement or account for all the different ways the
-    // user might be authenticating with their registries.
-    // We also generally prefer this because the remote cluster very likely doesn't (and shouldn't) have
-    // privileges to push to production registries.
-    log.info(`Pulling from deployment registry...`)
-    await pullBuild({ ctx: k8sCtx, action, log, localId: localImageId, remoteId: deploymentRegistryImageId })
-  }
-
+  const deploymentRegistryImageId = action.getOutput("deploymentImageId")
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
 
-  const taggedImages = [localImageId, remoteImageId]
-  log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
-  await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["tag", ...taggedImages], log, ctx })
+  // For in-cluster building or cloud builder, use regctl to copy the image.
+  // This does not require to pull the image locally.
+  if (provider.config.buildMode !== "local-docker" || cloudBuilderUsed.available) {
+    const regctlCopyCommand = ["image", "copy", deploymentRegistryImageId, remoteImageId]
+    log.info({ msg: `Publishing image ${remoteImageId}` })
+    await containerHelpers.regctlCli({ cwd: action.getBuildPath(), args: regctlCopyCommand, log, ctx })
+  } else {
+    const taggedImages = [localImageId, remoteImageId]
+    log.info({ msg: `Tagging images ${naturalList(taggedImages)}` })
+    await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["tag", ...taggedImages], log, ctx })
 
-  log.info({ msg: `Publishing image ${remoteImageId}...` })
-  // TODO: stream output to log if at debug log level
-  await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["push", remoteImageId], log, ctx })
+    log.info({ msg: `Publishing image ${remoteImageId}...` })
+    // TODO: stream output to log if at debug log level
+    await containerHelpers.dockerCli({ cwd: action.getBuildPath(), args: ["push", remoteImageId], log, ctx })
+  }
 
   return {
     state: "ready",

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -18,7 +18,7 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
 
-  const cloudBuilderUsed = await cloudBuilder.getAvailability(k8sCtx, action)
+  const cloudBuilderConfigured = cloudBuilder.isConfigured(k8sCtx)
 
   const localImageId = action.getOutput("localImageId")
   const deploymentRegistryImageId = action.getOutput("deploymentImageId")
@@ -26,7 +26,7 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
 
   // For in-cluster building or cloud builder, use regctl to copy the image.
   // This does not require to pull the image locally.
-  if (provider.config.buildMode !== "local-docker" || cloudBuilderUsed.available) {
+  if (provider.config.buildMode !== "local-docker" || cloudBuilderConfigured) {
     const regctlCopyCommand = ["image", "copy", deploymentRegistryImageId, remoteImageId]
     log.info({ msg: `Publishing image ${remoteImageId}` })
     await containerHelpers.regctlCli({ cwd: action.getBuildPath(), args: regctlCopyCommand, log, ctx })

--- a/core/test/integ/src/plugins/container/container.ts
+++ b/core/test/integ/src/plugins/container/container.ts
@@ -312,6 +312,7 @@ describe("plugins.container", () => {
       expect(args.slice(2, 4)).to.eql(["--build-arg", `GARDEN_ACTION_VERSION=${buildAction.versionString()}`])
     })
   })
+
   describe("multiPlatformBuilds", () => {
     it("should include platform flags", async () => {
       const config = cloneDeep(baseConfig)
@@ -326,24 +327,6 @@ describe("plugins.container", () => {
 
       const args = getDockerBuildFlags(resolvedBuild, ctx.provider.config)
       expect(args.slice(-4)).to.eql(["--platform", "linux/amd64", "--platform", "linux/arm64"])
-    })
-
-    it("should set GARDEN_ACTION_VERSION", async () => {
-      const config = cloneDeep(baseConfig)
-
-      const buildAction = await getTestBuild(config)
-
-      const resolvedBuild = await garden.resolveAction({
-        action: buildAction,
-        log,
-        graph: await garden.getConfigGraph({ log, emit: false }),
-      })
-
-      const args = getDockerBuildFlags(resolvedBuild, ctx.provider.config)
-
-      // Also module version is set for backwards compatability
-      expect(args.slice(0, 2)).to.eql(["--build-arg", `GARDEN_MODULE_VERSION=${buildAction.versionString()}`])
-      expect(args.slice(2, 4)).to.eql(["--build-arg", `GARDEN_ACTION_VERSION=${buildAction.versionString()}`])
     })
   })
 })

--- a/core/test/integ/src/plugins/container/container.ts
+++ b/core/test/integ/src/plugins/container/container.ts
@@ -312,4 +312,38 @@ describe("plugins.container", () => {
       expect(args.slice(2, 4)).to.eql(["--build-arg", `GARDEN_ACTION_VERSION=${buildAction.versionString()}`])
     })
   })
+  describe("multiPlatformBuilds", () => {
+    it("should include platform flags", async () => {
+      const config = cloneDeep(baseConfig)
+      config.spec.platforms = ["linux/amd64", "linux/arm64"]
+
+      const buildAction = await getTestBuild(config)
+      const resolvedBuild = await garden.resolveAction({
+        action: buildAction,
+        log,
+        graph: await garden.getConfigGraph({ log, emit: false }),
+      })
+
+      const args = getDockerBuildFlags(resolvedBuild, ctx.provider.config)
+      expect(args.slice(-4)).to.eql(["--platform", "linux/amd64", "--platform", "linux/arm64"])
+    })
+
+    it("should set GARDEN_ACTION_VERSION", async () => {
+      const config = cloneDeep(baseConfig)
+
+      const buildAction = await getTestBuild(config)
+
+      const resolvedBuild = await garden.resolveAction({
+        action: buildAction,
+        log,
+        graph: await garden.getConfigGraph({ log, emit: false }),
+      })
+
+      const args = getDockerBuildFlags(resolvedBuild, ctx.provider.config)
+
+      // Also module version is set for backwards compatability
+      expect(args.slice(0, 2)).to.eql(["--build-arg", `GARDEN_MODULE_VERSION=${buildAction.versionString()}`])
+      expect(args.slice(2, 4)).to.eql(["--build-arg", `GARDEN_ACTION_VERSION=${buildAction.versionString()}`])
+    })
+  })
 })

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -11,7 +11,7 @@ import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
 import { kustomize4Spec, kustomize5Spec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helm3Spec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
 import { downloadBinariesAndVerifyHashes } from "../../../src/util/testing.js"
-import { dockerSpec, namespaceCliSpec } from "../../../src/plugins/container/container.js"
+import { dockerSpec, namespaceCliSpec, regctlCliSpec } from "../../../src/plugins/container/container.js"
 
 describe("Docker binaries", () => {
   downloadBinariesAndVerifyHashes([dockerSpec])
@@ -19,6 +19,10 @@ describe("Docker binaries", () => {
 
 describe("NamespaceCLI binaries", () => {
   downloadBinariesAndVerifyHashes([namespaceCliSpec])
+})
+
+describe("regctlCLI binaries", () => {
+  downloadBinariesAndVerifyHashes([regctlCliSpec])
 })
 
 describe("Mutagen binaries", () => {

--- a/docs/k8s-plugins/guides/in-cluster-building.md
+++ b/docs/k8s-plugins/guides/in-cluster-building.md
@@ -707,7 +707,7 @@ spec:
   platforms: ["linux/amd64", "linux/arm64"]
 ```
 
-Multi-platform builds are available for both `cluster-buildkit` and `kaniko`.
+Multi-platform builds are available for `cluster-buildkit` only. Note that `kaniko` is *not* supported.
 
 ## Publishing images
 

--- a/docs/k8s-plugins/guides/in-cluster-building.md
+++ b/docs/k8s-plugins/guides/in-cluster-building.md
@@ -708,6 +708,7 @@ spec:
 ```
 
 Multi-platform builds are available for `cluster-buildkit` only. Note that `kaniko` is *not* supported.
+For high-performance multi-platform builds consider using [Garden Cloud Builder](../reference/providers/container.md).
 
 ## Publishing images
 

--- a/docs/k8s-plugins/guides/in-cluster-building.md
+++ b/docs/k8s-plugins/guides/in-cluster-building.md
@@ -708,7 +708,7 @@ spec:
 ```
 
 Multi-platform builds are available for `cluster-buildkit` only. Note that `kaniko` is *not* supported.
-For high-performance multi-platform builds consider using [Garden Cloud Builder](../reference/providers/container.md).
+For high-performance multi-platform builds consider using [Garden Cloud Builder](../../reference/providers/container.md).
 
 ## Publishing images
 

--- a/docs/k8s-plugins/guides/in-cluster-building.md
+++ b/docs/k8s-plugins/guides/in-cluster-building.md
@@ -694,6 +694,21 @@ providers:
         iam.gke.io/gcp-service-account: gar-access@${PROJECT_ID}.iam.gserviceaccount.com
 ```
 
+## Multi-Platform builds
+
+Garden supports building container images for multiple platforms and architectures. Use the `platforms` configuration field, to configure the platforms you want to build for e.g.:
+
+```yaml
+# garden.yml
+kind: Build
+type: container
+name: my-container
+spec:
+  platforms: ["linux/amd64", "linux/arm64"]
+```
+
+Multi-platform builds are available for both `cluster-buildkit` and `kaniko`.
+
 ## Publishing images
 
 You can publish images that have been built in your cluster, using the `garden publish` command. See the [Publishing images](../../other-plugins/container.md#publishing-images) section in the [Container Action guide](../../other-plugins/container.md) for details.

--- a/docs/other-plugins/container.md
+++ b/docs/other-plugins/container.md
@@ -104,7 +104,9 @@ spec:
 ```
 
 Garden interacts with several local and remote builders. Currently support for multi-platform builds varies based on the builder backend.
-The following build backends support multi-platform builds out of the box: `garden-cloudbuilder`, `cluster-buildkit`, `kaniko`.
+The following build backends support multi-platform builds out of the box: `garden-cloudbuilder`, `cluster-buildkit`.
+
+In-cluster building with `kaniko` does *not* support multi-platform builds.
 
 The `local-docker` build backend requires some additional configurations. Docker Desktop users can enable the experimental containerd image store to also store multi-platform images locally. All other local docker solutions e.g. orbstack, podman currently need a custom buildx builder of type `docker-container`. Documemtation for both can be found here https://docs.docker.com/build/building/multi-platform.
 If your local docker image store does not support storing multi-platform images, consider configuring an environment where you only build single platform images when building locally e.g.:

--- a/docs/other-plugins/container.md
+++ b/docs/other-plugins/container.md
@@ -104,7 +104,7 @@ spec:
 ```
 
 Garden interacts with several local and remote builders. Currently support for multi-platform builds varies based on the builder backend.
-The following build backends support multi-platform builds out of the box: `garden-cloudbuilder`, `cluster-buildkit`.
+The following build backends support multi-platform builds out of the box: [Garden Cloud Builder](../reference/providers/container.md), `cluster-buildkit`, `kaniko`.
 
 In-cluster building with `kaniko` does *not* support multi-platform builds.
 

--- a/docs/other-plugins/container.md
+++ b/docs/other-plugins/container.md
@@ -90,6 +90,39 @@ spec:
   image: redis:5.0.5-alpine   # <- replace with any docker image ID
 ```
 
+## Multi-Platform builds
+
+Garden supports building container images for multiple platforms and architectures. Use the `platforms` configuration field, to configure the platforms you want to build for e.g.:
+
+```yaml
+# garden.yml
+kind: Build
+type: container
+name: my-container
+spec:
+  platforms: ["linux/amd64", "linux/arm64"]
+```
+
+Garden interacts with several local and remote builders. Currently support for multi-platform builds varies based on the builder backend.
+The following build backends support multi-platform builds out of the box: `garden-cloudbuilder`, `cluster-buildkit`, `kaniko`.
+
+The `local-docker` build backend requires some additional configurations. Docker Desktop users can enable the experimental containerd image store to also store multi-platform images locally. All other local docker solutions e.g. orbstack, podman currently need a custom buildx builder of type `docker-container`. Documemtation for both can be found here https://docs.docker.com/build/building/multi-platform.
+If your local docker image store does not support storing multi-platform images, consider configuring an environment where you only build single platform images when building locally e.g.:
+
+```yaml
+# garden.yml
+kind: Build
+type: container
+name: my-container
+spec:
+  platforms:
+    $if: ${environment.name == "local"}
+    $then: [ "linux/amd64"]
+    $else: [ "linux/amd64", "linux/arm64" ]
+```
+
+Or you can specifiy to push your locally build images to a remote registry. If you are also using a Kubernetes provider and have a `deploymentRegistry` defined, the image will be pushed to this registry by default. If you are using garden only for building with the container provider, you can achieve the same behavior by specifying `--push` as an extra flag in your container action and setting `localId` to your registry name.
+
 ## Publishing images
 
 You can publish images that have been built in your cluster using the `garden publish` command.

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -374,6 +374,17 @@ Specify extra flags to use when building the container image. Note that argument
 | --------------- | -------- |
 | `array[string]` | No       |
 
+### `spec.platforms[]`
+
+[spec](#spec) > platforms
+
+Specify the platforms to build the image for. This is useful when building multi-platform images.
+The format is `os/arch`, e.g. `linux/amd64`, `linux/arm64`, etc.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `spec.dockerfile`
 
 [spec](#spec) > dockerfile

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -376,6 +376,17 @@ Note: Garden will always set a `GARDEN_ACTION_VERSION` (alias `GARDEN_MODULE_VER
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
+### `spec.platforms[]`
+
+[spec](#spec) > platforms
+
+Specify the platforms to build the image for. This is useful when building multi-platform images.
+The format is `os/arch`, e.g. `linux/amd64`, `linux/arm64`, etc.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `spec.dockerfile`
 
 [spec](#spec) > dockerfile

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -192,6 +192,10 @@ buildArgs: {}
 # implementations.
 extraFlags:
 
+# Specify the platforms to build the image for. This is useful when building multi-platform images.
+# The format is `os/arch`, e.g. `linux/amd64`, `linux/arm64`, etc.
+platforms:
+
 # Specify the image name for the container. Should be a valid Docker image identifier. If specified and the module
 # does not contain a Dockerfile, this image will be used to deploy services for this module. If specified and the
 # module does contain a Dockerfile, this identifier is used when pushing the built image.
@@ -1070,6 +1074,15 @@ Note: Garden will always set a `GARDEN_ACTION_VERSION` (alias `GARDEN_MODULE_VER
 ### `extraFlags[]`
 
 Specify extra flags to use when building the container image. Note that arguments may not be portable across implementations.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `platforms[]`
+
+Specify the platforms to build the image for. This is useful when building multi-platform images.
+The format is `os/arch`, e.g. `linux/amd64`, `linux/arm64`, etc.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -260,6 +260,10 @@ buildArgs: {}
 # implementations.
 extraFlags:
 
+# Specify the platforms to build the image for. This is useful when building multi-platform images.
+# The format is `os/arch`, e.g. `linux/amd64`, `linux/arm64`, etc.
+platforms:
+
 # Specify the image name for the container. Should be a valid Docker image identifier. If specified and the module
 # does not contain a Dockerfile, this image will be used to deploy services for this module. If specified and the
 # module does contain a Dockerfile, this identifier is used when pushing the built image.
@@ -1285,6 +1289,15 @@ Note: Garden will always set a `GARDEN_ACTION_VERSION` (alias `GARDEN_MODULE_VER
 ### `extraFlags[]`
 
 Specify extra flags to use when building the container image. Note that arguments may not be portable across implementations.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `platforms[]`
+
+Specify the platforms to build the image for. This is useful when building multi-platform images.
+The format is `os/arch`, e.g. `linux/amd64`, `linux/arm64`, etc.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/images/README.md
+++ b/images/README.md
@@ -9,6 +9,4 @@ We are building all images except the circleci image multi-platform for linux/ar
 
 Please note that the images are not available in your local docker images store, because they are build in the docker-container buildx builder. They are always pushed to DockerHub. If you want to inspect and run them locally pull them down.
 
-To build and push to DockerHub with a tag `dev` use `garden build`, and to publish a new image with a version tag specified in the `release_tag` variable run `garden build --var publish=true`.
-
-This is an intermediate step to allow multi platform builds and publish them to DockerHub until multi-platform builds are integrated more natively into garden and work with the publish command.
+To publish an updated version of these images update the `release-tag` in the respective action and run `garden publish`.

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -3,15 +3,15 @@ type: container
 name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
 variables:
-  publish: false
-  image_name: gardendev/buildkit
-  image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: v0.13.2
+  image-name: gardendev/buildkit
+  release-tag: v0.13.2
 spec:
-  localId: ${var.image_name}
+  publishId: ${var.image-name}:${var.release-tag}
+  localId: ${var.image-name}
   dockerfile: Dockerfile
   targetStage: buildkit
-  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
+  platforms: [ "linux/amd64", "linux/arm64" ]
+  extraFlags: [ "--push"]
 ---
 
 kind: Build
@@ -21,12 +21,12 @@ description: Used for the cluster-buildkit build mode in the kubernetes provider
 dependencies:
   - build.buildkit
 variables:
-  publish: false
-  image_name: gardendev/buildkit
-  image_tag: "${var.publish ? var.release_tag : 'dev-rootless'}"
-  release_tag: v0.13.2-rootless
+  image-name: gardendev/buildkit
+  release-tag: v0.13.2-rootless
 spec:
-  localId: ${var.image_name}
+  publishId: ${var.image-name}:${var.release-tag}
+  localId: ${var.image-name}
   dockerfile: Dockerfile
   targetStage: buildkit-rootless
-  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
+  platforms: [ "linux/amd64", "linux/arm64" ]
+  extraFlags: [ "--push"]

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -3,10 +3,11 @@ type: container
 name: circleci-runner
 description: Used for the core pipeline in CircleCI
 variables:
-  publish: false
-  image_name: gardendev/circleci-runner
-  image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: 22.2.0-0
+  image-name: gardendev/circleci-runner
+  release-tag: 22.2.0-0
 spec:
-  localId: gardendev/circleci-runner
-  extraFlags: [ "--platform", "linux/amd64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
+  publishId: ${var.image-name}:${var.release-tag}
+  localId: ${var.image-name}
+  dockerfile: Dockerfile
+  platforms: [ "linux/amd64" ]
+  extraFlags: [ "--push"]

--- a/images/k8s-reverse-proxy/garden.yml
+++ b/images/k8s-reverse-proxy/garden.yml
@@ -3,11 +3,11 @@ type: container
 name: k8s-reverse-proxy
 description: Used in local deployment mode as a reversed proxy in k8s cluster to replace an actual service and to route its traffic to a local service.
 variables:
-  publish: false
-  image_name: gardendev/k8s-reverse-proxy
-  image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: 0.1.1
+  image-name: gardendev/k8s-reverse-proxy
+  release-tag: 0.1.1
 spec:
-  localId: ${var.image_name}
+  publishId: ${var.image-name}:${var.release-tag}
+  localId: ${var.image-name}
   dockerfile: Dockerfile
-  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
+  platforms: [ "linux/amd64", "linux/arm64" ]
+  extraFlags: [ "--push"]

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -3,9 +3,11 @@ type: container
 name: k8s-sync
 description: Used by the kubernetes provider for sync setup
 variables:
-  publish: false
-  image_name: gardendev/k8s-sync
+  image-name: gardendev/k8s-sync
+  release-tag: 0.2.1 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
 spec:
-  publishId: ${var.image_name} # needs to be the full name including registry
+  publishId: ${var.image-name}:${var.release-tag}
+  localId: ${var.image-name}
   dockerfile: Dockerfile
   platforms: [ "linux/amd64", "linux/arm64" ]
+  extraFlags: [ "--push"]

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -5,9 +5,7 @@ description: Used by the kubernetes provider for sync setup
 variables:
   publish: false
   image_name: gardendev/k8s-sync
-  image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: 0.2.1 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
 spec:
-  localId: ${var.image_name}
+  publishId: ${var.image_name} # needs to be the full name including registry
   dockerfile: Dockerfile
-  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
+  platforms: [ "linux/amd64", "linux/arm64" ]

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -4,13 +4,14 @@ name: k8s-util
 description: Used by the kubernetes provider for build-related activities
 dependencies: [build.k8s-sync]
 variables:
-  publish: false
-  image_name: gardendev/k8s-util
-  image_tag: "${var.publish ? var.release_tag : 'dev'}"
-  release_tag: 0.6.1 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
+  image-name: gardendev/k8s-util
+  #release-tag: 0.6.1 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
+  release-tag: dev
 spec:
-  localId: ${var.image_name}
+  publishId: ${var.image-name}:${var.release-tag}
+  localId: ${var.image-name}
   dockerfile: Dockerfile
   buildArgs:
-    BASE_IMAGE: ${actions.build.k8s-sync.var.image_name}:${actions.build.k8s-sync.var.image_tag}
-  extraFlags: [ "--platform", "linux/amd64,linux/arm64", "--tag", "${var.image_name}:${var.image_tag}", "--push" ]
+    BASE_IMAGE: ${actions.build.k8s-sync.outputs.deploymentImageId}
+  platforms: [ "linux/amd64", "linux/arm64" ]
+  extraFlags: [ "--push"]


### PR DESCRIPTION
Adds the config option and capability to trigger multi-platform builds. To allow publishing multi-platform images with the publish command, the publish command now uses `regctl` whenever possible. This allows us to copy newly tagged images directly without the need to pull them down to a local image store first. This is more performant, enables usage of the publish command in container based CIs and it is necessary in the context of multi-platform builds because most local image stores don't support storing multi-platform images.

- feat(container): add multi platform builds
- feat(container): publish images without the need to pull them locally

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Uses regctl instead of skopeo, because it also has windows builds.