### PR TITLE
fix: retain original process env when call `spawn` helper

### DIFF
--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -33,7 +33,7 @@ import type { Resolved } from "../../actions/types.js"
 import pMemoize from "../../lib/p-memoize.js"
 import { styles } from "../../logger/styles.js"
 import type { ContainerProviderConfig } from "./container.js"
-import { type MaybeSecret } from "../../util/secrets.js"
+import type { MaybeSecret } from "../../util/secrets.js"
 
 const { readFile, pathExists, lstat } = fsExtra
 
@@ -393,7 +393,7 @@ const helpers = {
     stdout?: Writable
     stderr?: Writable
     timeout?: number
-    env?: { [key: string]: MaybeSecret }
+    env?: Record<string, MaybeSecret>
   }) {
     const docker = ctx.tools["container.docker"]
 

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -393,7 +393,7 @@ const helpers = {
     stdout?: Writable
     stderr?: Writable
     timeout?: number
-    env?: Record<string, MaybeSecret>
+    env?: Record<string, MaybeSecret | undefined>
   }) {
     const docker = ctx.tools["container.docker"]
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -7,17 +7,15 @@
  */
 
 import fsExtra from "fs-extra"
-const { pathExists, createWriteStream, ensureDir, chmod, remove, move, createReadStream } = fsExtra
 import { InternalError } from "../exceptions.js"
-import { join, dirname, basename, posix } from "path"
+import { basename, dirname, join, posix } from "path"
 import { getArchitecture, getPlatform, isDarwinARM } from "./arch-platform.js"
-import { hashString, exec, prepareClearTextEnv } from "./util.js"
+import { exec, hashString, prepareClearTextEnv, spawn } from "./util.js"
 import tar from "tar"
 import { GARDEN_GLOBAL_PATH } from "../constants.js"
 import type { Log } from "../logger/log-entry.js"
 import { createHash } from "node:crypto"
 import crossSpawn from "cross-spawn"
-import { spawn } from "./util.js"
 import type { Writable } from "stream"
 import got from "got"
 import type { PluginToolSpec, ToolBuildSpec } from "../plugin/tools.js"
@@ -28,7 +26,9 @@ import { LogLevel } from "../logger/logger.js"
 import { uuidv4 } from "./random.js"
 import { streamLogs, waitForProcess } from "./process.js"
 import { pipeline } from "node:stream/promises"
-import { type MaybeSecret } from "./secrets.js"
+import type { MaybeSecret } from "./secrets.js"
+
+const { pathExists, createWriteStream, ensureDir, chmod, remove, move, createReadStream } = fsExtra
 
 const toolsPath = join(GARDEN_GLOBAL_PATH, "tools")
 const lock = new AsyncLock()
@@ -36,7 +36,7 @@ const lock = new AsyncLock()
 export interface ExecParams {
   args?: string[]
   cwd?: string
-  env?: { [key: string]: MaybeSecret }
+  env?: Record<string, MaybeSecret>
   log: Log
   timeoutSec?: number
   input?: Buffer | string

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -36,7 +36,7 @@ const lock = new AsyncLock()
 export interface ExecParams {
   args?: string[]
   cwd?: string
-  env?: Record<string, MaybeSecret>
+  env?: Record<string, MaybeSecret | undefined>
   log: Log
   timeoutSec?: number
   input?: Buffer | string

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -177,7 +177,8 @@ export function prepareClearTextEnv(env: Record<string, MaybeSecret | undefined>
       : {}
 
   return toClearText({
-    ...(env || process.env),
+    ...process.env,
+    ...(env || {}),
     ...envOverride,
   })
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to #6294 we have never used the `env` parameter of the function `containerHelpers.dockerCli(...)`.

This PR ensures that the original process environment is always preserved and pass to the Docker process.
Without this fix, any custom `env` would replace the original process environment variables.
Instead of composing the merged env vars on the caller side, it's now done inside the helper function.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
