### PR TITLE
chore(deps): bump google/cloud-sdk to 486.0.0 in debian.Dockerfile

### DIFF
--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -80,8 +80,8 @@ RUN ./aws/install
 # garden-gcloud-base
 #
 FROM garden-base as garden-gcloud-base
-ENV GCLOUD_VERSION=484.0.0
-ENV GCLOUD_SHA256="5e97a63e5d5877204e404495b8c28b8b23f98b50c6a42be03a9195863dd546d5"
+ENV GCLOUD_VERSION=486.0.0
+ENV GCLOUD_SHA256="da4197eded5b292942d75ec164ffaa811ab79379edbc2371dc68da27787c10a7"
 
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN echo "${GCLOUD_SHA256}  google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" | sha256sum -c


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Ports #6354 to `debian.Dockerfile`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
