### PR TITLE
fix(testResult): transform undefined to null when serializing test result

### DIFF
--- a/core/src/util/serialization.ts
+++ b/core/src/util/serialization.ts
@@ -65,11 +65,12 @@ export async function loadYamlFile(path: string): Promise<any> {
 }
 
 export function serializeObject(o: any): string {
-  return Buffer.from(JSON.stringify(o)).toString("base64")
+  return Buffer.from(JSON.stringify(o === undefined ? null : o)).toString("base64")
 }
 
 export function deserializeObject(s: string) {
-  return JSON.parse(Buffer.from(s, "base64").toString())
+  const parsed = JSON.parse(Buffer.from(s, "base64").toString())
+  return parsed === null ? undefined : parsed
 }
 
 export function serializeValues(o: { [key: string]: any }): { [key: string]: string } {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

When serializing test result data, we can get an undefined value for some optional keys e.g. `diagnosticErrorMsg`. This will result in the reported error. Fixing this by transforming it to null in serialization and back to undefined in deserialization.

**Which issue(s) this PR fixes**:

Fixes #5561 

**Special notes for your reviewer**:
