### PR TITLE
ci: add imagepullsecret for dockerhub for e2e tests

### DIFF
--- a/e2e/projects/code-synchronization-modules/garden.yml
+++ b/e2e/projects/code-synchronization-modules/garden.yml
@@ -23,5 +23,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/demo-project-modules/garden.yml
+++ b/e2e/projects/demo-project-modules/garden.yml
@@ -24,5 +24,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/hadolint-modules/garden.yml
+++ b/e2e/projects/hadolint-modules/garden.yml
@@ -23,5 +23,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/jib-container-modules/project.garden.yml
+++ b/e2e/projects/jib-container-modules/project.garden.yml
@@ -23,5 +23,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/kustomize-modules/project.garden.yml
+++ b/e2e/projects/kustomize-modules/project.garden.yml
@@ -22,5 +22,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/open-telemetry/project.garden.yml
+++ b/e2e/projects/open-telemetry/project.garden.yml
@@ -30,6 +30,8 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
   - name: otel-collector
     exporters:
       - name: otlphttp

--- a/e2e/projects/remote-sources-modules/garden.yml
+++ b/e2e/projects/remote-sources-modules/garden.yml
@@ -34,6 +34,8 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}
   postgres-database: postgres

--- a/e2e/projects/tasks-modules/garden.yml
+++ b/e2e/projects/tasks-modules/garden.yml
@@ -22,5 +22,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/templated-k8s-container-modules/project.garden.yml
+++ b/e2e/projects/templated-k8s-container-modules/project.garden.yml
@@ -22,5 +22,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/vote-helm-modules/garden.yml
+++ b/e2e/projects/vote-helm-modules/garden.yml
@@ -27,5 +27,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}

--- a/e2e/projects/vote-modules/garden.yml
+++ b/e2e/projects/vote-modules/garden.yml
@@ -27,6 +27,8 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${local.username}
   postgres-database: postgres

--- a/examples/code-synchronization/garden.yml
+++ b/examples/code-synchronization/garden.yml
@@ -23,5 +23,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -27,6 +27,8 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}
 

--- a/examples/gke/garden.yml
+++ b/examples/gke/garden.yml
@@ -26,5 +26,7 @@ providers:
       # Make sure this matches the name and namespace of the imagePullSecret you've created
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/hadolint/garden.yml
+++ b/examples/hadolint/garden.yml
@@ -23,5 +23,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/jib-container/project.garden.yml
+++ b/examples/jib-container/project.garden.yml
@@ -23,5 +23,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/kustomize/project.garden.yml
+++ b/examples/kustomize/project.garden.yml
@@ -22,5 +22,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -37,6 +37,8 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}
   postgres-database: postgres

--- a/examples/run-actions/garden.yml
+++ b/examples/run-actions/garden.yml
@@ -22,5 +22,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/templated-k8s-container/project.garden.yml
+++ b/examples/templated-k8s-container/project.garden.yml
@@ -22,5 +22,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/vote-helm/garden.yml
+++ b/examples/vote-helm/garden.yml
@@ -27,5 +27,7 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -27,6 +27,8 @@ providers:
       # to authenticate with your registry (if needed)
       - name: gcr-config
         namespace: default
+      - name: dockerhub
+        namespace: default
 variables:
   userId: ${kebabCase(local.username)}
   postgres-database: postgres


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Added an `imagePullSecret`  for dockerhub to our ci GKE cluster and now we need to reference it in all garden projects that are used for e2e testing, since google cloud is not exempted from dockerhub rate limiting anymore.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
