### PR TITLE
fix(kubernetes-plugin): sanitize volumes configuration for helm and kubernetes type pod runners

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -918,6 +918,8 @@ export const runPodResourceSchema = (kind: string) =>
         This resource will be selected from the manifests provided in this ${kind}'s \`files\` or \`manifests\` config field.
 
         The following fields from the Pod will be used (if present) when executing the ${kind}:
+
+        **Warning**: Garden will retain \`configMaps\` and \`secrets\` as volumes, but remove \`persistentVolumeClaim\` volumes from the Pod spec, as they might already be mounted.
         ${runPodSpecWhitelistDescription()}
         `
   )

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -932,7 +932,7 @@ export const runPodSpecSchema = (kind: string) =>
 
     You can find the full Pod spec in the [official Kubernetes documentation](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
 
-    The following Pod spec fields from the selected \`resource\` will be used (if present) when executing the ${kind}:
+    The following Pod spec fields from the \`podSpec\` will be used (if present) when executing the ${kind}:
     ${runPodSpecWhitelistDescription()}
   `
     )
@@ -949,6 +949,8 @@ export const kubernetesTaskSchema = () =>
         ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the task:
+
+        **Warning**: Garden will retain \`configMaps\` and \`secrets\` as volumes, but remove \`persistentVolumeClaim\` volumes from the Pod spec, as they might already be mounted.
         ${runPodSpecWhitelistDescription()}`
       ),
       ...kubernetesCommonRunSchemaKeys(),
@@ -966,6 +968,8 @@ export const kubernetesTestSchema = () =>
         ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+
+        **Warning**: Garden will retain \`configMaps\` and \`secrets\` as volumes, but remove \`persistentVolumeClaim\` volumes from the Pod spec, as they might already be mounted.
         ${runPodSpecWhitelistDescription()}`
       ),
       command: joi

--- a/core/src/plugins/kubernetes/helm/helm-pod.ts
+++ b/core/src/plugins/kubernetes/helm/helm-pod.ts
@@ -16,7 +16,13 @@ import type { CommonRunParams } from "../../../plugin/handlers/Run/run.js"
 import type { KubernetesPluginContext } from "../config.js"
 import { getActionNamespaceStatus } from "../namespace.js"
 import { k8sGetRunResult, storeRunResult } from "../run-results.js"
-import { getResourceContainer, getResourcePodSpec, getTargetResource, makePodName } from "../util.js"
+import {
+  getResourceContainer,
+  getResourcePodSpec,
+  getTargetResource,
+  makePodName,
+  sanitizeVolumesForPodRunner,
+} from "../util.js"
 import type { HelmPodRunAction, HelmPodTestAction } from "./config.js"
 import { helmPodRunSchema } from "./config.js"
 import { runAndCopy } from "../run.js"
@@ -166,6 +172,8 @@ export async function runOrTestWithChart(
   })
   const podSpec = getResourcePodSpec(target)
   const container = getResourceContainer(target, resourceSpec.containerName)
+
+  sanitizeVolumesForPodRunner(podSpec, container)
 
   return runAndCopy({
     ...params,

--- a/core/src/plugins/kubernetes/helm/helm-pod.ts
+++ b/core/src/plugins/kubernetes/helm/helm-pod.ts
@@ -16,13 +16,7 @@ import type { CommonRunParams } from "../../../plugin/handlers/Run/run.js"
 import type { KubernetesPluginContext } from "../config.js"
 import { getActionNamespaceStatus } from "../namespace.js"
 import { k8sGetRunResult, storeRunResult } from "../run-results.js"
-import {
-  getResourceContainer,
-  getResourcePodSpec,
-  getTargetResource,
-  makePodName,
-  sanitizeVolumesForPodRunner,
-} from "../util.js"
+import { getResourceContainer, getResourcePodSpec, getTargetResource, makePodName } from "../util.js"
 import type { HelmPodRunAction, HelmPodTestAction } from "./config.js"
 import { helmPodRunSchema } from "./config.js"
 import { runAndCopy } from "../run.js"
@@ -172,8 +166,6 @@ export async function runOrTestWithChart(
   })
   const podSpec = getResourcePodSpec(target)
   const container = getResourceContainer(target, resourceSpec.containerName)
-
-  sanitizeVolumesForPodRunner(podSpec, container)
 
   return runAndCopy({
     ...params,

--- a/core/src/plugins/kubernetes/helm/module-config.ts
+++ b/core/src/plugins/kubernetes/helm/module-config.ts
@@ -113,6 +113,8 @@ const helmTaskSchema = () =>
         ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the task:
+
+        **Warning**: Garden will retain \`configMaps\` and \`secrets\` as volumes, but remove \`persistentVolumeClaim\` volumes from the Pod spec, as they might already be mounted.
         ${runPodSpecWhitelistDescription}`
     ),
   })
@@ -127,6 +129,8 @@ const helmTestSchema = () =>
         ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+
+        **Warning**: Garden will retain \`configMaps\` and \`secrets\` as volumes, but remove \`persistentVolumeClaim\` volumes from the Pod spec, as they might already be mounted.
         ${runPodSpecWhitelistDescription}`
     ),
   })

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -22,7 +22,14 @@ import type { HelmModule } from "../helm/module-config.js"
 import type { KubernetesDeployAction } from "./config.js"
 import type { CommonRunParams } from "../../../plugin/handlers/Run/run.js"
 import { runAndCopy } from "../run.js"
-import { getResourceContainer, getResourceKey, getResourcePodSpec, getTargetResource, makePodName } from "../util.js"
+import {
+  getResourceContainer,
+  getResourceKey,
+  getResourcePodSpec,
+  getTargetResource,
+  makePodName,
+  sanitizeVolumesForPodRunner,
+} from "../util.js"
 import type { ActionMode, Resolved } from "../../../actions/types.js"
 import type { KubernetesPodRunAction, KubernetesPodTestAction } from "./kubernetes-pod.js"
 import type { V1ConfigMap } from "@kubernetes/client-node"
@@ -570,6 +577,8 @@ export async function runOrTestWithPod(
       message: `${action.longDescription()} specified a podSpec without containers. Please make sure there is at least one container in the spec.`,
     })
   }
+
+  sanitizeVolumesForPodRunner(podSpec, container)
 
   return runAndCopy({
     ...params,

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -8,7 +8,6 @@
 
 import { basename, dirname, join, resolve } from "path"
 import fsExtra from "fs-extra"
-const { pathExists, readFile } = fsExtra
 import { flatten, isEmpty, keyBy, set } from "lodash-es"
 import type { KubernetesModule } from "./module-config.js"
 import type { KubernetesResource } from "../types.js"
@@ -22,14 +21,7 @@ import type { HelmModule } from "../helm/module-config.js"
 import type { KubernetesDeployAction } from "./config.js"
 import type { CommonRunParams } from "../../../plugin/handlers/Run/run.js"
 import { runAndCopy } from "../run.js"
-import {
-  getResourceContainer,
-  getResourceKey,
-  getResourcePodSpec,
-  getTargetResource,
-  makePodName,
-  sanitizeVolumesForPodRunner,
-} from "../util.js"
+import { getResourceContainer, getResourceKey, getResourcePodSpec, getTargetResource, makePodName } from "../util.js"
 import type { ActionMode, Resolved } from "../../../actions/types.js"
 import type { KubernetesPodRunAction, KubernetesPodTestAction } from "./kubernetes-pod.js"
 import type { V1ConfigMap } from "@kubernetes/client-node"
@@ -38,6 +30,8 @@ import isGlob from "is-glob"
 import pFilter from "p-filter"
 import { kubectl } from "../kubectl.js"
 import { loadAndValidateYaml } from "../../../config/base.js"
+
+const { pathExists, readFile } = fsExtra
 
 /**
  * "DeployFile": Manifest has been read from one of the files declared in Garden Deploy `spec.files`
@@ -572,7 +566,6 @@ export async function runOrTestWithPod(
     })
     podSpec = getResourcePodSpec(target)
     container = getResourceContainer(target, resourceSpec.containerName)
-    sanitizeVolumesForPodRunner(podSpec, container)
   } else if (!container) {
     throw new ConfigurationError({
       message: `${action.longDescription()} specified a podSpec without containers. Please make sure there is at least one container in the spec.`,

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -572,13 +572,12 @@ export async function runOrTestWithPod(
     })
     podSpec = getResourcePodSpec(target)
     container = getResourceContainer(target, resourceSpec.containerName)
+    sanitizeVolumesForPodRunner(podSpec, container)
   } else if (!container) {
     throw new ConfigurationError({
       message: `${action.longDescription()} specified a podSpec without containers. Please make sure there is at least one container in the spec.`,
     })
   }
-
-  sanitizeVolumesForPodRunner(podSpec, container)
 
   return runAndCopy({
     ...params,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -23,7 +23,7 @@ import { KubeApi, KubernetesError } from "./api.js"
 import { getPodLogs, checkPodStatus } from "./status/pod.js"
 import type { KubernetesResource, KubernetesPod, KubernetesServerResource, SupportedRuntimeAction } from "./types.js"
 import type { ContainerEnvVars, ContainerResourcesSpec, ContainerVolumeSpec } from "../container/config.js"
-import { prepareEnvVars, makePodName, renderPodEvents } from "./util.js"
+import { prepareEnvVars, makePodName, renderPodEvents, sanitizeVolumesForPodRunner } from "./util.js"
 import { dedent, deline, randomString } from "../../util/string.js"
 import type { ArtifactSpec } from "../../config/validation.js"
 import { prepareSecrets } from "./secrets.js"
@@ -319,6 +319,8 @@ export async function prepareRunPodSpec({
   // and `configmap` actions (which are only supported for `container` actions, and are currently discouraged).
   if (volumes && volumes.length && action.type === "container") {
     configureVolumes(action, preparedPodSpec, volumes)
+  } else {
+    sanitizeVolumesForPodRunner(preparedPodSpec, container)
   }
 
   if (getArtifacts) {

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -824,6 +824,8 @@ export function summarize(resources: KubernetesResource[]) {
 /**
  * Filter out all volumes and volumemounts that are not a configmaps or secrets,
  * since they will probably cause issues when creating a pod runner from a chart or larger manifest.
+ *
+ * This is not a pure function, i.e. it has side-effects and can mutate the input arguments.
  */
 export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, containerSpec: V1Container) {
   if (podSpec && podSpec.volumes) {
@@ -841,7 +843,6 @@ export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, cont
       }
     })
   }
-  return { podSpec, containerSpec }
 }
 
 export function isOctal(value: string) {

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -821,8 +821,10 @@ export function summarize(resources: KubernetesResource[]) {
   return resources.map((r) => `${r.kind} ${r.metadata.name}`).join(", ")
 }
 
-// Filter out all volumes and volumemounts that are not a configmaps or secrets, since they will
-// probably cause issues when creating a pod runner from a chart or larger manifest.
+/**
+ * Filter out all volumes and volumemounts that are not a configmaps or secrets,
+ * since they will probably cause issues when creating a pod runner from a chart or larger manifest.
+ */
 export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, containerSpec: V1Container) {
   if (podSpec && podSpec.volumes) {
     podSpec.volumes = podSpec.volumes.filter((volume) => volume.configMap || volume.secret)

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -826,12 +826,18 @@ export function summarize(resources: KubernetesResource[]) {
  * since they will probably cause issues when creating a pod runner from a chart or larger manifest.
  *
  * This is not a pure function, i.e. it has side effects and can mutate the input arguments.
+ *
+ * This sanitization only makes sense when both `podSpec` and `containerSpec` are defined.
+ * It serves helm-pod and kubernetes-pod action types.
  */
-export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, containerSpec: V1Container) {
+export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, containerSpec: V1Container | undefined) {
   if (!podSpec) {
     return
   }
   if (!podSpec.volumes) {
+    return
+  }
+  if (!containerSpec) {
     return
   }
 

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -834,7 +834,7 @@ export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, cont
     })
     // We also make sure the defaultMode of a configMap volume is an octal number.
     podSpec.volumes.forEach((volume) => {
-      if (volume.configMap && volume.configMap.defaultMode && isOctal(volume.configMap.defaultMode.toString())) {
+      if (volume.configMap && volume.configMap.defaultMode && !isOctal(volume.configMap.defaultMode.toString())) {
         volume.configMap!.defaultMode = parseInt(`0${volume.configMap?.defaultMode}`, 8)
       }
     })

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -822,27 +822,34 @@ export function summarize(resources: KubernetesResource[]) {
 }
 
 /**
- * Filter out all volumes and volumemounts that are not a configmaps or secrets,
+ * Filter out all volumes and volumeMounts that are not a ConfigMaps or Secrets,
  * since they will probably cause issues when creating a pod runner from a chart or larger manifest.
  *
- * This is not a pure function, i.e. it has side-effects and can mutate the input arguments.
+ * This is not a pure function, i.e. it has side effects and can mutate the input arguments.
  */
 export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, containerSpec: V1Container) {
-  if (podSpec && podSpec.volumes) {
-    podSpec.volumes = podSpec.volumes.filter((volume) => volume.configMap || volume.secret)
-
-    const retainedVolumes = new Set(podSpec?.volumes?.map((volume) => volume.name))
-
-    containerSpec.volumeMounts = containerSpec.volumeMounts?.filter((volumeMount) => {
-      return retainedVolumes.has(volumeMount.name)
-    })
-    // We also make sure the defaultMode of a configMap volume is an octal number.
-    podSpec.volumes.forEach((volume) => {
-      if (volume.configMap && volume.configMap.defaultMode && !isOctal(volume.configMap.defaultMode.toString())) {
-        volume.configMap!.defaultMode = parseInt(`0${volume.configMap?.defaultMode}`, 8)
-      }
-    })
+  if (!podSpec) {
+    return
   }
+  if (!podSpec.volumes) {
+    return
+  }
+
+  // Sanitize volumes
+  podSpec.volumes = podSpec.volumes.filter((volume) => volume.configMap || volume.secret)
+
+  // Sanitize volumeMounts
+  const retainedVolumes = new Set(podSpec?.volumes?.map((volume) => volume.name))
+  containerSpec.volumeMounts = containerSpec.volumeMounts?.filter((volumeMount) => {
+    return retainedVolumes.has(volumeMount.name)
+  })
+
+  // We also make sure the defaultMode of a configMap volume is an octal number.
+  podSpec.volumes.forEach((volume) => {
+    if (volume.configMap && volume.configMap.defaultMode && !isOctal(volume.configMap.defaultMode.toString())) {
+      volume.configMap!.defaultMode = parseInt(`0${volume.configMap?.defaultMode}`, 8)
+    }
+  })
 }
 
 export function isOctal(value: string) {

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -51,7 +51,6 @@ import type { Resolved } from "../../actions/types.js"
 import { serializeValues } from "../../util/serialization.js"
 import { PassThrough } from "stream"
 import { styles } from "../../logger/styles.js"
-import { parse } from "path"
 
 const STATIC_LABEL_REGEX = /[0-9]/g
 export const workloadTypes = ["Deployment", "DaemonSet", "ReplicaSet", "StatefulSet"]

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -844,6 +844,6 @@ export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, cont
   return { podSpec, containerSpec }
 }
 
-function isOctal(value: string) {
-  return /^(0o)[0-7]+$/i.test(value)
+export function isOctal(value: string) {
+  return /^(0o?)[0-7]+$/i.test(value)
 }

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -850,6 +850,21 @@ export function sanitizeVolumesForPodRunner(podSpec: V1PodSpec | undefined, cont
     return retainedVolumes.has(volumeMount.name)
   })
 
+  /*
+  Here we get the `containerSpec` and the `podSpec` as separate arguments,
+  so we can't be sure that `containerSpec` object   has the same identity as one of the containers defined in `podSpec.containers`.
+
+  The names of these 2 containers can also be different
+  because we always override the container name in the caller function `prepareRunPodSpec()`.
+
+  Thus, we need to sanitize `podSpec.containers` explicitly.
+   */
+  for (const podSpecContainer of podSpec.containers) {
+    podSpecContainer.volumeMounts = podSpecContainer.volumeMounts?.filter((volumeMount) => {
+      return retainedVolumes.has(volumeMount.name)
+    })
+  }
+
   // We also make sure the defaultMode of a configMap volume is an octal number.
   podSpec.volumes.forEach((volume) => {
     if (volume.configMap && volume.configMap.defaultMode && !isOctal(volume.configMap.defaultMode.toString())) {

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -640,7 +640,7 @@ describe("kubernetes Pod runner functions", () => {
         provider: helmCtx.provider,
         manifests: helmManifests,
         action: helmAction,
-        query: { ...helmResourceSpec, podSelector: undefined, name: helmAction.getSpec().releaseName },
+        query: { ...helmResourceSpec, name: helmAction.getSpec().releaseName },
       })
       helmContainer = getResourceContainer(helmTarget, helmResourceSpec.containerName)
     })

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -633,6 +633,7 @@ describe("kubernetes Pod runner functions", () => {
         provider: helmCtx.provider,
       })
     })
+
     beforeEach(async () => {
       helmTarget = await getTargetResource({
         ctx: helmCtx,
@@ -708,7 +709,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         resources, // <---
         description: "Helm module",
@@ -762,7 +762,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         resources, // <---
         description: "Helm module",
@@ -838,7 +837,9 @@ describe("kubernetes Pod runner functions", () => {
         ...helmContainer,
         volumeMounts,
       }
+
       sanitizeVolumesForPodRunner(podSpecWithVolumes, helmContainerWithVolumeMounts)
+
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: podSpecWithVolumes,
         getArtifacts: false,
@@ -848,7 +849,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         resources,
         description: "Helm module",
@@ -863,6 +863,7 @@ describe("kubernetes Pod runner functions", () => {
       expect(generatedPodSpec.volumes).to.eql(volumes)
       expect(generatedPodSpec.containers[0].volumeMounts).to.eql(volumeMounts)
     })
+
     it("should not include persistentVolumes in the generated pod spec", async () => {
       const podSpecWithPersistentVolume = getResourcePodSpec(helmTarget)
       const volumes: V1Volume[] = [
@@ -884,7 +885,9 @@ describe("kubernetes Pod runner functions", () => {
         ...helmContainer,
         volumeMounts,
       }
+
       sanitizeVolumesForPodRunner(podSpecWithPersistentVolume, helmContainerWithVolumeMounts)
+
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: podSpecWithPersistentVolume,
         getArtifacts: false,
@@ -894,7 +897,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         resources,
         description: "Helm module",
@@ -908,6 +910,7 @@ describe("kubernetes Pod runner functions", () => {
       expect(generatedPodSpec.volumes).to.eql([])
       expect(generatedPodSpec.containers[0].volumeMounts).to.eql([])
     })
+
     it("should make sure configMap file permissions are in octal", async () => {
       const podSpecWithConfigMap = getResourcePodSpec(helmTarget)
       const volumes = [
@@ -930,7 +933,9 @@ describe("kubernetes Pod runner functions", () => {
         ...helmContainer,
         volumeMounts,
       }
+
       sanitizeVolumesForPodRunner(podSpecWithConfigMap, helmContainerWithVolumeMounts)
+
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: podSpecWithConfigMap,
         getArtifacts: false,
@@ -940,7 +945,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         resources,
         description: "Helm module",
@@ -953,6 +957,7 @@ describe("kubernetes Pod runner functions", () => {
       })
       expect(generatedPodSpec.volumes![0].configMap?.defaultMode).to.eql(493)
     })
+
     it("should apply security context fields to the main container when provided", async () => {
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: undefined,
@@ -963,7 +968,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         resources, // <---
         description: "Helm module",
@@ -1048,7 +1052,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         description: "Helm module",
         mainContainerName: "main",
@@ -1125,7 +1128,6 @@ describe("kubernetes Pod runner functions", () => {
         action: helmAction,
         args: ["sh", "-c"],
         command: ["echo", "foo"],
-
         envVars: {},
         description: "Helm module",
         mainContainerName: "main",

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -52,6 +52,7 @@ import type { Resolved } from "../../../../../src/actions/types.js"
 import type { HelmDeployAction } from "../../../../../src/plugins/kubernetes/helm/config.js"
 import { executeAction } from "../../../../../src/graph/actions.js"
 import { DEFAULT_RUN_TIMEOUT_SEC } from "../../../../../src/constants.js"
+import cloneDeep from "fast-copy"
 
 describe("kubernetes Pod runner functions", () => {
   let garden: Garden
@@ -634,14 +635,16 @@ describe("kubernetes Pod runner functions", () => {
     })
 
     beforeEach(async () => {
-      helmTarget = await getTargetResource({
-        ctx: helmCtx,
-        log: helmLog,
-        provider: helmCtx.provider,
-        manifests: helmManifests,
-        action: helmAction,
-        query: { ...helmResourceSpec, name: helmAction.getSpec().releaseName },
-      })
+      helmTarget = cloneDeep(
+        await getTargetResource({
+          ctx: helmCtx,
+          log: helmLog,
+          provider: helmCtx.provider,
+          manifests: helmManifests,
+          action: helmAction,
+          query: { ...helmResourceSpec, name: helmAction.getSpec().releaseName },
+        })
+      )
       helmContainer = getResourceContainer(helmTarget, helmResourceSpec.containerName)
     })
 

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -30,6 +30,7 @@ import {
   getServiceResourceSpec,
   getResourcePodSpec,
   makePodName,
+  sanitizeVolumesForPodRunner,
 } from "../../../../../src/plugins/kubernetes/util.js"
 import { getContainerTestGarden } from "./container/container.js"
 import type {
@@ -44,7 +45,7 @@ import { buildHelmModules, getHelmTestGarden } from "./helm/common.js"
 import { getBaseModule, getChartResources } from "../../../../../src/plugins/kubernetes/helm/common.js"
 import { getActionNamespace } from "../../../../../src/plugins/kubernetes/namespace.js"
 import type { GardenModule } from "../../../../../src/types/module.js"
-import type { V1Container, V1Pod, V1PodSpec } from "@kubernetes/client-node"
+import type { V1Container, V1Pod, V1PodSpec, V1Volume } from "@kubernetes/client-node"
 import { getResourceRequirements } from "../../../../../src/plugins/kubernetes/container/util.js"
 import type { ContainerBuildAction, ContainerResourcesSpec } from "../../../../../src/plugins/container/moduleConfig.js"
 import type { KubernetesPodRunActionSpec } from "../../../../../src/plugins/kubernetes/kubernetes-type/kubernetes-pod.js"
@@ -803,19 +804,41 @@ describe("kubernetes Pod runner functions", () => {
       })
     })
 
-    it("should include volume mounts for containers in the generated pod spec", async () => {
-      const volumeMounts = [
+    it("should include configMaps and secrets in the generated pod spec", async () => {
+      const podSpec = getResourcePodSpec(helmTarget)
+      const volumes = [
         {
-          name: "some-volume",
-          mountPath: "/some-volume",
+          name: "myconfigmap",
+          configMap: {
+            name: "myconfigmap",
+            defaultMode: 0o755,
+          },
+        },
+        {
+          name: "mysecret",
+          secret: {
+            secretName: "mysecret",
+          },
         },
       ]
+      const volumeMounts = [
+        {
+          name: "myconfigmap",
+          mountPath: "/config",
+        },
+        {
+          name: "mysecret",
+          mountPath: "/secret",
+        },
+      ]
+      podSpec!.volumes = volumes
       const helmContainerWithVolumeMounts = {
         ...helmContainer,
         volumeMounts,
       }
+      sanitizeVolumesForPodRunner(podSpec, helmContainerWithVolumeMounts)
       const generatedPodSpec = await prepareRunPodSpec({
-        podSpec: undefined,
+        podSpec,
         getArtifacts: false,
         api: helmApi,
         provider: helmProvider,
@@ -836,6 +859,7 @@ describe("kubernetes Pod runner functions", () => {
       })
 
       expect(pruneEmpty(generatedPodSpec)).to.eql({
+        volumes, // <------
         containers: [
           {
             name: "main",
@@ -867,7 +891,96 @@ describe("kubernetes Pod runner functions", () => {
         imagePullSecrets: [],
       })
     })
+    it("should not include persistentVolumes in the generated pod spec", async () => {
+      const podSpec = getResourcePodSpec(helmTarget)
+      const volumes: V1Volume[] = [
+        {
+          name: "myvolume",
+          persistentVolumeClaim: {
+            claimName: "myVolumeClaim",
+          },
+        },
+      ]
+      const volumeMounts = [
+        {
+          name: "myvolume",
+          mountPath: "/data",
+        },
+      ]
+      podSpec!.volumes = volumes
+      const helmContainerWithVolumeMounts = {
+        ...helmContainer,
+        volumeMounts,
+      }
+      sanitizeVolumesForPodRunner(podSpec, helmContainerWithVolumeMounts)
+      const generatedPodSpec = await prepareRunPodSpec({
+        podSpec: undefined,
+        getArtifacts: false,
+        api: helmApi,
+        provider: helmProvider,
+        log: helmLog,
+        action: helmAction,
+        args: ["sh", "-c"],
+        command: ["echo", "foo"],
 
+        envVars: {},
+        resources,
+        description: "Helm module",
+        mainContainerName: "main",
+        image: "foo",
+        container: helmContainerWithVolumeMounts,
+        namespace: helmNamespace,
+        // Note: We're not passing the `volumes` param here, since that's for `container` Runs/Tests.
+        // This test case is intended for `kubernetes-pod` Runs and Tests.
+      })
+      expect(generatedPodSpec.volumes).to.eql([])
+      expect(generatedPodSpec.containers[0].volumeMounts).to.eql([])
+    })
+    it("should make sure configMap file permissions are in octal", async () => {
+      const podSpec = getResourcePodSpec(helmTarget)
+      const volumes = [
+        {
+          name: "myconfigmap",
+          configMap: {
+            name: "myconfigmap",
+            defaultMode: 755, // <--- This is not in octal
+          },
+        },
+      ]
+      const volumeMounts = [
+        {
+          name: "myconfigmap",
+          mountPath: "/config",
+        },
+      ]
+      podSpec!.volumes = volumes
+      const helmContainerWithVolumeMounts = {
+        ...helmContainer,
+        volumeMounts,
+      }
+      sanitizeVolumesForPodRunner(podSpec, helmContainerWithVolumeMounts)
+      const generatedPodSpec = await prepareRunPodSpec({
+        podSpec,
+        getArtifacts: false,
+        api: helmApi,
+        provider: helmProvider,
+        log: helmLog,
+        action: helmAction,
+        args: ["sh", "-c"],
+        command: ["echo", "foo"],
+
+        envVars: {},
+        resources,
+        description: "Helm module",
+        mainContainerName: "main",
+        image: "foo",
+        container: helmContainerWithVolumeMounts,
+        namespace: helmNamespace,
+        // Note: We're not passing the `volumes` param here, since that's for `container` Runs/Tests.
+        // This test case is intended for `kubernetes-pod` Runs and Tests.
+      })
+      expect(generatedPodSpec.volumes![0].configMap?.defaultMode).to.eql(0o755)
+    })
     it("should apply security context fields to the main container when provided", async () => {
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: undefined,

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -30,7 +30,6 @@ import {
   getServiceResourceSpec,
   getResourcePodSpec,
   makePodName,
-  sanitizeVolumesForPodRunner,
 } from "../../../../../src/plugins/kubernetes/util.js"
 import { getContainerTestGarden } from "./container/container.js"
 import type {
@@ -838,8 +837,6 @@ describe("kubernetes Pod runner functions", () => {
         volumeMounts,
       }
 
-      sanitizeVolumesForPodRunner(podSpecWithVolumes, helmContainerWithVolumeMounts)
-
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: podSpecWithVolumes,
         getArtifacts: false,
@@ -886,8 +883,6 @@ describe("kubernetes Pod runner functions", () => {
         volumeMounts,
       }
 
-      sanitizeVolumesForPodRunner(podSpecWithPersistentVolume, helmContainerWithVolumeMounts)
-
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: podSpecWithPersistentVolume,
         getArtifacts: false,
@@ -933,8 +928,6 @@ describe("kubernetes Pod runner functions", () => {
         ...helmContainer,
         volumeMounts,
       }
-
-      sanitizeVolumesForPodRunner(podSpecWithConfigMap, helmContainerWithVolumeMounts)
 
       const generatedPodSpec = await prepareRunPodSpec({
         podSpec: podSpecWithConfigMap,

--- a/core/test/unit/src/plugins/kubernetes/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/util.ts
@@ -17,6 +17,7 @@ import {
   getSelectorString,
   makePodName,
   matchSelector,
+  isOctal,
 } from "../../../../../src/plugins/kubernetes/util.js"
 import type { KubernetesPod, KubernetesServerResource } from "../../../../../src/plugins/kubernetes/types.js"
 import type { V1Pod } from "@kubernetes/client-node"
@@ -360,5 +361,29 @@ describe("matchSelector", () => {
   it("should return true if selector is a subset of labels", () => {
     const matched = matchSelector({ foo: "bar" }, { foo: "bar", something: "else" })
     expect(matched).to.be.true
+  })
+})
+
+describe("isOctal", () => {
+  describe("should recognize octal numbers", () => {
+    it("in YAML <= 1.1", () => {
+      expect(isOctal("0777")).to.true
+    })
+
+    it("in YAML >= 1.2", () => {
+      expect(isOctal("0o777")).to.true
+    })
+  })
+
+  it("should not recognize non-octal numeric strings", () => {
+    expect(isOctal("777")).to.false
+  })
+
+  it("should not recognize hex numbers", () => {
+    expect(isOctal("0xff")).to.false
+  })
+
+  it("should not non-numeric strings", () => {
+    expect(isOctal("qweRTY")).to.false
   })
 })

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -534,6 +534,8 @@ Specify a Kubernetes resource to derive the Pod spec from for the Run.
 This resource will be selected from the manifests provided in this Run's `files` or `manifests` config field.
 
 The following fields from the Pod will be used (if present) when executing the Run:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -305,6 +305,8 @@ Specify a Kubernetes resource to derive the Pod spec from for the Run.
 This resource will be selected from the manifests provided in this Run's `files` or `manifests` config field.
 
 The following fields from the Pod will be used (if present) when executing the Run:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -657,7 +657,7 @@ Supply a custom Pod specification. This should be a normal Kubernetes Pod manife
 
 You can find the full Pod spec in the [official Kubernetes documentation](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
 
-The following Pod spec fields from the selected `resource` will be used (if present) when executing the Run:
+The following Pod spec fields from the `podSpec` will be used (if present) when executing the Run:
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -576,6 +576,8 @@ Specify a Kubernetes resource to derive the Pod spec from for the Run.
 This resource will be selected from the manifests provided in this Run's `files` or `manifests` config field.
 
 The following fields from the Pod will be used (if present) when executing the Run:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -534,6 +534,8 @@ Specify a Kubernetes resource to derive the Pod spec from for the Run.
 This resource will be selected from the manifests provided in this Run's `files` or `manifests` config field.
 
 The following fields from the Pod will be used (if present) when executing the Run:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -305,6 +305,8 @@ Specify a Kubernetes resource to derive the Pod spec from for the Test.
 This resource will be selected from the manifests provided in this Test's `files` or `manifests` config field.
 
 The following fields from the Pod will be used (if present) when executing the Test:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -657,7 +657,7 @@ Supply a custom Pod specification. This should be a normal Kubernetes Pod manife
 
 You can find the full Pod spec in the [official Kubernetes documentation](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
 
-The following Pod spec fields from the selected `resource` will be used (if present) when executing the Test:
+The following Pod spec fields from the `podSpec` will be used (if present) when executing the Test:
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -576,6 +576,8 @@ Specify a Kubernetes resource to derive the Pod spec from for the Test.
 This resource will be selected from the manifests provided in this Test's `files` or `manifests` config field.
 
 The following fields from the Pod will be used (if present) when executing the Test:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -466,6 +466,9 @@ tasks:
     # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the task:
+    #
+    # **Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim`
+    # volumes from the Pod spec, as they might already be mounted.
     # * `affinity`
     # * `automountServiceAccountToken`
     # * `containers`
@@ -570,6 +573,9 @@ tests:
     # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+    #
+    # **Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim`
+    # volumes from the Pod spec, as they might already be mounted.
     # * `affinity`
     # * `automountServiceAccountToken`
     # * `containers`
@@ -1693,6 +1699,8 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the task:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`
@@ -1963,6 +1971,8 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -452,6 +452,9 @@ tasks:
     # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the task:
+    #
+    # **Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim`
+    # volumes from the Pod spec, as they might already be mounted.
     # * `affinity`
     # * `automountServiceAccountToken`
     # * `containers`
@@ -552,6 +555,9 @@ tests:
     # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+    #
+    # **Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim`
+    # volumes from the Pod spec, as they might already be mounted.
     # * `affinity`
     # * `automountServiceAccountToken`
     # * `containers`
@@ -1613,6 +1619,8 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the task:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`
@@ -1874,6 +1882,8 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+
+**Warning**: Garden will retain `configMaps` and `secrets` as volumes, but remove `persistentVolumeClaim` volumes from the Pod spec, as they might already be mounted.
 * `affinity`
 * `automountServiceAccountToken`
 * `containers`


### PR DESCRIPTION
**What this PR does / why we need it**:

The kubernetes-type and helm pod runners for `Run` and `Test` actions are using the `podSpec` from a Kubernetes manifest or helm chart if a `resource` is specified. If these resources e.g. a `statefulSet` include volumes, these pods may fail to be deployed, because the volumes are already attached (most volumes are read-write-once).

We therefore sanitize the `podSpec` by removing all volumes except `configMaps` and `secrets`  which may be crucial for the pod to contain the correct configuration or credentials to run. These volume types can also be mounted several times and are less likely to cause issues.

In case of `configMaps` we also make sure that the `defaultMode` of the file permission is in octal.

If the `podSpec` is explicitly configured in a kubernetes-pod we keep all kinds of volumes, even `persistentVolumeClaims` since the user has explicitly configured them and can make sure they exist and can be mounted. This PR only removes `persistentVolumeClaim` type volumes if they are implicitly set through a helm chart or Kubernetes manifest.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Volume mounts in pod runners were allowed in #6112. We might need to re-visit those changes and apply the necessary amendments and restrictions.