### PR TITLE
fix(exec): remove duplicate logging

### DIFF
--- a/core/src/plugins/exec/common.ts
+++ b/core/src/plugins/exec/common.ts
@@ -55,11 +55,9 @@ export async function execRunCommand({
 
   const outputStream = split2()
   outputStream.on("error", (line: Buffer) => {
-    log.error(line.toString())
     ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
   })
   outputStream.on("data", (line: Buffer) => {
-    log.verbose(line.toString())
     ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

No need to do explicit logging because we already emit the log events.

**Which issue(s) this PR fixes**:

Fixes #6292

**Special notes for your reviewer**:
