### PR TITLE
fix(cloudbuilder): add error handling to fallback to cli install of buildx builder

### DIFF
--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -196,6 +196,14 @@ async function buildContainerLocally({
           Learn more at https://docs.docker.com/go/build-multi-platform/
         `,
       })
+    } else if (error.message.includes("failed to push")) {
+      throw new ConfigurationError({
+        message: dedent`
+          The Docker daemon failed to push the image to the registry.
+          Please make sure that you are logged in and that you
+          have sufficient permissions on this machine to push to the registry.
+        `,
+      })
     }
     throw error
   }

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -335,8 +335,8 @@ class BuildxBuilder {
 
       try {
         if (refCount === 1) {
-          await this.remove_builder()
-          await this.remove_tmpdir()
+          await this.removeBuilder()
+          await this.removeTmpdir()
         }
       } finally {
         // even decrease refcount if removal failed
@@ -367,12 +367,12 @@ class BuildxBuilder {
 
   // private: clean
 
-  private async remove_tmpdir() {
+  private async removeTmpdir() {
     this.ctx.log.debug(`Removing ${this.certDir}...`)
     await rm(this.certDir, { recursive: true, force: true })
   }
 
-  private async remove_builder() {
+  private async removeBuilder() {
     try {
       await rm(this.buildxInstanceJsonPath)
     } catch (e) {

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -378,7 +378,7 @@ class BuildxBuilder {
     } catch (e) {
       // fall back to docker CLI
       const result = await containerHelpers.dockerCli({
-        cwd: this.certDir,
+        cwd: this.ctx.projectRoot,
         args: ["buildx", "rm", this.name],
         ctx: this.ctx,
         log: this.ctx.log,
@@ -446,6 +446,7 @@ class BuildxBuilder {
       // An error is thrown e.g. if the path does not exist.
       // We don't need to handle this error, as we will fall back to the CLI installation.
       if (isErrnoException(e) && e.code === "ENOENT") {
+        this.ctx.log.debug(`Error checking buildx instance path ${this.buildxInstanceJsonPath}: ${e.message}`)
         return false
       }
       throw e

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -8,7 +8,7 @@
 import type { PluginContext } from "../../plugin-context.js"
 import type { Resolved } from "../../actions/types.js"
 import type { ContainerBuildAction } from "./config.js"
-import { ConfigurationError, InternalError } from "../../exceptions.js"
+import { ConfigurationError, InternalError, isErrnoException } from "../../exceptions.js"
 import type { ContainerProvider, ContainerProviderConfig } from "./container.js"
 import dedent from "dedent"
 import { styles } from "../../logger/styles.js"
@@ -335,8 +335,8 @@ class BuildxBuilder {
 
       try {
         if (refCount === 1) {
-          await this.remove_tmpdir()
           await this.remove_builder()
+          await this.remove_tmpdir()
         }
       } finally {
         // even decrease refcount if removal failed
@@ -355,7 +355,7 @@ class BuildxBuilder {
 
       await this.writeCertificates()
 
-      const success = this.installDirectly()
+      const success = await this.installDirectly()
       if (!success) {
         await this.installUsingCLI()
       }
@@ -435,12 +435,21 @@ class BuildxBuilder {
   }
 
   private async installDirectly() {
-    const statResult = await stat(dirname(this.buildxInstanceJsonPath))
-    if (statResult.isDirectory()) {
-      await writeFile(this.buildxInstanceJsonPath, JSON.stringify(this.getBuildxInstanceJson()))
-      return true
+    try {
+      const statResult = await stat(dirname(this.buildxInstanceJsonPath))
+      if (statResult.isDirectory()) {
+        await writeFile(this.buildxInstanceJsonPath, JSON.stringify(this.getBuildxInstanceJson()))
+        return true
+      }
+      return false
+    } catch (e) {
+      // An error is thrown e.g. if the path does not exist.
+      // We don't need to handle this error, as we will fall back to the CLI installation.
+      if (isErrnoException(e) && e.code === "ENOENT") {
+        return false
+      }
+      throw e
     }
-    return false
   }
 
   private getBuildxInstanceJson() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
We try to install a buildx builder directly by writing to the local .docker directory and if that fails we use docker cli to install the builder. In some environments e.g. CI the local .docker directory may not be available or not configured with the correct subpath of `~/.docker/buildx/instances`. We were missing some error handling and await when checking for these paths, which led garden to fail in case the path does not exist.
Also adds an error message for a common error which is missing or wrong credentials for the registry.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
