### PR TITLE
feat(kubernetes): plugin command to remove `garden-util` resources

### DIFF
--- a/core/src/plugins/kubernetes/commands/cleanup-garden-util.ts
+++ b/core/src/plugins/kubernetes/commands/cleanup-garden-util.ts
@@ -24,11 +24,10 @@ export const cleanupUtilDeployment: PluginCommand = {
     const k8sCtx = ctx as KubernetesPluginContext
     const provider = k8sCtx.provider
 
-    log.info({ msg: styles.highlight(`\nRemoving ${utilDeploymentName} deployment`) })
-
     const namespace = provider.outputs["app-namespace"]
-    const targetKinds = ["Service", "Deployment"]
+    log.info({ msg: styles.highlight(`\nRemoving ${utilDeploymentName} deployment from namespace ${namespace}`) })
 
+    const targetKinds = ["Service", "Deployment"]
     const resources: KubernetesResource[] = targetKinds.map((kind) => {
       return { apiVersion: "v1", kind, metadata: { name: utilDeploymentName } }
     })

--- a/core/src/plugins/kubernetes/commands/cleanup-garden-util.ts
+++ b/core/src/plugins/kubernetes/commands/cleanup-garden-util.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { KubernetesPluginContext } from "../config.js"
+import type { PluginCommand } from "../../../plugin/command.js"
+import { utilDeploymentName } from "../container/build/common.js"
+import { styles } from "../../../logger/styles.js"
+import { deleteResources } from "../kubectl.js"
+import type { KubernetesResource } from "../types.js"
+
+export const cleanupUtilDeployment: PluginCommand = {
+  name: "cleanup-util-deployment",
+  description: `Remove ${utilDeploymentName} utility deployment from the current namespace`,
+  title: `Cleanup ${utilDeploymentName} deployment`,
+  resolveGraph: true,
+
+  handler: async ({ ctx, log }) => {
+    const result = {}
+    const k8sCtx = ctx as KubernetesPluginContext
+    const provider = k8sCtx.provider
+
+    log.info({ msg: styles.highlight(`\nRemoving ${utilDeploymentName} deployment`) })
+
+    const namespace = provider.outputs["app-namespace"]
+    const targetKinds = ["Service", "Deployment"]
+
+    const resources: KubernetesResource[] = targetKinds.map((kind) => {
+      return { apiVersion: "v1", kind, metadata: { name: utilDeploymentName } }
+    })
+
+    for (const resource of resources) {
+      log.info(`Deleting ${resource.kind}/${resource.metadata.name}`)
+      await deleteResources({ ctx, log, provider, namespace, resources })
+    }
+
+    log.success("\nDone!")
+
+    return { result }
+  },
+}

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -36,7 +36,6 @@ import { LogLevel } from "../../../../logger/logger.js"
 import type { ActionRuntime } from "../../../../plugin/base.js"
 
 export const inClusterBuilderServiceAccount = "garden-in-cluster-builder"
-export const sharedBuildSyncDeploymentName = "garden-build-sync"
 export const utilContainerName = "util"
 export const utilRsyncPort = 8730
 export const utilDeploymentName = "garden-util"

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -454,7 +454,7 @@ export async function ensureUtilDeployment({
       namespace,
       ctx,
       provider,
-      actionName: "garden-util",
+      actionName: utilDeploymentName,
       resources: [deployment, service],
       log: buildUtilLog,
       timeoutSec: 600,

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -47,6 +47,7 @@ import { helmPodRunDefinition, helmPodTestDefinition } from "./helm/helm-pod.js"
 import { kubernetesPodRunDefinition, kubernetesPodTestDefinition } from "./kubernetes-type/kubernetes-pod.js"
 import { kubernetesExecRunDefinition, kubernetesExecTestDefinition } from "./kubernetes-type/kubernetes-exec.js"
 import { makeDocsLinkPlain, makeDocsLinkStyled } from "../../docs/common.js"
+import { cleanupUtilDeployment } from "./commands/cleanup-garden-util.js"
 
 export const CONTAINER_BUILD_CONCURRENCY_LIMIT_REMOTE_KUBERNETES = 5
 export const CONTAINER_STATUS_CONCURRENCY_LIMIT_REMOTE_KUBERNETES = 20
@@ -154,6 +155,7 @@ export const gardenPlugin = () => {
     outputsSchema,
     commands: [
       cleanupClusterRegistry,
+      cleanupUtilDeployment,
       clusterInit,
       uninstallGardenServices,
       pullImage,


### PR DESCRIPTION
**What this PR does / why we need it**:

A kubernetes plugin command to manually remove the unnecessary `garden-util` resources from the cluster.

**Which issue(s) this PR fixes**:

Fixes #5909

**Special notes for your reviewer**:
