### PR TITLE
ci: update k8s version matrix in integration tests

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1364,11 +1364,11 @@ workflows:
       # variant and k8s version would be quite expensive, so we try and make sure each of the latest 6-7 k8s versions is
       # tested, and that the most recent versions are broadly tested. The kind tests are the cheapest to run so we use many
       # of those, but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
-      - test-k3s:
-          name: vm-1.27-k3s
-          requires: [build]
-          # version v1.27.4+k3s1 fails with this issue https://github.com/moby/moby/issues/45935
-          k3sVersion: v1.27.2+k3s1
+#      - test-k3s:
+#          name: vm-1.27-k3s
+#          requires: [build]
+#          # version v1.27.4+k3s1 fails with this issue https://github.com/moby/moby/issues/45935
+#          k3sVersion: v1.27.2+k3s1
       - test-minikube:
           name: vm-1.28-minikube
           requires: [ build ]

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1017,7 +1017,7 @@ jobs:
       k3sVersion:
         description: The k3s version to use
         type: string
-        default: v1.27.4+k3s1
+        default: v1.30.4+k3s1
       skipTests:
         description: Integ test groups to skip
         type: string
@@ -1364,11 +1364,6 @@ workflows:
       # variant and k8s version would be quite expensive, so we try and make sure each of the latest 6-7 k8s versions is
       # tested, and that the most recent versions are broadly tested. The kind tests are the cheapest to run so we use many
       # of those, but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
-#      - test-k3s:
-#          name: vm-1.27-k3s
-#          requires: [build]
-#          # version v1.27.4+k3s1 fails with this issue https://github.com/moby/moby/issues/45935
-#          k3sVersion: v1.27.2+k3s1
       - test-minikube:
           name: vm-1.28-minikube
           requires: [ build ]
@@ -1382,6 +1377,10 @@ workflows:
           name: vm-1.30-microk8s
           requires: [build]
           kubernetesVersion: "1.30"
+      - test-k3s:
+          name: vm-1.30-k3s
+          requires: [build]
+          k3sVersion: v1.30.4+k3s1
 
       - test-plugins:
           <<: *only-internal-prs

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1372,7 +1372,7 @@ workflows:
       - test-kind:
           name: vm-1.29-kind
           requires: [build]
-          kindNodeImage: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+          kindNodeImage: kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
       - test-microk8s:
           name: vm-1.30-microk8s
           requires: [build]
@@ -1385,7 +1385,7 @@ workflows:
       - test-plugins:
           <<: *only-internal-prs
           requires: [build]
-          kindNodeImage: kindest/node:1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+          kindNodeImage: kindest/node:1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
 
       # This is only for edge release (Overrides version to edge-bonsai)
       - build:


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update k3s from 1.27 to 1.30.
* Update kind version to the latest patch release.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
