### PR TITLE
fix(template): allow partially resolved vars in arithmetic expressions

### DIFF
--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -406,6 +406,58 @@ describe("resolveTemplateString", () => {
     })
   })
 
+  context("partial resolution in binary operators", () => {
+    context("arithmetic operators", () => {
+      const arithmeticOperators = ["-", "*", "/", "%", ">", ">=", "<", "<="]
+      for (const operator of arithmeticOperators) {
+        describe(`with ${operator} operator`, () => {
+          it("a missing reference as the first clause returns the original template", () => {
+            const res = resolveTemplateString({
+              string: `$\{var.foo ${operator} 2}`,
+              context: new TestContext({ var: {} }),
+              contextOpts: { allowPartial: true },
+            })
+            expect(res).to.equal(`$\{var.foo ${operator} 2}`)
+          })
+
+          it("a missing reference as the second clause returns the original template", () => {
+            const res = resolveTemplateString({
+              string: `$\{2 ${operator} var.foo}`,
+              context: new TestContext({ var: {} }),
+              contextOpts: { allowPartial: true },
+            })
+            expect(res).to.equal(`$\{2 ${operator} var.foo}`)
+          })
+        })
+      }
+    })
+
+    context("overloaded operators", () => {
+      const overLoadedOperators = ["+"]
+      for (const operator of overLoadedOperators) {
+        describe(`with ${operator} operator`, () => {
+          it(`a missing reference as the first clause returns the original template`, () => {
+            const res = resolveTemplateString({
+              string: `$\{var.foo ${operator} '2'}`,
+              context: new TestContext({ var: {} }),
+              contextOpts: { allowPartial: true },
+            })
+            expect(res).to.equal(`$\{var.foo ${operator} '2'}`)
+          })
+
+          it("a missing reference as the second clause returns the original template", () => {
+            const res = resolveTemplateString({
+              string: `$\{2 ${operator} var.foo}`,
+              context: new TestContext({ var: {} }),
+              contextOpts: { allowPartial: true },
+            })
+            expect(res).to.equal(`$\{2 ${operator} var.foo}`)
+          })
+        })
+      }
+    })
+  })
+
   it("should handle a positive equality comparison between equal resolved values", () => {
     const res = resolveTemplateString({ string: "${a == b}", context: new TestContext({ a: "a", b: "a" }) })
     expect(res).to.equal(true)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows using partially resolved variables in arithmetic operations.

**Which issue(s) this PR fixes**:

Fixes #6201

**Special notes for your reviewer**:

If we omit the explicit double-quotes in the `echo` command args in the example in #6201, i.e. replace
```yaml
spec:
  command: [echo, '"${var.prefix.suffix * 4}"']
```

with
```yaml
spec:
  command: [echo, '${var.prefix.suffix * 4}']
```
we'll get a schema validation error:
```console
Error validating spec for Run type=exec name=my-test:

At path spec.command.1: Expected string, received number
```

That is not related to the template string resolution and should be fixed in a separate PR. A possible solution is to stringify all numbers in `spec.command`'s args implicitly.