### PR TITLE
fix: resolve `disabled` action flag before duplicate action names validation

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -261,9 +261,16 @@ export class Garden {
   public log: Log
   private gardenInitLog?: Log
   private loadedPlugins?: GardenPluginSpec[]
+
+  /**
+   * These 3 fields store the raw action configs,
+   * i.e. unresolved action-, module-, and workflow configs detected by {@link #scanAndAddConfigs}
+   * loaded from the disk.
+   */
   protected readonly actionConfigs: ActionConfigMap
   protected readonly moduleConfigs: ModuleConfigMap
   protected readonly workflowConfigs: WorkflowConfigMap
+
   protected configPaths: Set<string>
   private resolvedProviders: { [key: string]: Provider }
   protected readonly state: GardenInstanceState

--- a/core/test/data/test-projects/disabled-action-with-duplicate-name/project.garden.yml
+++ b/core/test/data/test-projects/disabled-action-with-duplicate-name/project.garden.yml
@@ -1,0 +1,10 @@
+apiVersion: garden.io/v1
+kind: Project
+name: disabled-action-with-duplicate-name
+defaultEnvironment: local
+environments:
+  - name: local
+  - name: remote
+providers:
+  - name: exec
+    environments: [ local, remote ]

--- a/core/test/data/test-projects/disabled-action-with-duplicate-name/runs.garden.yml
+++ b/core/test/data/test-projects/disabled-action-with-duplicate-name/runs.garden.yml
@@ -1,0 +1,15 @@
+kind: Run
+name: run-script
+type: exec
+disabled: "${environment.name != 'local'}"
+spec:
+  command: ["sh", "-c", "echo 'Hello from local'"]
+
+---
+
+kind: Run
+name: run-script
+type: exec
+disabled: "${environment.name != 'remote'}"
+spec:
+  command: ["sh", "-c", "echo 'Hello from remote'"]

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3041,6 +3041,17 @@ describe("Garden", () => {
       expect(omit(test.internal, "yamlDoc")).to.eql(internal)
     })
 
+    it("should resolve disabled flag in actions and allow two actions with same key if one is disabled", async () => {
+      const garden = await makeTestGarden(getDataDir("test-projects", "disabled-action-with-duplicate-name"))
+      const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+
+      // There are 2 'run-script' actions defined in the project, one per environment.
+      // This test uses 'local' environment, so the action for 'remote' environment should be disabled and skipped.
+      const runScript = graph.getRun("run-script")
+      expect(runScript.isDisabled()).to.be.false
+      expect(runScript.getConfig().spec.command).to.eql(["sh", "-c", "echo 'Hello from local'"])
+    })
+
     it("should resolve actions from templated config templates", async () => {
       const garden = await makeTestGarden(getDataDir("test-projects", "config-templates-with-templating"))
       await garden.scanAndAddConfigs()

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3069,6 +3069,7 @@ describe("Garden", () => {
         kind: "Run",
         type: "exec",
         name: runNameA,
+        disabled: false,
         spec: {
           command: ["echo", runNameA],
         },
@@ -3081,6 +3082,7 @@ describe("Garden", () => {
         kind: "Run",
         type: "exec",
         name: runNameB,
+        disabled: false,
         spec: {
           command: ["echo", runNameB],
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR patches the feature implemented in #4805 and #5686.

**Which issue(s) this PR fixes**:

Without this fix, the disabled flag on actions is not resolved properly if it's defined as a template string.

**Special notes for your reviewer**:
