### PR TITLE
fix(pulumi): respect `--skip-dependencies` flag in `preview` command

### DIFF
--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -33,6 +33,7 @@ import {
 import { dedent, deline } from "@garden-io/sdk/build/src/util/string.js"
 import { BooleanParameter, parsePluginCommandArgs } from "@garden-io/sdk/build/src/util/cli.js"
 import fsExtra from "fs-extra"
+
 const { copy, emptyDir } = fsExtra
 import { join } from "path"
 import { isDeployAction } from "@garden-io/core/build/src/actions/deploy.js"
@@ -271,6 +272,10 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
    * Override the base method to be sure that `garden plugins pulumi preview` happens in dependency order.
    */
   override resolveProcessDependencies() {
+    if (this.skipRuntimeDependencies) {
+      return []
+    }
+
     const pulumiDeployNames = this.graph
       .getDeploys()
       .filter((d) => d.type === "pulumi")


### PR DESCRIPTION
**What this PR does / why we need it**:

The flag `--skip-dependencies` was initially implemented in #3096.

The logic that respects the flag was removed in e54d1b5eda7f88df8afba373ff3a5f65400ce6e5, likely by accident.
This commit restores the logic that prevents dependency resolution if the corresponding flag is set.

**Which issue(s) this PR fixes**:

Fixes #6206

**Special notes for your reviewer**:
