### PR TITLE
fix: print action version in logs while status check

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -7,27 +7,26 @@
  */
 
 import titleize from "titleize"
-import type { ConfigGraph, GetActionOpts, ResolvedConfigGraph } from "../graph/config-graph.js"
+import type { ConfigGraph, GetActionOpts, PickTypeByKind, ResolvedConfigGraph } from "../graph/config-graph.js"
 import type { ActionReference, DeepPrimitiveMap } from "../config/common.js"
 import {
+  createSchema,
   includeGuideLink,
   joi,
+  joiArray,
   joiIdentifier,
   joiRepositoryUrl,
   joiSparseArray,
   joiUserIdentifier,
+  joiVarfile,
   joiVariables,
   parseActionReference,
-  createSchema,
   unusedApiVersionSchema,
-  joiArray,
-  joiVarfile,
 } from "../config/common.js"
 import { DOCS_BASE_URL } from "../constants.js"
 import { dedent, naturalList, stableStringify } from "../util/string.js"
-import type { ModuleVersion, TreeVersion, ActionVersion } from "../vcs/vcs.js"
-import { getActionSourcePath } from "../vcs/vcs.js"
-import { hashStrings, versionStringPrefix } from "../vcs/vcs.js"
+import type { ActionVersion, ModuleVersion, TreeVersion } from "../vcs/vcs.js"
+import { getActionSourcePath, hashStrings, versionStringPrefix } from "../vcs/vcs.js"
 import type { BuildAction, ResolvedBuildAction } from "./build.js"
 import type { ActionKind } from "../plugin/action-types.js"
 import pathIsInside from "path-is-inside"
@@ -58,7 +57,6 @@ import type {
 } from "./types.js"
 import { actionKinds, actionStateTypes } from "./types.js"
 import { baseInternalFieldsSchema, varfileDescription } from "../config/base.js"
-import type { PickTypeByKind } from "../graph/config-graph.js"
 import type { DeployAction } from "./deploy.js"
 import type { TestAction } from "./test.js"
 import type { RunAction } from "./run.js"

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -104,6 +104,7 @@ interface TaskEvents<O extends ValidResultType> {
   processed: TaskEventPayload<O>
   ready: { result: O }
 }
+
 @Profile()
 export abstract class BaseTask<O extends ValidResultType = ValidResultType> extends TypedEventEmitter<TaskEvents<O>> {
   abstract readonly type: string
@@ -472,7 +473,9 @@ export function logAndEmitGetStatusEvents<
     const styledName = styles.highlight(this.action.name)
     const logStrings = actionLogStrings[this.action.kind]
 
-    log.info(`Getting status for ${this.action.kind} ${styledName} (type ${styles.highlight(this.action.type)})...`)
+    log.info(
+      `Getting status for ${this.action.kind} ${styledName} (type ${styles.highlight(this.action.type)}) at version ${this.action.versionString()}...`
+    )
 
     // First we emit the "getting-status" event
     this.garden.events.emit(


### PR DESCRIPTION
**What this PR does / why we need it**:

In Garden 0.13.x there has been slight regression in the logging output.
The action versions have not been printed while status checks.

This PR fixes that issue.

**Logs from Garden 0.12**
```console
$ garden build --logger-type=basic
[..]
ℹ hello-world-go-image      → Getting build status for v-6e7207d990...
[..]
✔ hello-world-go-image      → Getting build status for v-6e7207d990... → Already built
ℹ hello-world-go            → Getting build status for v-2003407d80...
ℹ hello-world-go            → Building version v-2003407d80...
✔ hello-world-go            → Building version v-2003407d80... → Done (took 0 sec)

$ garden build hello-world-go-image --logger-type basic
[..]
ℹ hello-world-go-image      → Getting build status for v-6e7207d990..
[..]
✔ hello-world-go-image      → Getting build status for v-6e7207d990... → Already built
```

**Logs from Garden 0.13**
```console
$ garden build --logger-type=default
[..]
ℹ build.hello-world-go-image → Getting status for Build hello-world-go-image (type container)...
[..]
✔ build.hello-world-go-image → Already built

$ garden build hello-world-go-image --logger-type default
[..]
ℹ build.hello-world-go-image → Getting status for Build hello-world-go-image (type container)...
[..]
ℹ build.hello-world-go-image → Done!
✔ build.hello-world-go-image → Already built
```

**Special notes for your reviewer**:
