### PR TITLE
fix(template): fix template string escaping and resolution in Module configs

### DIFF
--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -932,7 +932,14 @@ export class ModuleResolver {
     templateContextParams: ModuleConfigContextParams
   ): Promise<DeepPrimitiveMap> {
     const moduleConfigContext = new ModuleConfigContext(templateContextParams)
-    const resolveOpts = { allowPartial: false }
+    const resolveOpts = {
+      allowPartial: false,
+      // Modules will be converted to actions later, and the actions will be properly unescaped.
+      // We avoid premature un-escaping here,
+      // because otherwise it will strip the escaped value in the module config
+      // to the normal template string in the converted action config.
+      unescape: false,
+    }
 
     let varfileVars: DeepPrimitiveMap = {}
     if (config.varfile) {

--- a/core/src/template-string/parser.pegjs
+++ b/core/src/template-string/parser.pegjs
@@ -57,7 +57,7 @@ TemplateString
   / $(.*) { return text() === "" ? [] : [{ resolved: text() }] }
 
 FormatString
-  = EscapeStart SourceCharacter* FormatEndWithOptional {
+  = EscapeStart (!FormatEndWithOptional SourceCharacter)* FormatEndWithOptional {
     if (options.unescape) {
       return text().slice(1)
     } else {

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -126,7 +126,7 @@ export const resolveTemplateString = profile(function resolveTemplateString({
       return false
     }
 
-    return !!ctxOpts.unescape || !contextOpts.allowPartial
+    return !!ctxOpts.unescape || !ctxOpts.allowPartial
   }
 
   try {

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -96,6 +96,15 @@ export class TemplateError extends GardenError {
   }
 }
 
+const shouldUnescape = (ctxOpts: ContextResolveOpts) => {
+  // Explicit non-escaping takes the highest priority.
+  if (ctxOpts.unescape === false) {
+    return false
+  }
+
+  return !!ctxOpts.unescape || !ctxOpts.allowPartial
+}
+
 /**
  * Parse and resolve a templated string, with the given context. The template format is similar to native JS templated
  * strings but only supports simple lookups from the given context, e.g. "prefix-${nested.key}-suffix", and not
@@ -118,15 +127,6 @@ export const resolveTemplateString = profile(function resolveTemplateString({
   // Just return immediately if this is definitely not a template string
   if (!maybeTemplateString(string)) {
     return string
-  }
-
-  const shouldUnescape = (ctxOpts: ContextResolveOpts) => {
-    // Explicit non-escaping takes the highest priority.
-    if (ctxOpts.unescape === false) {
-      return false
-    }
-
-    return !!ctxOpts.unescape || !ctxOpts.allowPartial
   }
 
   try {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Skip pre-mature string unescaping in Module configs
* Fix too greedy escaped string pattern definition in PeggyJS

**Which issue(s) this PR fixes**:

Fixes #3989
Patches #5680

**Special notes for your reviewer**:
