### PR TITLE
fix(jib): set `localId` in JIB module-to-action converter

### DIFF
--- a/plugins/jib/src/index.ts
+++ b/plugins/jib/src/index.ts
@@ -350,6 +350,7 @@ export const gardenPlugin = () =>
                 // base container fields
                 buildArgs: module.spec.buildArgs,
                 extraFlags: module.spec.extraFlags,
+                localId: module.spec.image,
                 publishId: module.spec.image,
                 targetStage: module.spec.build.targetImage,
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `localId` was not set in the JIB module-to-action converter. That caused an unexpected value as an image id while JIB builds. The module's `name` was used as an image id instead of module's `image` config field.

**Which issue(s) this PR fixes**:

Fixes #6204

**Special notes for your reviewer**:

We do not have any specific tests for JIB module converters and for Maven build args yet. I've tested the changes manually.