### PR TITLE
docs(varfiles): actualize the default format description

### DIFF
--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -43,11 +43,11 @@ export const noTemplateFields = ["apiVersion", "kind", "type", "name", "internal
 export const varfileDescription = `
 The format of the files is determined by the configured file's extension:
 
+* \`.yaml\`/\`.yml\` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * \`.env\` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* \`.yaml\`/\`.yml\` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * \`.json\` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 `.trim()
 
 export type ObjectPath = (string | number)[]

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -152,11 +152,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -152,11 +152,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -164,11 +164,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -194,11 +194,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -198,11 +198,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -200,11 +200,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -198,11 +198,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -202,11 +202,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -194,11 +194,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -200,11 +200,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -198,11 +198,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -194,11 +194,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -200,11 +200,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -196,11 +196,11 @@ If you specify multiple paths, they are merged in the order specified, i.e. the 
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different varfiles in different environments, you can template in the environment name to the varfile name, e.g. `varfile: "my-action.${environment.name}.env"` (this assumes that the corresponding varfiles exist).
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1572,12 +1572,12 @@ providers:
         #
         # The format of the files is determined by the configured file's extension:
         #
-        # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
         # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys
-        # may contain any value type.
+        # may contain any value type. YAML format is used by default.
+        # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
         # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
         #
-        # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+        # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
         # nested objects and arrays._
         #
         # To use different module-level varfiles in different environments, you can template in the environment name
@@ -1848,12 +1848,12 @@ actionConfigs:
       #
       # The format of the files is determined by the configured file's extension:
       #
-      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-      # contain any value type.
+      # contain any value type. YAML format is used by default.
+      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
       #
-      # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+      # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
       # nested objects and arrays._
       #
       # To use different varfiles in different environments, you can template in the environment name to the varfile
@@ -2064,12 +2064,12 @@ actionConfigs:
       #
       # The format of the files is determined by the configured file's extension:
       #
-      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-      # contain any value type.
+      # contain any value type. YAML format is used by default.
+      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
       #
-      # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+      # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
       # nested objects and arrays._
       #
       # To use different varfiles in different environments, you can template in the environment name to the varfile
@@ -2219,12 +2219,12 @@ actionConfigs:
       #
       # The format of the files is determined by the configured file's extension:
       #
-      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-      # contain any value type.
+      # contain any value type. YAML format is used by default.
+      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
       #
-      # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+      # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
       # nested objects and arrays._
       #
       # To use different varfiles in different environments, you can template in the environment name to the varfile
@@ -2374,12 +2374,12 @@ actionConfigs:
       #
       # The format of the files is determined by the configured file's extension:
       #
-      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-      # contain any value type.
+      # contain any value type. YAML format is used by default.
+      # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
       # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
       #
-      # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+      # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
       # nested objects and arrays._
       #
       # To use different varfiles in different environments, you can template in the environment name to the varfile
@@ -2524,12 +2524,12 @@ moduleConfigs:
     #
     # The format of the files is determined by the configured file's extension:
     #
-    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-    # contain any value type.
+    # contain any value type. YAML format is used by default.
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
     #
-    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
     # nested objects and arrays._
     #
     # To use different module-level varfiles in different environments, you can template in the environment name
@@ -3098,12 +3098,12 @@ modules:
     #
     # The format of the files is determined by the configured file's extension:
     #
-    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-    # contain any value type.
+    # contain any value type. YAML format is used by default.
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
     #
-    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
     # nested objects and arrays._
     #
     # To use different module-level varfiles in different environments, you can template in the environment name

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -171,12 +171,12 @@ modules:
     #
     # The format of the files is determined by the configured file's extension:
     #
-    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-    # contain any value type.
+    # contain any value type. YAML format is used by default.
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
     #
-    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
     # nested objects and arrays._
     #
     # To use different module-level varfiles in different environments, you can template in the environment name
@@ -569,11 +569,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -154,12 +154,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -460,11 +460,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -157,12 +157,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -468,11 +468,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -169,12 +169,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -1041,11 +1041,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -166,12 +166,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -650,11 +650,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -160,12 +160,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -459,11 +459,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -162,12 +162,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -920,11 +920,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -237,12 +237,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -1256,11 +1256,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -161,12 +161,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -903,11 +903,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -154,12 +154,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -523,11 +523,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -156,12 +156,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -539,11 +539,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -148,12 +148,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -452,11 +452,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -162,12 +162,12 @@ variables:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # To use different module-level varfiles in different environments, you can template in the environment name
@@ -489,11 +489,11 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 To use different module-level varfiles in different environments, you can template in the environment name
 to the varfile name, e.g. `varfile: "my-module.${environment.name}.env` (this assumes that the corresponding

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -67,12 +67,12 @@ environments:
     #
     # The format of the files is determined by the configured file's extension:
     #
-    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-    # contain any value type.
+    # contain any value type. YAML format is used by default.
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
     # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
     #
-    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of
     # nested objects and arrays._
     #
     # If you don't set the field and the `garden.<env-name>.env` file does not exist,
@@ -192,12 +192,12 @@ sources:
 #
 # The format of the files is determined by the configured file's extension:
 #
-# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
-# contain any value type.
+# contain any value type. YAML format is used by default.
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
 # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 #
-# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# _NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested
 # objects and arrays._
 #
 # If you don't set the field and the `garden.env` file does not exist, we simply ignore it.
@@ -332,11 +332,11 @@ _environment-specific_ `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 If you don't set the field and the `garden.<env-name>.env` file does not exist,
 we simply ignore it. If you do override the default value and the file doesn't exist, an error will be thrown.
@@ -679,11 +679,11 @@ project-wide `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type. YAML format is used by default.
 * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
 * `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
-_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+_NOTE: The default varfile format was changed to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
 If you don't set the field and the `garden.env` file does not exist, we simply ignore it.
 If you do override the default value and the file doesn't exist, an error will be thrown.


### PR DESCRIPTION
**What this PR does / why we need it**:

Actualize the description of the supported varfiles formats.
Garden 0.13 was released more than 1 year ago, so the description shouldn't say "will be" :)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
