### PR TITLE
fix(template): use stricter context for `disabled` flag resolution

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -122,6 +122,7 @@ import {
   DefaultEnvironmentContext,
   ProjectConfigContext,
   RemoteSourceConfigContext,
+  TemplatableConfigContext,
 } from "./config/template-contexts/project.js"
 import type { CloudApi, CloudProject } from "./cloud/api.js"
 import { getGardenCloudDomain } from "./cloud/api.js"
@@ -172,7 +173,6 @@ import { styles } from "./logger/styles.js"
 import { renderDuration } from "./logger/util.js"
 import { getCloudDistributionName, getCloudLogSectionName } from "./util/cloud.js"
 import { makeDocsLinkStyled } from "./docs/common.js"
-import { ActionConfigContext } from "./config/template-contexts/actions.js"
 
 const defaultLocalAddress = "localhost"
 
@@ -1521,16 +1521,7 @@ export class Garden {
       return disabledFlag
     }
 
-    const context = new ActionConfigContext({
-      garden: this,
-      config,
-      thisContextParams: {
-        name: config.name,
-        // TODO: resolve this if necessary
-        mode: "default",
-      },
-      variables: this.variables,
-    })
+    const context = new TemplatableConfigContext(this, config)
 
     return resolveTemplateString({
       string: disabledFlag,


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not allow `this.*` context for `disabled` field, just to avoid unnecessary complexity in passing action mode to the `scanAndAddConfigs()`.

Now an error is thrown if  `disabled:` flag has a reference to `${this.mode}`.

**Which issue(s) this PR fixes**:

Fixes the incorrectly defined action mode introduced in #6293.

**Special notes for your reviewer**:

We can support `${this.*}` context as a separate feature PR if necessary.