### PR TITLE
improvement(sync): use native Mutagen daemon by default

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -101,7 +101,7 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  GARDEN_ENABLE_NEW_SYNC: env.get("GARDEN_ENABLE_NEW_SYNC").required(false).default("false").asBool(),
+  GARDEN_ENABLE_NEW_SYNC: env.get("GARDEN_ENABLE_NEW_SYNC").required(false).default("true").asBool(),
   // GARDEN_CLOUD_BUILDER will always override the config; That's why it doesn't have a default.
   // FIXME: If the environment variable is not set, asBool returns undefined, unlike the type suggests. That's why we cast to `boolean | undefined`.
   GARDEN_CLOUD_BUILDER: env.get("GARDEN_CLOUD_BUILDER").required(false).asBool() as boolean | undefined,

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -334,7 +334,7 @@ function logMutagenDaemonWarning(log: Log) {
 
   log.warn(
     deline`
-    It looks like you might have changed to a different version of the sync daemon.\n
+    It looks like the sync daemon might have been changed to a different version.\n
 
     Therefore the sync daemon needs to be restarted, and the affected deploys must be redeployed.\n
     Please, stop this command and follow the instructions below.\n
@@ -378,8 +378,8 @@ export class Mutagen {
       deline`
     Warning!\n
 
-    Garden will use the new sync daemon in the next release (0.13.34).
-    Thus, the default value of the \`GARDEN_ENABLE_NEW_SYNC\` environment variable will be switched to \`true\`.\n
+    Starting from 0.13.34, Garden uses the new sync daemon.
+    Thus, the default value of the \`GARDEN_ENABLE_NEW_SYNC\` environment variable is \`true\` now.\n
 
     Please make sure you have tested the new sync daemon. See the troubleshooting docs for more details: ${makeDocsLinkStyled("guides/code-synchronization", "#restarting-sync-daemon")}\n`
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR flips the default value of `GARDEN_ENABLE_NEW_SYNC` feature flag to `true`.
It means that the sync mode will use the [native Mutagen](https://github.com/mutagen-io/mutagen) instead of the [Garden-fork](https://github.com/garden-io/mutagen) as a synchronization machinery.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
