### PR TITLE
fix(profiler): handle getters and setters in `@Profile` decorator

### DIFF
--- a/core/src/util/profiling.ts
+++ b/core/src/util/profiling.ts
@@ -220,13 +220,20 @@ export function Profile(profiler?: Profiler) {
     }
 
     for (const propertyName of Object.getOwnPropertyNames(target.prototype)) {
-      const propertyValue = target.prototype[propertyName]
-      const isMethod = propertyValue instanceof Function
-      if (!isMethod) {
-        continue
+      const propertyDescriptor = Object.getOwnPropertyDescriptor(target.prototype, propertyName)
+      if (propertyDescriptor) {
+        const isGetter = propertyDescriptor.get
+        const isSetter = propertyDescriptor.set
+        if (!isGetter && !isSetter) {
+          const propertyValue = target.prototype[propertyName]
+          const isMethod = propertyValue instanceof Function
+          if (!isMethod) {
+            continue
+          }
+        }
       }
 
-      const descriptor = Object.getOwnPropertyDescriptor(target.prototype, propertyName)!
+      const descriptor = propertyDescriptor!
       const originalMethod = descriptor.get || descriptor.value
 
       const timingKey = `${target.name}#${propertyName}`


### PR DESCRIPTION
**What this PR does / why we need it**:

The profiler has been broken since #5955
where we introduced properties with getters and setters in some classes.

The decorator implementation was crashing on getters and setters.

**Which issue(s) this PR fixes**:

Fixes the crash that has been occurring while running `GARDEN_ENABLE_PROFILING=true garden util profile-project`:

```console
file:///~/garden/core/build/src/graph/nodes.js:216
        return this.task.executeConcurrencyLimit;
                         ^

TypeError: Cannot read properties of undefined (reading 'executeConcurrencyLimit')
    at get concurrencyLimit (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/graph/nodes.js:216:26)
    at file:///~/garden/core/build/src/util/profiling.js:169:51
    at __decorate (file:///~/garden/core/build/src/graph/nodes.js:11:95)
    at file:///~/garden/core/build/src/graph/nodes.js:274:19
    at ModuleJob.run (node:internal/modules/esm/module_job:262:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:475:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:109:5)

Node.js v22.2.0
```

**Special notes for your reviewer**:
