### PR TITLE
fix(pulumi): fix dependency resolution when `--skip-dependencies` is on

### DIFF
--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -273,7 +273,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
    */
   override resolveProcessDependencies() {
     if (this.skipRuntimeDependencies) {
-      return []
+      return [this.getResolveTask(this.action)]
     }
 
     const pulumiDeployNames = this.graph
@@ -290,7 +290,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
       })
       .filter(isDeployAction)
 
-    const tasks = deps.map((action) => {
+    const depTasks = deps.map((action) => {
       return new PulumiPluginCommandTask({
         garden: this.garden,
         graph: this.graph,
@@ -305,7 +305,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
       })
     })
 
-    return [this.getResolveTask(this.action), ...tasks]
+    return [this.getResolveTask(this.action), ...depTasks]
   }
 
   async getStatus() {

--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -272,8 +272,9 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
    * Override the base method to be sure that `garden plugins pulumi preview` happens in dependency order.
    */
   override resolveProcessDependencies() {
+    const currentTask = this.getResolveTask(this.action)
     if (this.skipRuntimeDependencies) {
-      return [this.getResolveTask(this.action)]
+      return [currentTask]
     }
 
     const pulumiDeployNames = this.graph
@@ -305,7 +306,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
       })
     })
 
-    return [this.getResolveTask(this.action), ...depTasks]
+    return [currentTask, ...depTasks]
   }
 
   async getStatus() {


### PR DESCRIPTION
**What this PR does / why we need it**:

A follow-up fix for #6226.

It returns the current task itself if the `--skip-dependencies` flag is on.
Otherwise, a [graph resolution error](https://github.com/garden-io/garden/issues/6206#issuecomment-2188967323) will be thrown.

**Which issue(s) this PR fixes**:

Patches #6226
Fixes #6206

**Special notes for your reviewer**:
