### PR TITLE
chore: amend warn on upcoming sync daemon change

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -378,7 +378,7 @@ export class Mutagen {
       deline`
     Warning!\n
 
-    Garden will use the new sync daemon in the next release (0.13.33).
+    Garden will use the new sync daemon in the next release (0.13.34).
     Thus, the default value of the \`GARDEN_ENABLE_NEW_SYNC\` environment variable will be switched to \`true\`.\n
 
     Please make sure you have tested the new sync daemon. See the troubleshooting docs for more details: ${makeDocsLinkStyled("guides/code-synchronization", "#restarting-sync-daemon")}\n`


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

We'll likely release `0.13.33` patch later this week to address some `0.12` -> `0.13` migration issues.

So, let's defer the daemon switch to `0.13.34`, to give more time to users to be ready.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
