### PR TITLE
fix(sync): ensure the sync daemon env is configured correctly

### DIFF
--- a/core/src/plugins/kubernetes/commands/sync.ts
+++ b/core/src/plugins/kubernetes/commands/sync.ts
@@ -87,7 +87,7 @@ export const syncPause: PluginCommand = {
         await mutagen.exec({
           cwd: dataDir,
           log,
-          env: getMutagenEnv({ dataDir }),
+          env: await getMutagenEnv({ dataDir }, log),
           args: ["sync", "pause", sessionName],
         })
       }
@@ -133,7 +133,7 @@ export const syncResume: PluginCommand = {
         await mutagen.exec({
           cwd: dataDir,
           log,
-          env: getMutagenEnv({ dataDir }),
+          env: await getMutagenEnv({ dataDir }, log),
           args: ["sync", "resume", sessionName],
         })
       }
@@ -148,7 +148,7 @@ async function getMutagenSyncSessions({ mutagen, dataDir, log }: { mutagen: Plug
   const res = await mutagen.exec({
     cwd: dataDir,
     log,
-    env: getMutagenEnv({ dataDir }),
+    env: await getMutagenEnv({ dataDir }, log),
     args: ["sync", "list", "--template={{ json . }}"],
   })
   return parseSyncListResult(res)

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -46,6 +46,8 @@ export const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
 export const k8sSyncUtilImageName: DockerImageWithDigest =
   "gardendev/k8s-sync:0.2.1@sha256:90a583672c63e61031a036900753cb6a8a6b0b7dc20909e2abcc079a1120127b"
 
+export const k8sSyncUtilContainerName = "garden-dev-init"
+
 export function getK8sSyncUtilImageName(): DockerImageWithDigest {
   return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sSyncUtilImageName : k8sSyncUtilImageNameLegacy
 }

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -13,8 +13,6 @@ import { makeDocsLinkPlain } from "../../docs/common.js"
 export const rsyncPortName = "garden-rsync"
 export const buildSyncVolumeName = `garden-sync`
 
-export const CLUSTER_REGISTRY_PORT = 5000
-export const CLUSTER_REGISTRY_DEPLOYMENT_NAME = "garden-docker-registry"
 export const MAX_CONFIGMAP_DATA_SIZE = 1024 * 1024 // max ConfigMap data size is 1MB
 // max ConfigMap data size is 1MB but we need to factor in overhead, plus in some cases the log is duplicated in
 // the outputs field, so we cap at 250kB.

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -46,7 +46,7 @@ export const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
 export const k8sSyncUtilImageName: DockerImageWithDigest =
   "gardendev/k8s-sync:0.2.1@sha256:90a583672c63e61031a036900753cb6a8a6b0b7dc20909e2abcc079a1120127b"
 
-export const k8sSyncUtilContainerName = "garden-dev-init"
+export const k8sSyncUtilContainerName = "garden-sync-init"
 
 export function getK8sSyncUtilImageName(): DockerImageWithDigest {
   return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sSyncUtilImageName : k8sSyncUtilImageNameLegacy

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -58,7 +58,7 @@ import { isConfiguredForSyncMode } from "./status/status.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { SyncConfig, SyncSession } from "../../mutagen.js"
 import { haltedStatuses, Mutagen, mutagenAgentPath, mutagenStatusDescriptions } from "../../mutagen.js"
-import { getK8sSyncUtilImageName, syncGuideLink } from "./constants.js"
+import { getK8sSyncUtilImageName, k8sSyncUtilContainerName, syncGuideLink } from "./constants.js"
 import { isAbsolute, relative, resolve } from "path"
 import type { Resolved } from "../../actions/types.js"
 import { joinWithPosix } from "../../util/fs.js"
@@ -463,7 +463,7 @@ export async function configureSyncMode({
     const k8sSyncUtilImageName = getK8sSyncUtilImageName()
     if (!podSpec.initContainers.find((c) => c.image === k8sSyncUtilImageName)) {
       const initContainer = {
-        name: "garden-dev-init",
+        name: k8sSyncUtilContainerName,
         image: k8sSyncUtilImageName,
         command: [
           "/bin/sh",

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -38,6 +38,7 @@ import { gardenAnnotationKey } from "../../../../../../src/util/string.js"
 import {
   getK8sSyncUtilImageName,
   k8sReverseProxyImageName,
+  k8sSyncUtilContainerName,
   PROXY_CONTAINER_SSH_TUNNEL_PORT,
   PROXY_CONTAINER_SSH_TUNNEL_PORT_NAME,
   PROXY_CONTAINER_USER_NAME,
@@ -444,13 +445,13 @@ describe("kubernetes container deployment handlers", () => {
 
       const initContainer = resource.spec.template?.spec?.initContainers![0]
       expect(initContainer).to.exist
-      expect(initContainer!.name).to.eq("garden-dev-init")
+      expect(initContainer!.name).to.eq(k8sSyncUtilContainerName)
       expect(initContainer!.volumeMounts).to.exist
       expect(initContainer!.volumeMounts![0]).to.eql({ name: "garden", mountPath: "/.garden" })
 
       expect(resource.spec.template?.spec?.initContainers).to.eql([
         {
-          name: "garden-dev-init",
+          name: k8sSyncUtilContainerName,
           image: getK8sSyncUtilImageName(),
           command: ["/bin/sh", "-c", "'cp' '/usr/local/bin/mutagen-agent' '/.garden/mutagen-agent'"],
           imagePullPolicy: "IfNotPresent",


### PR DESCRIPTION
**What this PR does / why we need it**:

Make sure that `MUTAGEN_SSH_PATH` pointing to the faux ssh is always set when a native Mutagen daemon is used.

**Which issue(s) this PR fixes**:

See the [Discord thread](https://discord.com/channels/817392104711651328/1239306293307637932/1239306293307637932).

**Special notes for your reviewer**:

This doesn't completely solve the original issue mentioned in the Discord. But, it ensures that the right version of the ssh binary (i.e. our own faux ssh binary) is used.
