### PR TITLE
Feature: allow replacing image when in sync mode

### DIFF
--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -161,6 +161,7 @@ export interface KubernetesDeployOverrideSpec {
   target?: KubernetesTargetResourceSpec
   command?: string[]
   args?: string[]
+  image?: string
 }
 
 export interface KubernetesDeploySyncSpec {
@@ -176,6 +177,7 @@ const syncModeOverrideSpec = () =>
     ),
     command: joi.array().items(joi.string()).description("Override the command/entrypoint in the matched container."),
     args: joi.array().items(joi.string()).description("Override the args in the matched container."),
+    image: joi.string().description("Override the image of the matched container."),
   })
 
 export const kubernetesDeploySyncSchema = () =>
@@ -331,6 +333,7 @@ export async function configureSyncMode({
           Override configuration:
           ${(override.command?.length ?? 0) > 0 ? `Command: ${override.command?.join(" ")}` : ""}
           ${(override.args?.length ?? 0) > 0 ? `Args: ${override.args?.join(" ")}` : ""}
+          ${override.image?.length ?? 0 ? `Image: ${override.image}` : ""}
         `,
       })
     }
@@ -405,6 +408,9 @@ export async function configureSyncMode({
     }
     if (override.args) {
       targetContainer.args = override.args
+    }
+    if (override.image) {
+      targetContainer.image = override.image
     }
 
     updatedTargets[key] = resolved

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -880,6 +880,16 @@ Override the args in the matched container.
 | --------------- | -------- |
 | `array[string]` | No       |
 
+### `spec.sync.overrides[].image`
+
+[spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > image
+
+Override the image of the matched container.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `spec.localMode`
 
 [spec](#spec) > localMode

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -934,6 +934,16 @@ Override the args in the matched container.
 | --------------- | -------- |
 | `array[string]` | No       |
 
+### `spec.sync.overrides[].image`
+
+[spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > image
+
+Override the image of the matched container.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `spec.localMode`
 
 [spec](#spec) > localMode


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a feature I need - the ability to replace the deployed image when running the sync mode. The motivation is explained in the linked issue  :smile: 

**Which issue(s) this PR fixes**:

Fixes #6232 

**Special notes for your reviewer**:

Can't seem to run `npm run generate-docs`, I get an error. 

Feel free to regenerate and push in my stead :man_shrugging: 