### PR TITLE
fix(sync): correct search path for mutagen faux ssh

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -1120,7 +1120,7 @@ export const mutagenFauxSshSpec: PluginToolSpec = {
       sha256: "c7645e615efc9e5139f8a281abb9acae61ea2ce2084ea25aa438438da3481167",
       extract: {
         format: "tar",
-        targetPath: "mutagen",
+        targetPath: "ssh",
       },
     },
     {

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -321,7 +321,7 @@ export class PluginTool extends CliWrapper {
         if (this.buildSpec.extract && !(await pathExists(targetAbsPath))) {
           // if this happens, it's a bug!
           throw new InternalError({
-            message: `Error while downloading ${this.name}: Archive ${this.buildSpec.url} does not contain a file or directory at ${this.targetSubpath}`,
+            message: `Error while downloading ${this.name}: Archive ${this.buildSpec.url} does not contain a file or directory at ${targetAbsPath}`,
           })
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes a small bug where the mutagen faux ssh binary path is wrong for linux arm64 builds. Also improves the error message around this.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
