### PR TITLE
chore: remove gsutil component due to security issues in submodule

### DIFF
--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -103,7 +103,7 @@ COPY --chown=$USER:root --from=aws-builder /usr/bin/aws-iam-authenticator /usr/b
 #
 FROM google/cloud-sdk:486.0.0-alpine@sha256:4c437f46e93d26af92e62c8d549c04d6deb15e559363fc8ccc2d1ccbbbbd0431 as gcloud-base
 
-RUN gcloud components install kubectl gke-gcloud-auth-plugin --quiet && gcloud components uninstall gsutil --quiet
+RUN gcloud components install kubectl gke-gcloud-auth-plugin --quiet && gcloud components remove gsutil --quiet
 
 # Clean up bloat that increases layer size unnecessarily
 RUN rm -rf $(find /google-cloud-sdk/ -regex ".*/__pycache__") && rm -rf /google-cloud-sdk/.install/.backup

--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -103,7 +103,7 @@ COPY --chown=$USER:root --from=aws-builder /usr/bin/aws-iam-authenticator /usr/b
 #
 FROM google/cloud-sdk:486.0.0-alpine@sha256:4c437f46e93d26af92e62c8d549c04d6deb15e559363fc8ccc2d1ccbbbbd0431 as gcloud-base
 
-RUN gcloud components install kubectl gke-gcloud-auth-plugin --quiet
+RUN gcloud components install kubectl gke-gcloud-auth-plugin --quiet && gcloud components uninstall gsutil --quiet
 
 # Clean up bloat that increases layer size unnecessarily
 RUN rm -rf $(find /google-cloud-sdk/ -regex ".*/__pycache__") && rm -rf /google-cloud-sdk/.install/.backup

--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -87,7 +87,7 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
 RUN echo "${GCLOUD_SHA256}  google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" | sha256sum -c
 RUN tar -xf google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN ./google-cloud-sdk/install.sh --quiet
-RUN ./google-cloud-sdk/bin/gcloud components install kubectl gke-gcloud-auth-plugin --quiet &&  && ./google-cloud-sdk/bin/gcloud components remove gsutil --quiet
+RUN ./google-cloud-sdk/bin/gcloud components install kubectl gke-gcloud-auth-plugin --quiet && ./google-cloud-sdk/bin/gcloud components remove gsutil --quiet
 
 #
 # garden-azure-base

--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -87,7 +87,7 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
 RUN echo "${GCLOUD_SHA256}  google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" | sha256sum -c
 RUN tar -xf google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN ./google-cloud-sdk/install.sh --quiet
-RUN ./google-cloud-sdk/bin/gcloud components install kubectl gke-gcloud-auth-plugin --quiet
+RUN ./google-cloud-sdk/bin/gcloud components install kubectl gke-gcloud-auth-plugin --quiet &&  && ./google-cloud-sdk/bin/gcloud components uninstall gsutil --quiet
 
 #
 # garden-azure-base

--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -87,7 +87,7 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
 RUN echo "${GCLOUD_SHA256}  google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" | sha256sum -c
 RUN tar -xf google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN ./google-cloud-sdk/install.sh --quiet
-RUN ./google-cloud-sdk/bin/gcloud components install kubectl gke-gcloud-auth-plugin --quiet &&  && ./google-cloud-sdk/bin/gcloud components uninstall gsutil --quiet
+RUN ./google-cloud-sdk/bin/gcloud components install kubectl gke-gcloud-auth-plugin --quiet &&  && ./google-cloud-sdk/bin/gcloud components remove gsutil --quiet
 
 #
 # garden-azure-base


### PR DESCRIPTION

**What this PR does / why we need it**:
gsutil references a lot of old python packages which gives us a lot of alerts in our security scanners.
The gsutil component is not necessary for our users.

