### PR TITLE
fix(exec): fix error handling in exec run and test actions

### DIFF
--- a/core/src/plugins/exec/common.ts
+++ b/core/src/plugins/exec/common.ts
@@ -16,7 +16,7 @@ import { exec } from "../../util/util.js"
 import type { Log } from "../../logger/log-entry.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { ResolvedExecAction } from "./config.js"
-import { RuntimeError, toGardenError } from "../../exceptions.js"
+import { RuntimeError } from "../../exceptions.js"
 
 export function getDefaultEnvVars(action: ResolvedExecAction) {
   return {

--- a/core/src/plugins/exec/common.ts
+++ b/core/src/plugins/exec/common.ts
@@ -16,7 +16,7 @@ import { exec } from "../../util/util.js"
 import type { Log } from "../../logger/log-entry.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { ResolvedExecAction } from "./config.js"
-import { RuntimeError } from "../../exceptions.js"
+import { RuntimeError, toGardenError } from "../../exceptions.js"
 
 export function getDefaultEnvVars(action: ResolvedExecAction) {
   return {
@@ -115,6 +115,8 @@ export async function copyArtifacts(
         if (err.name === "CpyError") {
           throw new RuntimeError({ message: err.message })
         }
+
+        throw err
       }
     })
   )

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -62,7 +62,7 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
   }
 
   if (commandResult.outputLog) {
-    const prefix = `Finished running ${styles.highlight(action.name)}. Here is the full output:`
+    const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
     log.info(
       renderMessageWithDivider({
         prefix,

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -42,9 +42,6 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
     version: action.versionString(),
     success: commandResult.success,
     log: commandResult.outputLog,
-    outputs: {
-      log: commandResult.outputLog,
-    },
     startedAt,
     completedAt: commandResult.completedAt,
   }

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -48,6 +48,16 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
     log: execCommandOutputs.outputLog,
   }
 
+  if (!execCommandOutputs.success) {
+    return {
+      state: runResultToActionState(detail),
+      detail,
+      outputs: {
+        log: execCommandOutputs.outputLog,
+      },
+    }
+  }
+
   if (execCommandOutputs.outputLog) {
     const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
     log.info(

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -39,13 +39,13 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
 
   const detail = {
     moduleName: action.moduleName(),
-    command,
     testName: action.name,
+    command,
     version: action.versionString(),
     success: commandResult.success,
+    log: commandResult.outputLog,
     startedAt,
     completedAt: commandResult.completedAt,
-    log: commandResult.outputLog,
   }
 
   const result = {

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -35,26 +35,26 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
   const startedAt = new Date()
   const { command, env } = action.getSpec()
 
-  const result = await execRunCommand({ command, action, ctx, log, env, opts: { reject: false } })
+  const execCommandOutputs = await execRunCommand({ command, action, ctx, log, env, opts: { reject: false } })
 
   const detail = {
     moduleName: action.moduleName(),
     command,
     testName: action.name,
     version: action.versionString(),
-    success: result.success,
+    success: execCommandOutputs.success,
     startedAt,
-    completedAt: result.completedAt,
-    log: result.outputLog,
+    completedAt: execCommandOutputs.completedAt,
+    log: execCommandOutputs.outputLog,
   }
 
-  if (result.outputLog) {
+  if (execCommandOutputs.outputLog) {
     const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
     log.info(
       renderMessageWithDivider({
         prefix,
-        msg: result.outputLog,
-        isError: !result.success,
+        msg: execCommandOutputs.outputLog,
+        isError: !execCommandOutputs.success,
         color: styles.primary,
       })
     )
@@ -67,7 +67,7 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
     state: runResultToActionState(detail),
     detail,
     outputs: {
-      log: result.outputLog,
+      log: execCommandOutputs.outputLog,
     },
   }
 })

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -37,8 +37,16 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
 
   const result = await execRunCommand({ command, action, ctx, log, env, opts: { reject: false } })
 
-  const artifacts = action.getSpec("artifacts")
-  await copyArtifacts(log, artifacts, action.getBuildPath(), artifactsPath)
+  const detail = {
+    moduleName: action.moduleName(),
+    command,
+    testName: action.name,
+    version: action.versionString(),
+    success: result.success,
+    startedAt,
+    completedAt: result.completedAt,
+    log: result.outputLog,
+  }
 
   if (result.outputLog) {
     const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
@@ -52,16 +60,8 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
     )
   }
 
-  const detail = {
-    moduleName: action.moduleName(),
-    command,
-    testName: action.name,
-    version: action.versionString(),
-    success: result.success,
-    startedAt,
-    completedAt: result.completedAt,
-    log: result.outputLog,
-  }
+  const artifacts = action.getSpec("artifacts")
+  await copyArtifacts(log, artifacts, action.getBuildPath(), artifactsPath)
 
   return {
     state: runResultToActionState(detail),

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -48,14 +48,16 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
     log: execCommandOutputs.outputLog,
   }
 
+  const result = {
+    state: runResultToActionState(detail),
+    detail,
+    outputs: {
+      log: execCommandOutputs.outputLog,
+    },
+  } as const
+
   if (!execCommandOutputs.success) {
-    return {
-      state: runResultToActionState(detail),
-      detail,
-      outputs: {
-        log: execCommandOutputs.outputLog,
-      },
-    }
+    return result
   }
 
   if (execCommandOutputs.outputLog) {
@@ -73,11 +75,5 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
   const artifacts = action.getSpec("artifacts")
   await copyArtifacts(log, artifacts, action.getBuildPath(), artifactsPath)
 
-  return {
-    state: runResultToActionState(detail),
-    detail,
-    outputs: {
-      log: execCommandOutputs.outputLog,
-    },
-  }
+  return result
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the command result processing and error handling in `Run` and `Test` actions of `exec` type, and align the error handling behaviour between the commands.:

* an error is returned immediately if the command exited with non-zero code, so Garden does not attempt to copy missing or incomplete artifacts; the error message includes the command output and the exit code.
* the command execution output is always printed in the console if the command was successful; in case of error, it will be printed as a part of the error message, and won't be printed twice.
* the artifacts are copied only if the command execution as successful
* I/O errors while artifacts copying do not crash the Garden process, and are handled as the other runtime errors

**Which issue(s) this PR fixes**:

Fixes #6261

**Special notes for your reviewer**:

The changes have been tested manually. We do not have integration tests for exec provider yet, so let's skip it. We do not change the affected part of the code often.

There is another function [`copyArtifacts` in `util/artifacts.ts`](https://github.com/garden-io/garden/blob/main/core/src/util/artifacts.ts#L63) which is used on the action router-level in:
* [Run action router](https://github.com/garden-io/garden/blob/main/core/src/router/run.ts#L65)
* [Test action router](https://github.com/garden-io/garden/blob/main/core/src/router/test.ts#L65)

Both places seem to be irrelevant to the issue in question. There is a kind of clean-up in the finally block where the produced artifacts are copied form the temp directory before cleaning it up.

I'm not sure if we need to do that at all, but let's leave the code as-is, and change that part in a separate PR if necessary.