### PR TITLE
chore(deps-dev): bump @garden-io/platform-api-types from 1.914.0 to 1.1131.0

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -166,7 +166,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
-    "@garden-io/platform-api-types": "1.914.0",
+    "@garden-io/platform-api-types": "1.1131.0",
     "@google-cloud/artifact-registry": "^3.0.1",
     "@types/archiver": "^6.0.2",
     "@types/async": "^3.2.24",

--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -395,7 +395,7 @@ export class AnalyticsHandler {
     }
 
     if (cloudProject) {
-      this.cloudCustomerName = cloudProject.organizationId
+      this.cloudCustomerName = cloudProject.organization.name
     }
 
     this.isRecurringUser = getIsRecurringUser(analyticsConfig.firstRunAt, analyticsConfig.latestRunAt)
@@ -406,7 +406,7 @@ export class AnalyticsHandler {
       anonymousId: anonymousUserId,
       traits: {
         userIdV2,
-        customer: cloudProject?.organizationId,
+        customer: cloudProject?.organization.name,
         platform: platform(),
         platformVersion: release(),
         gardenVersion: getPackageVersion(),

--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -251,7 +251,7 @@ const SEGMENT_HOST = "https://api.segment.io"
  * prompt for opt-in/opt-out and wrappers for single events.
  *
  * Initalization:
- * const analyticsClient = await AnalyticsHandler.init(garden: Garden, log: LogEntry)
+ * const analyticsClient = await AnalyticsHandler.init(garden: Garden)
  * analyticsClient.trackCommand(commandName)
  *
  * Subsequent usage:
@@ -418,7 +418,7 @@ export class AnalyticsHandler {
     })
   }
 
-  static async init(garden: Garden, log: Log) {
+  static async init(garden: Garden) {
     // Ensure that we re-initialize the analytics metadata when switching projects
     if (!AnalyticsHandler.instance || AnalyticsHandler.instance.garden?.projectName !== garden.projectName) {
       // We're passing this explicitly to that it's easier to overwrite and test
@@ -428,7 +428,7 @@ export class AnalyticsHandler {
         ciName: ci.name,
       }
 
-      AnalyticsHandler.instance = await AnalyticsHandler.factory({ garden, log, ciInfo })
+      AnalyticsHandler.instance = await AnalyticsHandler.factory({ garden, log: garden.log, ciInfo })
     } else {
       /**
        * This init is called from within the do while loop in the cli

--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -428,7 +428,7 @@ export class AnalyticsHandler {
         ciName: ci.name,
       }
 
-      AnalyticsHandler.instance = await AnalyticsHandler.factory({ garden, log: garden.log, ciInfo })
+      AnalyticsHandler.instance = await AnalyticsHandler.factory({ garden, ciInfo })
     } else {
       /**
        * This init is called from within the do while loop in the cli
@@ -458,11 +458,12 @@ export class AnalyticsHandler {
    *
    * It also initializes the analytics config and updates the analytics data we store in local config.
    */
-  static async factory({ garden, log, ciInfo, host }: { garden: Garden; log: Log; ciInfo: CiInfo; host?: string }) {
+  static async factory({ garden, ciInfo, host }: { garden: Garden; ciInfo: CiInfo; host?: string }) {
     const currentAnalyticsConfig = await garden.globalConfigStore.get("analytics")
     const isFirstRun = !currentAnalyticsConfig.firstRunAt
     const moduleConfigs = await garden.getRawModuleConfigs()
     const actionConfigs = await garden.getRawActionConfigs()
+    const log = garden.log
 
     let cloudUser: UserResult | undefined
     let cloudProject: CloudProject | undefined

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -150,11 +150,16 @@ export interface CloudEnvironment {
   name: string
 }
 
+export interface CloudOrganization {
+  id: string
+  name: string
+}
+
 // Represents a cloud project
 export interface CloudProject {
   id: string
   name: string
-  organizationId: string
+  organization: CloudOrganization
   repositoryUrl: string
   environments: CloudEnvironment[]
 }
@@ -175,7 +180,7 @@ function toCloudProject(project: GetProjectResponse["data"] | CreateProjectsForR
   return {
     id: project.id,
     name: project.name,
-    organizationId: project.organization.id,
+    organization: { id: project.organization.id, name: project.organization.name },
     repositoryUrl: project.repositoryUrl,
     environments,
   }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -598,7 +598,7 @@ export class Garden {
 
   @pMemoizeDecorator()
   async getAnalyticsHandler() {
-    return AnalyticsHandler.init(this, this.log)
+    return AnalyticsHandler.init(this)
   }
 
   // TODO: would be nice if this returned a type based on the input tasks

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -106,7 +106,7 @@ export const cloudBuilder = {
     const { publicKeyPem } = await getMtlsKeyPair()
 
     const res = await ctx.cloudApi.registerCloudBuilderBuild({
-      organizationId: (await ctx.cloudApi.getProjectById(ctx.projectId)).organizationId,
+      organizationId: (await ctx.cloudApi.getProjectById(ctx.projectId)).organization.id,
       actionUid: action.uid,
       actionName: action.name,
       actionVersion: action.getFullVersion().toString(),

--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -181,6 +181,7 @@ export type TestGardenOpts = Partial<GardenOpts> & {
 export class TestGarden extends Garden {
   override events: TestEventBus
   // Overriding the type declarations of a few instance variables to allow reassignment in test code.
+  public declare projectId?: string
   public declare actionConfigs: ActionConfigMap
   public declare moduleConfigs: ModuleConfigMap
   public declare workflowConfigs: WorkflowConfigMap

--- a/core/test/helpers/api.ts
+++ b/core/test/helpers/api.ts
@@ -14,6 +14,7 @@ import { uuidv4 } from "../../src/util/random.js"
 import type { StringMap } from "../../src/config/common.js"
 import type { GetProfileResponse } from "@garden-io/platform-api-types"
 
+export const fakeOrganizationId = uuidv4()
 export const apiProjectId = uuidv4()
 export const apiRemoteOriginUrl = "git@github.com:garden-io/garden.git"
 // The sha512 hash of "test-project-a"
@@ -56,7 +57,7 @@ export class FakeCloudApi extends CloudApi {
       id: apiProjectId,
       name,
       repositoryUrl: apiRemoteOriginUrl,
-      organizationId: uuidv4(),
+      organizationId: fakeOrganizationId,
       environments: [],
     }
   }
@@ -66,7 +67,7 @@ export class FakeCloudApi extends CloudApi {
       id: apiProjectId,
       name,
       repositoryUrl: apiRemoteOriginUrl,
-      organizationId: uuidv4(),
+      organizationId: fakeOrganizationId,
       environments: [],
     }
   }
@@ -76,7 +77,7 @@ export class FakeCloudApi extends CloudApi {
       id: apiProjectId,
       name: apiProjectName,
       repositoryUrl: apiRemoteOriginUrl,
-      organizationId: uuidv4(),
+      organizationId: fakeOrganizationId,
       environments: [],
     }
   }

--- a/core/test/helpers/api.ts
+++ b/core/test/helpers/api.ts
@@ -12,6 +12,7 @@ import type { Log } from "../../src/logger/log-entry.js"
 import { GlobalConfigStore } from "../../src/config-store/global.js"
 import { uuidv4 } from "../../src/util/random.js"
 import type { StringMap } from "../../src/config/common.js"
+import type { GetProfileResponse } from "@garden-io/platform-api-types"
 
 export const apiProjectId = uuidv4()
 export const apiRemoteOriginUrl = "git@github.com:garden-io/garden.git"
@@ -28,7 +29,7 @@ export class FakeCloudApi extends CloudApi {
     })
   }
 
-  override async getProfile() {
+  override async getProfile(): Promise<GetProfileResponse["data"]> {
     return {
       id: "1",
       createdAt: new Date().toString(),
@@ -45,6 +46,8 @@ export class FakeCloudApi extends CloudApi {
       groups: [],
       meta: {},
       singleProjectId: "",
+      singleProjectOrgId: "",
+      organizations: [],
     }
   }
 

--- a/core/test/helpers/api.ts
+++ b/core/test/helpers/api.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { CloudProject, GetSecretsParams } from "../../src/cloud/api.js"
+import type { CloudOrganization, CloudProject, GetSecretsParams } from "../../src/cloud/api.js"
 import { CloudApi } from "../../src/cloud/api.js"
 import type { Log } from "../../src/logger/log-entry.js"
 import { GlobalConfigStore } from "../../src/config-store/global.js"
@@ -14,7 +14,8 @@ import { uuidv4 } from "../../src/util/random.js"
 import type { StringMap } from "../../src/config/common.js"
 import type { GetProfileResponse } from "@garden-io/platform-api-types"
 
-export const fakeOrganizationId = uuidv4()
+export const dummyOrganization: CloudOrganization = { id: uuidv4(), name: "test-org" } as const
+
 export const apiProjectId = uuidv4()
 export const apiRemoteOriginUrl = "git@github.com:garden-io/garden.git"
 // The sha512 hash of "test-project-a"
@@ -57,7 +58,7 @@ export class FakeCloudApi extends CloudApi {
       id: apiProjectId,
       name,
       repositoryUrl: apiRemoteOriginUrl,
-      organizationId: fakeOrganizationId,
+      organization: dummyOrganization,
       environments: [],
     }
   }
@@ -67,7 +68,7 @@ export class FakeCloudApi extends CloudApi {
       id: apiProjectId,
       name,
       repositoryUrl: apiRemoteOriginUrl,
-      organizationId: fakeOrganizationId,
+      organization: dummyOrganization,
       environments: [],
     }
   }
@@ -77,7 +78,7 @@ export class FakeCloudApi extends CloudApi {
       id: apiProjectId,
       name: apiProjectName,
       repositoryUrl: apiRemoteOriginUrl,
-      organizationId: fakeOrganizationId,
+      organization: dummyOrganization,
       environments: [],
     }
   }

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -11,7 +11,13 @@ import { validate as validateUuid } from "uuid"
 
 import type { TestGarden } from "../../../helpers.js"
 import { makeTestGardenA, enableAnalytics, getDataDir, makeTestGarden, freezeTime } from "../../../helpers.js"
-import { FakeCloudApi, apiProjectName, apiRemoteOriginUrl } from "../../../helpers/api.js"
+import {
+  FakeCloudApi,
+  apiProjectName,
+  apiRemoteOriginUrl,
+  apiProjectId,
+  fakeOrganizationId,
+} from "../../../helpers/api.js"
 import type { CommandResultEvent } from "../../../../src/analytics/analytics.js"
 import { AnalyticsHandler, getAnonymousUserId } from "../../../../src/analytics/analytics.js"
 import {
@@ -296,6 +302,9 @@ describe("AnalyticsHandler", () => {
       const mockedEndpoint = await mockServer.forPost("/v1/batch").thenReply(200)
       const now = freezeTime()
       await garden.globalConfigStore.set("analytics", basicConfig)
+      // set fake project id
+      garden.projectId = apiProjectId
+
       analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       await analytics.closeAndFlush()
@@ -310,7 +319,7 @@ describe("AnalyticsHandler", () => {
           anonymousId: "6d87dd61-0feb-4373-8c78-41cd010907e7",
           traits: {
             userIdV2: AnalyticsHandler.hashV2("6d87dd61-0feb-4373-8c78-41cd010907e7"),
-            customer: "garden",
+            customer: fakeOrganizationId,
             platform: body.batch[0].traits.platform,
             platformVersion: body.batch[0].traits.platformVersion,
             gardenVersion: body.batch[0].traits.gardenVersion,

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -90,7 +90,7 @@ describe("AnalyticsHandler", () => {
       expect(currentConfig).to.eql({})
 
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const newConfig = await garden.globalConfigStore.get("analytics")
       expect(newConfig.anonymousUserId).to.be.a("string")
@@ -103,7 +103,7 @@ describe("AnalyticsHandler", () => {
     })
     it("should create a valid anonymous user ID on first run", async () => {
       await garden.globalConfigStore.set("analytics", {})
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const config = await garden.globalConfigStore.get("analytics")
 
@@ -111,7 +111,7 @@ describe("AnalyticsHandler", () => {
     })
     it("should set user ID to ci-user if in CI", async () => {
       await garden.globalConfigStore.set("analytics", {})
-      analytics = await AnalyticsHandler.factory({ garden, log: garden.log, ciInfo: { isCi: true, ciName: "foo" } })
+      analytics = await AnalyticsHandler.factory({ garden, ciInfo: { isCi: true, ciName: "foo" } })
 
       const config = await garden.globalConfigStore.get("analytics")
 
@@ -119,7 +119,7 @@ describe("AnalyticsHandler", () => {
     })
     it("should not override anonymous user ID on subsequent runs", async () => {
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const config = await garden.globalConfigStore.get("analytics")
       expect(config.anonymousUserId).to.eql(basicConfig.anonymousUserId)
@@ -127,7 +127,7 @@ describe("AnalyticsHandler", () => {
     it("should update the analytics config if it already exists", async () => {
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const config = await garden.globalConfigStore.get("analytics")
       expect(config).to.eql({
@@ -140,7 +140,7 @@ describe("AnalyticsHandler", () => {
     })
     it("should print an info message if first Garden run", async () => {
       await garden.globalConfigStore.set("analytics", {})
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       const msgs = garden.log.root.getLogEntries().map((l) => resolveMsg(l))
       const infoMsg = msgs.find((msg) => msg?.includes("Thanks for installing Garden!"))
 
@@ -149,7 +149,7 @@ describe("AnalyticsHandler", () => {
     it("should NOT print an info message on subsequent runs", async () => {
       // The existens of base config suggests it's not the first run
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       const msgs = garden.log.root.getLogEntries().map((l) => resolveMsg(l))
       const infoMsg = msgs.find((msg) => msg?.includes("Thanks for installing Garden!"))
 
@@ -160,7 +160,7 @@ describe("AnalyticsHandler", () => {
 
       const now = freezeTime()
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       await analytics.closeAndFlush()
 
@@ -207,7 +207,7 @@ describe("AnalyticsHandler", () => {
         ...basicConfig,
         optedOut: true,
       })
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       await analytics.closeAndFlush()
 
       expect(analytics.isEnabled).to.equal(false)
@@ -217,7 +217,7 @@ describe("AnalyticsHandler", () => {
     })
     it("should be enabled by default", async () => {
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       expect(analytics.isEnabled).to.be.true
     })
@@ -225,7 +225,7 @@ describe("AnalyticsHandler", () => {
       const originalEnvVar = gardenEnv.GARDEN_DISABLE_ANALYTICS
       gardenEnv.GARDEN_DISABLE_ANALYTICS = true
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       gardenEnv.GARDEN_DISABLE_ANALYTICS = originalEnvVar
 
@@ -236,7 +236,7 @@ describe("AnalyticsHandler", () => {
         ...basicConfig,
         optedOut: true,
       })
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       expect(analytics.isEnabled).to.be.false
     })
@@ -264,7 +264,7 @@ describe("AnalyticsHandler", () => {
       await garden.globalConfigStore.set("analytics", basicConfig)
 
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const newConfig = await garden.globalConfigStore.get("analytics")
       expect(newConfig).to.eql({
@@ -277,14 +277,14 @@ describe("AnalyticsHandler", () => {
     })
     it("should be enabled unless env var for disabling is set", async () => {
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       const isEnabledWhenNoEnvVar = analytics.isEnabled
 
       const originalEnvVar = gardenEnv.GARDEN_DISABLE_ANALYTICS
       gardenEnv.GARDEN_DISABLE_ANALYTICS = true
       // Create a fresh instance after setting env var
       AnalyticsHandler.clearInstance()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       const isEnabledWhenEnvVar = analytics.isEnabled
 
       gardenEnv.GARDEN_DISABLE_ANALYTICS = originalEnvVar
@@ -296,7 +296,7 @@ describe("AnalyticsHandler", () => {
       const mockedEndpoint = await mockServer.forPost("/v1/batch").thenReply(200)
       const now = freezeTime()
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       await analytics.closeAndFlush()
 
@@ -335,7 +335,7 @@ describe("AnalyticsHandler", () => {
       const originalEnvVar = gardenEnv.GARDEN_DISABLE_ANALYTICS
       gardenEnv.GARDEN_DISABLE_ANALYTICS = true
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       gardenEnv.GARDEN_DISABLE_ANALYTICS = originalEnvVar
       await analytics.closeAndFlush()
 
@@ -363,7 +363,7 @@ describe("AnalyticsHandler", () => {
 
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       const event = analytics.trackCommand("testCommand")
 
       expect(event).to.eql({
@@ -408,7 +408,7 @@ describe("AnalyticsHandler", () => {
 
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ garden, log: garden.log, ciInfo: { isCi: true, ciName: "foo" } })
+      analytics = await AnalyticsHandler.factory({ garden, ciInfo: { isCi: true, ciName: "foo" } })
       const event = analytics.trackCommand("testCommand")
 
       expect(event).to.eql({
@@ -469,7 +469,7 @@ describe("AnalyticsHandler", () => {
 
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const event = analytics.trackCommand("testCommand")
 
@@ -519,7 +519,7 @@ describe("AnalyticsHandler", () => {
 
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const event = analytics.trackCommand("testCommand")
 
@@ -569,7 +569,7 @@ describe("AnalyticsHandler", () => {
 
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const event = analytics.trackCommand("testCommand", "test-parent-session")
 
@@ -619,7 +619,7 @@ describe("AnalyticsHandler", () => {
 
       await garden.globalConfigStore.set("analytics", basicConfig)
       const now = freezeTime()
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       const event = analytics.trackCommand("testCommand")
 
@@ -683,7 +683,7 @@ describe("AnalyticsHandler", () => {
       const startTime = new Date()
       timekeeper.freeze(startTime)
 
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       timekeeper.travel(startTime.getTime() + 60000)
       const event = analytics.trackCommandResult("testCommand", [], startTime, 0)
@@ -738,7 +738,7 @@ describe("AnalyticsHandler", () => {
       const startTime = new Date()
       timekeeper.freeze(startTime)
 
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       timekeeper.travel(startTime.getTime() + 60000)
 
@@ -819,7 +819,7 @@ describe("AnalyticsHandler", () => {
       const startTime = new Date()
       timekeeper.freeze(startTime)
 
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       timekeeper.travel(startTime.getTime() + 60000)
       const errors = [
@@ -897,7 +897,7 @@ describe("AnalyticsHandler", () => {
       })
 
       await garden.globalConfigStore.set("analytics", basicConfig)
-      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, log: garden.log, ciInfo })
+      analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
 
       analytics.trackCommand("test-command-A")
       await analytics.closeAndFlush()

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -153,7 +153,7 @@ describe("AnalyticsHandler", () => {
       expect(infoMsg).to.exist
     })
     it("should NOT print an info message on subsequent runs", async () => {
-      // The existens of base config suggests it's not the first run
+      // The existence of base config suggests it's not the first run
       await garden.globalConfigStore.set("analytics", basicConfig)
       analytics = await AnalyticsHandler.factory({ host: mockServer.url, garden, ciInfo })
       const msgs = garden.log.root.getLogEntries().map((l) => resolveMsg(l))

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -16,7 +16,7 @@ import {
   apiProjectName,
   apiRemoteOriginUrl,
   apiProjectId,
-  fakeOrganizationId,
+  dummyOrganization,
 } from "../../../helpers/api.js"
 import type { CommandResultEvent } from "../../../../src/analytics/analytics.js"
 import { AnalyticsHandler, getAnonymousUserId } from "../../../../src/analytics/analytics.js"
@@ -319,7 +319,7 @@ describe("AnalyticsHandler", () => {
           anonymousId: "6d87dd61-0feb-4373-8c78-41cd010907e7",
           traits: {
             userIdV2: AnalyticsHandler.hashV2("6d87dd61-0feb-4373-8c78-41cd010907e7"),
-            customer: fakeOrganizationId,
+            customer: dummyOrganization.name,
             platform: body.batch[0].traits.platform,
             platformVersion: body.batch[0].traits.platformVersion,
             gardenVersion: body.batch[0].traits.gardenVersion,

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -315,7 +315,7 @@ describe("AnalyticsHandler", () => {
       const body = (await seenRequests[0].body.getJson()) as any
       expect(body.batch).to.eql([
         {
-          userId: "garden_1", // This is the imporant part
+          userId: `${dummyOrganization.name}_1`, // This is the important part
           anonymousId: "6d87dd61-0feb-4373-8c78-41cd010907e7",
           traits: {
             userIdV2: AnalyticsHandler.hashV2("6d87dd61-0feb-4373-8c78-41cd010907e7"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,7 +1219,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
-        "@garden-io/platform-api-types": "1.914.0",
+        "@garden-io/platform-api-types": "1.1131.0",
         "@google-cloud/artifact-registry": "^3.0.1",
         "@types/archiver": "^6.0.2",
         "@types/async": "^3.2.24",
@@ -1333,9 +1333,10 @@
       "integrity": "sha512-YLq+crMPJiBmIdkRmv9nZuZy1mVtMlDcUKlg4mvI0UsC/dZeIaGoGB5p/C4FrpeOhZ7zBTK03T58S0DFkRNMnw=="
     },
     "core/node_modules/@garden-io/platform-api-types": {
-      "version": "1.914.0",
+      "version": "1.1131.0",
+      "resolved": "https://registry.npmjs.org/@garden-io/platform-api-types/-/platform-api-types-1.1131.0.tgz",
+      "integrity": "sha512-ZHRAvBHidYLkAnsobRPEkeaD/YwWvWEotUAyp+hLJ1e8EpiXNUgG+iNfjKroU1Vf8ZXAdAxneK2s7XYYuO9WZg==",
       "dev": true,
-      "license": "UNLICENSED",
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces #6310 that was automatically generated by dependabot.

**Which issue(s) this PR fixes**:

Supersedes #6310

**Special notes for your reviewer**:

Some non-trivial code changes were required to use the new version of `@garden-io/platform-api-types`. Thus, a separate PR was created to avoid code changes committed by dependabot.