### PR TITLE
fix(pulumi): fix process spawn machinery in Pulumi plugin

### DIFF
--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -141,13 +141,11 @@ export abstract class CliWrapper {
     }
 
     const logStream = split2()
-    // logStream.on("error", () => {})
     logStream.on("data", (line: Buffer) => {
       const logLine = line.toString()
       ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: logLine, ...logEventContext })
     })
 
-    // return this.exec({ args, cwd, env, log, ignoreError: false })
     return await this.spawnAndWait({ args, cwd, env, log, stdout: logStream, stderr: logStream })
   }
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -24,7 +24,7 @@ import AsyncLock from "async-lock"
 import type { PluginContext } from "../plugin-context.js"
 import { LogLevel } from "../logger/logger.js"
 import { uuidv4 } from "./random.js"
-import { streamLogs, waitForProcess } from "./process.js"
+// import { streamLogs, waitForProcess } from "./process.js"
 import { pipeline } from "node:stream/promises"
 import type { MaybeSecret } from "./secrets.js"
 
@@ -133,21 +133,22 @@ export abstract class CliWrapper {
     cwd,
     env,
     log,
-    ctx,
-    errorPrefix,
+    // ctx,
+    // errorPrefix,
   }: SpawnParams & { errorPrefix: string; ctx: PluginContext; statusLine?: Log }) {
-    const proc = await this.spawn({ args, cwd, env, log })
+    return this.exec({ args, cwd, env, log, ignoreError: false })
+    // const proc = await this.spawn({ args, cwd, env, log })
 
-    streamLogs({
-      proc,
-      name: this.name,
-      ctx,
-    })
+    // streamLogs({
+    //   proc,
+    //   name: this.name,
+    //   ctx,
+    // })
 
-    await waitForProcess({
-      proc,
-      errorPrefix,
-    })
+    // await waitForProcess({
+    //   proc,
+    //   errorPrefix,
+    // })
   }
 
   /**

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -24,9 +24,9 @@ import AsyncLock from "async-lock"
 import type { PluginContext } from "../plugin-context.js"
 import { LogLevel } from "../logger/logger.js"
 import { uuidv4 } from "./random.js"
-// import { streamLogs, waitForProcess } from "./process.js"
 import { pipeline } from "node:stream/promises"
 import type { MaybeSecret } from "./secrets.js"
+import split2 from "split2"
 
 const { pathExists, createWriteStream, ensureDir, chmod, remove, move, createReadStream } = fsExtra
 
@@ -122,7 +122,7 @@ export abstract class CliWrapper {
   }
 
   /**
-   * Helper for using spawn with live log streaming. Waits for the command to finish before returning.
+   * Helper for using exec with live log streaming. Waits for the command to finish before returning.
    *
    * If an error occurs and no output has been written to stderr, we use stdout for the error message instead.
    *
@@ -133,22 +133,22 @@ export abstract class CliWrapper {
     cwd,
     env,
     log,
-    // ctx,
-    // errorPrefix,
+    ctx,
   }: SpawnParams & { errorPrefix: string; ctx: PluginContext; statusLine?: Log }) {
-    return this.exec({ args, cwd, env, log, ignoreError: false })
-    // const proc = await this.spawn({ args, cwd, env, log })
+    const logEventContext = {
+      origin: this.name,
+      level: "verbose" as const,
+    }
 
-    // streamLogs({
-    //   proc,
-    //   name: this.name,
-    //   ctx,
-    // })
+    const logStream = split2()
+    // logStream.on("error", () => {})
+    logStream.on("data", (line: Buffer) => {
+      const logLine = line.toString()
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: logLine, ...logEventContext })
+    })
 
-    // await waitForProcess({
-    //   proc,
-    //   errorPrefix,
-    // })
+    // return this.exec({ args, cwd, env, log, ignoreError: false })
+    return await this.spawnAndWait({ args, cwd, env, log, stdout: logStream, stderr: logStream })
   }
 
   /**


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

This PR simplifies the machinery of spawning oulumi CLI process and streaming its logs.

Now it uses `spawnAndWait` as many other external tools and supplies a logStream as `stdout` and `stderr` to stream the logs to the Cloud.

**Which issue(s) this PR fixes**:

Fixes #6322

**Special notes for your reviewer**:

