### PR TITLE
fix(template): null-safe error message extraction

### DIFF
--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -845,7 +845,7 @@ function buildBinaryExpression(head: any, tail: any) {
     // Disallow undefined values for comparisons
     if (left === undefined || right === undefined) {
       const message = [leftRes, rightRes]
-        .map((res) => res.message)
+        .map((res) => res?.message)
         .filter(Boolean)
         .join(" ")
       const err = new TemplateStringError({


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR handles the case when either of binary operator's arguments is undefined and an error occurs.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
