### PR TITLE
fix: allow relative symlinks to directories when using build staging

### DIFF
--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -189,7 +189,7 @@ export class BuildStaging {
 
     // Source root must exist and be a directory
     let sourceStat = await statsHelper.extendedStat({ path: sourceRoot })
-    if (!sourceStat || !(sourceStat.isDirectory() || sourceStat.target?.isDirectory())) {
+    if (!sourceStat || !sourceStat.isDirectory()) {
       throw new InternalError({
         message: `Build staging: Source root ${sourceRoot} must exist and be a directory`,
       })
@@ -271,6 +271,8 @@ export class BuildStaging {
       const to = targetShouldBeDirectory || targetStat?.isDirectory() ? join(targetPath, sourceBasename) : targetPath
 
       await syncFileAsync({
+        log,
+        root: sourceRoot,
         from: sourceRoot,
         to,
         allowDelete: withDelete,
@@ -323,7 +325,7 @@ export class BuildStaging {
               ([fromRelative, toRelative], fileCb) => {
                 const from = joinWithPosix(sourceRoot, fromRelative)
                 const to = joinWithPosix(targetPath, toRelative)
-                cloneFile({ from, to, allowDelete: withDelete, statsHelper }, fileCb)
+                cloneFile({ log, root: sourceRoot, from, to, allowDelete: withDelete, statsHelper }, fileCb)
               },
               cb
             )

--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -189,7 +189,7 @@ export class BuildStaging {
 
     // Source root must exist and be a directory
     let sourceStat = await statsHelper.extendedStat({ path: sourceRoot })
-    if (!sourceStat || !sourceStat.isDirectory()) {
+    if (!sourceStat || !(sourceStat.isDirectory() || sourceStat.target?.isDirectory())) {
       throw new InternalError({
         message: `Build staging: Source root ${sourceRoot} must exist and be a directory`,
       })

--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -272,7 +272,7 @@ export class BuildStaging {
 
       await syncFileAsync({
         log,
-        root: sourceRoot,
+        sourceRoot,
         from: sourceRoot,
         to,
         allowDelete: withDelete,
@@ -325,7 +325,7 @@ export class BuildStaging {
               ([fromRelative, toRelative], fileCb) => {
                 const from = joinWithPosix(sourceRoot, fromRelative)
                 const to = joinWithPosix(targetPath, toRelative)
-                cloneFile({ log, root: sourceRoot, from, to, allowDelete: withDelete, statsHelper }, fileCb)
+                cloneFile({ log, sourceRoot, from, to, allowDelete: withDelete, statsHelper }, fileCb)
               },
               cb
             )

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -308,8 +308,15 @@ export class ExtendedStats extends Stats {
     this.targetPath = targetPath
   }
 
-  static fromStats(stats: fsExtra.Stats, path: string, target?: ExtendedStats | null, targetPath?: string | null) {
-    const o = new ExtendedStats({ path: path, target: target, targetPath: targetPath })
+  static fromStats({
+    stats,
+    path,
+    target,
+    targetPath,
+  }: {
+    stats: fsExtra.Stats
+  } & ExtendedStatsCtorParams) {
+    const o = new ExtendedStats({ path, target, targetPath })
     Object.assign(o, stats)
     return o
   }
@@ -394,10 +401,10 @@ export class FileStatsHelper {
           cb(lstatErr, null)
         } else if (lstats.isSymbolicLink()) {
           this.resolveSymlink({ path, allowAbsolute: allowAbsoluteSymlinks }, (symlinkErr, target, targetPath) => {
-            cb(symlinkErr, ExtendedStats.fromStats(lstats, path, target, targetPath))
+            cb(symlinkErr, ExtendedStats.fromStats({ stats: lstats, path, target, targetPath }))
           })
         } else {
-          cb(null, ExtendedStats.fromStats(lstats, path))
+          cb(null, ExtendedStats.fromStats({ stats: lstats, path }))
         }
       })
     }
@@ -497,7 +504,7 @@ export class FileStatsHelper {
           }
         } else {
           // Return with path and stats for final symlink target
-          cb(null, ExtendedStats.fromStats(targetStats, targetPath), target)
+          cb(null, ExtendedStats.fromStats({ stats: targetStats, path: targetPath }), target)
         }
       })
     })

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -341,8 +341,8 @@ type ExtendedStatsCallback = (err: NodeJS.ErrnoException | null, stats: Extended
  * The idea is for an instance to be used for the duration of e.g. one sync flow, but not for longer.
  */
 export class FileStatsHelper {
-  private lstatCache: { [path: string]: fsExtra.Stats }
-  private extendedStatCache: { [path: string]: ExtendedStats | null }
+  private readonly lstatCache: { [path: string]: fsExtra.Stats }
+  private readonly extendedStatCache: { [path: string]: ExtendedStats | null }
 
   constructor() {
     this.lstatCache = {}

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -333,6 +333,7 @@ export interface ResolveSymlinkParams {
   _resolvedPaths?: string[]
 }
 
+type StatsCallback = (err: NodeJS.ErrnoException | null, stats: fsExtra.Stats) => void
 type ExtendedStatsCallback = (err: NodeJS.ErrnoException | null, stats: ExtendedStats | null) => void
 
 /**
@@ -352,7 +353,7 @@ export class FileStatsHelper {
   /**
    * Calls fs.lstat on the given path, and caches the result.
    */
-  lstat(path: string, cb: (err: NodeJS.ErrnoException | null, stats: fsExtra.Stats) => void) {
+  lstat(path: string, cb: StatsCallback) {
     if (this.lstatCache[path]) {
       cb(null, this.lstatCache[path])
     } else {

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -335,6 +335,11 @@ export interface ResolveSymlinkParams {
 
 type StatsCallback = (err: NodeJS.ErrnoException | null, stats: fsExtra.Stats) => void
 type ExtendedStatsCallback = (err: NodeJS.ErrnoException | null, stats: ExtendedStats | null) => void
+type ResolveSymlinkCallback = (
+  err: NodeJS.ErrnoException | null,
+  target: ExtendedStats | null,
+  targetPath: string | null
+) => void
 
 /**
  * A helper class for getting information about files/dirs, that caches the stats for the lifetime of the class, and
@@ -448,10 +453,7 @@ export class FileStatsHelper {
    * By default, absolute symlinks are ignored, and if one is encountered the method resolves to null. Set
    * `allowAbsolute: true` to allow absolute symlinks.
    */
-  resolveSymlink(
-    params: ResolveSymlinkParams,
-    cb: (err: NodeJS.ErrnoException | null, target: ExtendedStats | null, targetPath: string | null) => void
-  ) {
+  resolveSymlink(params: ResolveSymlinkParams, cb: ResolveSymlinkCallback) {
     const { path, allowAbsolute } = params
     const _resolvedPaths = params._resolvedPaths || [path]
 

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -6,22 +6,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { readlink, copyFile, constants, utimes } from "fs"
+import { readlink, copyFile, constants, utimes, symlink } from "fs"
 import readdir from "@jsdevtools/readdir-enhanced"
-import { splitLast } from "../util/string.js"
+import { dedent, splitLast } from "../util/string.js"
 import { Minimatch } from "minimatch"
-import { isAbsolute, parse, basename, resolve } from "path"
+import { isAbsolute, parse, basename, resolve, join, dirname } from "path"
 import fsExtra from "fs-extra"
 const { ensureDir, Stats, lstat, remove } = fsExtra
-import { FilesystemError, InternalError, isErrnoException } from "../exceptions.js"
+import { ConfigurationError, FilesystemError, InternalError, isErrnoException } from "../exceptions.js"
 import type { AsyncResultCallback } from "async"
 import async from "async"
 import { round } from "lodash-es"
 import { promisify } from "util"
+import { styles } from "../logger/styles.js"
+import { emitNonRepeatableWarning } from "../warnings.js"
+import { type Log } from "../logger/log-entry.js"
 
 export type MappedPaths = [string, string][]
 
 export interface CloneFileParams {
+  log: Log
+  root: string
   from: string
   to: string
   allowDelete: boolean
@@ -37,7 +42,7 @@ type SyncCallback = AsyncResultCallback<SyncResult, Error>
 /**
  * Synchronizes (clones) a single file in one direction.
  */
-export function cloneFile({ from, to, allowDelete, statsHelper }: CloneFileParams, done: SyncCallback) {
+export function cloneFile({ log, root, from, to, allowDelete, statsHelper }: CloneFileParams, done: SyncCallback) {
   // Stat the files
   async.parallel<ExtendedStats | null>(
     {
@@ -57,33 +62,60 @@ export function cloneFile({ from, to, allowDelete, statsHelper }: CloneFileParam
         return done(null, { skipped: true })
       }
 
-      // Follow symlink on source, if applicable
       if (sourceStats.isSymbolicLink()) {
-        if (sourceStats.target) {
-          sourceStats = sourceStats.target
-        } else {
-          // Symlink couldn't be resolved, so we ignore it
+        if (!sourceStats.targetPath) {
+          // This symlink failed validation (e.g. it is absolute, when absolute symlinks are not allowed)
           return done(null, { skipped: true })
+        }
+        const resolved = resolve(dirname(sourceStats.path), sourceStats.targetPath)
+        const outOfBounds = !resolved.startsWith(join(root, "/"))
+        if (outOfBounds) {
+          const outOfBoundsMessage = dedent`
+            Encountered a symlink ${sourceStats.path} whose target ${sourceStats.targetPath} is out of bounds (not inside ${root}).
+
+            When using ${styles.highlight("staged builds")} or ${styles.highlight("copyFrom")}. Staged builds must be self-contained.
+
+            Symbolic links to directories or files outside the action's source directory (when ${styles.highlight("builds")}), or build directory (when using ${styles.highlight("copyFrom")}), are not allowed.
+
+            In case this is not acceptable, you can disable build staging by setting ${styles.highlight("buildAtSource: true")} in the action configuration to disable build staging for this action.`
+          if (sourceStats.target?.isFile()) {
+            // For compatibility with older versions of garden that would allow symlink targets outside the root, if the target file existed, we only emit a warning here.
+            // TODO(0.14): Throw an error here
+            emitNonRepeatableWarning(
+              log,
+              outOfBoundsMessage + `\n\nWARNING: This will become an error in an upcoming release of Garden.`
+            )
+            // For compatibility with older versions of Garden, copy the target file instead of reproducing the symlink
+            // TODO(0.14): Only reproduce the symlink. The target file will be copied in another call to `cloneFile`.
+            sourceStats = sourceStats.target
+          } else {
+            // Note: If a symlink pointed to a directory, we threw another error "source is neither a symbolic link, nor a file" in previous versions of garden,
+            // so this is not a breaking change.
+            throw new ConfigurationError({
+              message: outOfBoundsMessage,
+            })
+          }
         }
       }
 
-      if (!sourceStats.isFile()) {
+      if (!sourceStats.isFile() && !sourceStats.isSymbolicLink()) {
         return done(
-          new FilesystemError({
+          // Using internal error here because if this happens, it's a logical error here in this code
+          new InternalError({
             message: `Error while copying from '${from}' to '${to}': Source is neither a symbolic link, nor a file.`,
           })
         )
       }
 
       if (targetStats) {
-        // If target is a directory and deletes are allowed, delete the directory before copying, otherwise throw
-        if (targetStats.isDirectory()) {
+        // If target is a directory or source is a symbolic link and deletes are allowed, delete the target before copying, otherwise throw
+        if (targetStats.isDirectory() || sourceStats.isSymbolicLink()) {
           if (allowDelete) {
             return remove(to, (removeErr) => {
               if (removeErr) {
                 return done(removeErr)
               } else {
-                return doClone({ from, to, sourceStats: sourceStats!, done, statsHelper })
+                return doClone({ from, to, sourceStats: sourceStats!, targetStats, done, statsHelper })
               }
             })
           } else {
@@ -101,7 +133,7 @@ export function cloneFile({ from, to, allowDelete, statsHelper }: CloneFileParam
         }
       }
 
-      return doClone({ from, to, sourceStats, done, statsHelper })
+      return doClone({ from, to, sourceStats, targetStats, done, statsHelper })
     }
   )
 }
@@ -112,14 +144,15 @@ export const cloneFileAsync = promisify(cloneFile) as (params: CloneFileParams) 
 interface CopyParams {
   from: string
   to: string
-  sourceStats: fsExtra.Stats
+  sourceStats: ExtendedStats
+  targetStats: ExtendedStats | null
   done: SyncCallback
   statsHelper: FileStatsHelper
   resolvedSymlinkPaths?: string[]
 }
 
 function doClone(params: CopyParams) {
-  const { from, to, done, sourceStats } = params
+  const { from, to, done, sourceStats, targetStats } = params
   const dir = parse(to).dir
 
   // TODO: take care of this ahead of time to avoid the extra i/o
@@ -128,11 +161,7 @@ function doClone(params: CopyParams) {
       return done(err)
     }
 
-    // COPYFILE_FICLONE instructs the function to use a copy-on-write reflink on platforms/filesystems where available
-    copyFile(from, to, constants.COPYFILE_FICLONE, (copyErr) => {
-      if (copyErr) {
-        return done(copyErr)
-      }
+    const setUtimes = () => {
       // Set the mtime on the cloned file to the same as the source file
       utimes(to, new Date(), sourceStats.mtimeMs / 1000, (utimesErr) => {
         if (utimesErr && (!isErrnoException(utimesErr) || utimesErr.code !== "ENOENT")) {
@@ -140,7 +169,44 @@ function doClone(params: CopyParams) {
         }
         done(null, { skipped: false })
       })
-    })
+    }
+
+    if (sourceStats.isSymbolicLink()) {
+      // reproduce the symbolic link. Validation happens before.
+      if (sourceStats.targetPath) {
+        symlink(
+          sourceStats.targetPath,
+          to,
+          // relevant on windows
+          // nodejs will auto-detect this on windows, but if the symlink is copied before the target then the auto-detection will get it wrong.
+          targetStats?.isDirectory() ? "dir" : "file",
+          (symlinkErr) => {
+            if (symlinkErr) {
+              return done(symlinkErr)
+            }
+
+            setUtimes()
+          }
+        )
+      } else {
+        throw new InternalError({
+          message: "Source is a symbolic link, but targetPath was null or undefined.",
+        })
+      }
+    } else if (sourceStats.isFile()) {
+      // COPYFILE_FICLONE instructs the function to use a copy-on-write reflink on platforms/filesystems where available
+      copyFile(from, to, constants.COPYFILE_FICLONE, (copyErr) => {
+        if (copyErr) {
+          return done(copyErr)
+        }
+
+        setUtimes()
+      })
+    } else {
+      throw new InternalError({
+        message: "Expected doClone source to be a file or a symbolic link.",
+      })
+    }
   })
 }
 
@@ -220,15 +286,18 @@ export async function scanDirectoryForClone(root: string, pattern?: string): Pro
 export class ExtendedStats extends Stats {
   path: string
   target?: ExtendedStats | null
+  // original relative or absolute path the symlink points to. This can be defined when target is null when the target does not exist, for instance.
+  targetPath?: string | null
 
-  constructor(path: string, target?: ExtendedStats | null) {
+  constructor(path: string, target?: ExtendedStats | null, targetPath?: string | null) {
     super()
     this.path = path
     this.target = target
+    this.targetPath = targetPath
   }
 
-  static fromStats(stats: fsExtra.Stats, path: string, target?: ExtendedStats | null) {
-    const o = new ExtendedStats(path, target)
+  static fromStats(stats: fsExtra.Stats, path: string, target?: ExtendedStats | null, targetPath?: string | null) {
+    const o = new ExtendedStats(path, target, targetPath)
     Object.assign(o, stats)
     return o
   }
@@ -312,8 +381,8 @@ export class FileStatsHelper {
         if (lstatErr) {
           cb(lstatErr, null)
         } else if (lstats.isSymbolicLink()) {
-          this.resolveSymlink({ path, allowAbsolute: allowAbsoluteSymlinks }, (symlinkErr, target) => {
-            cb(symlinkErr, ExtendedStats.fromStats(lstats, path, target))
+          this.resolveSymlink({ path, allowAbsolute: allowAbsoluteSymlinks }, (symlinkErr, target, targetPath) => {
+            cb(symlinkErr, ExtendedStats.fromStats(lstats, path, target, targetPath))
           })
         } else {
           cb(null, ExtendedStats.fromStats(lstats, path))
@@ -351,6 +420,9 @@ export class FileStatsHelper {
    * fs.Stats for the resolved target, if one can be resolved. If target cannot be found, the callback is resolved
    * with a null value.
    *
+   * The second callback parameter, `targetPath`, is the unresolved target of the symbolic link. The `targetPath` will be undefined
+   * if the symbolic link is absolute, and absolute symbolic links are not allowed.
+   *
    * `path` must be an absolute path (an error is thrown otherwise).
    *
    * By default, absolute symlinks are ignored, and if one is encountered the method resolves to null. Set
@@ -358,7 +430,7 @@ export class FileStatsHelper {
    */
   resolveSymlink(
     params: ResolveSymlinkParams,
-    cb: (err: NodeJS.ErrnoException | null, target: ExtendedStats | null) => void
+    cb: (err: NodeJS.ErrnoException | null, target: ExtendedStats | null, targetPath: string | null) => void
   ) {
     const { path, allowAbsolute } = params
     const _resolvedPaths = params._resolvedPaths || [path]
@@ -370,15 +442,15 @@ export class FileStatsHelper {
     readlink(path, (readlinkErr, target) => {
       if (readlinkErr?.code === "ENOENT") {
         // Symlink target not found, so we ignore it
-        return cb(null, null)
+        return cb(null, null, null)
       } else if (readlinkErr) {
-        return cb(InternalError.wrapError(readlinkErr, "Error reading symlink"), null)
+        return cb(InternalError.wrapError(readlinkErr, "Error reading symlink"), null, null)
       }
 
       // Ignore absolute symlinks unless specifically allowed
       // TODO: also allow limiting links to a certain absolute path
       if (isAbsolute(target) && !allowAbsolute) {
-        return cb(null, null)
+        return cb(null, null, null)
       }
 
       // Resolve the symlink path
@@ -387,25 +459,33 @@ export class FileStatsHelper {
       // Stat the final path and return
       this.lstat(targetPath, (statErr, targetStats) => {
         if (statErr?.code === "ENOENT") {
-          // Can't find the final target, so we ignore it
-          cb(null, null)
+          // The symlink target does not exist. That's not an error.
+          cb(null, null, target)
         } else if (statErr) {
           // Propagate other errors
-          cb(statErr, null)
+          cb(statErr, null, null)
         } else if (targetStats.isSymbolicLink()) {
           // Keep resolving until we get to a real path
           if (_resolvedPaths.includes(targetPath)) {
             // We've gone into a symlink loop, so we ignore it
-            cb(null, null)
+            cb(null, null, target)
           } else {
             this.resolveSymlink(
               { path: targetPath, allowAbsolute, _resolvedPaths: [..._resolvedPaths, targetPath] },
-              cb
+              (innerResolveErr, innerStats, _innerTarget) => {
+                if (innerResolveErr) {
+                  cb(innerResolveErr, null, null)
+                } else {
+                  // make sure the original symlink target is not overridden by the recursive search here
+                  // TODO(0.14): In a future version of garden it would be better to simply reproduce relative symlinks, instead of resolving them and copying the target directories.
+                  cb(null, innerStats, target)
+                }
+              }
             )
           }
         } else {
           // Return with path and stats for final symlink target
-          cb(null, ExtendedStats.fromStats(targetStats, targetPath))
+          cb(null, ExtendedStats.fromStats(targetStats, targetPath), target)
         }
       })
     })

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -26,7 +26,7 @@ export type MappedPaths = [string, string][]
 
 export interface CloneFileParams {
   log: Log
-  root: string
+  sourceRoot: string
   from: string
   to: string
   allowDelete: boolean
@@ -42,7 +42,10 @@ type SyncCallback = AsyncResultCallback<SyncResult, Error>
 /**
  * Synchronizes (clones) a single file in one direction.
  */
-export function cloneFile({ log, root, from, to, allowDelete, statsHelper }: CloneFileParams, done: SyncCallback) {
+export function cloneFile(
+  { log, sourceRoot, from, to, allowDelete, statsHelper }: CloneFileParams,
+  done: SyncCallback
+) {
   // Stat the files
   async.parallel<ExtendedStats | null>(
     {
@@ -68,12 +71,12 @@ export function cloneFile({ log, root, from, to, allowDelete, statsHelper }: Clo
           return done(null, { skipped: true })
         }
         const resolved = resolve(dirname(sourceStats.path), sourceStats.targetPath)
-        const outOfBounds = !resolved.startsWith(join(root, "/"))
+        const outOfBounds = !resolved.startsWith(join(sourceRoot, "/"))
         if (outOfBounds) {
           const outOfBoundsMessage = dedent`
             The action's source directory (when using ${styles.highlight("staged builds")}), or build directory (when using ${styles.highlight("copyFrom")}), must be self-contained.
 
-            Encountered a symlink at ${styles.highlight(sourceStats.path)} whose target ${styles.highlight(sourceStats.targetPath)} is out of bounds (not inside ${root}).
+            Encountered a symlink at ${styles.highlight(sourceStats.path)} whose target ${styles.highlight(sourceStats.targetPath)} is out of bounds (not inside ${sourceRoot}).
 
             In case this is not acceptable, you can disable build staging by setting ${styles.highlight("buildAtSource: true")} in the action configuration to disable build staging for this action.`
           if (sourceStats.target?.isFile()) {

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -18,6 +18,8 @@ import { expectError } from "../../../helpers.js"
 import { sleep } from "../../../../src/util/util.js"
 import { sortBy } from "lodash-es"
 import { equalWithPrecision } from "../../../../src/util/testing.js"
+import { getRootLogger } from "../../../../src/logger/logger.js"
+import { readlink } from "fs/promises"
 
 describe("build staging helpers", () => {
   let statsHelper: FileStatsHelper
@@ -40,11 +42,14 @@ describe("build staging helpers", () => {
   }
 
   describe("cloneFile", () => {
+    const logger = getRootLogger()
+    const log = logger.createLog()
+
     it("clones a file", async () => {
       const a = join(tmpPath, "a")
       const b = join(tmpPath, "b")
       await writeFile(a, "foo")
-      const res = await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
       const data = await readFileStr(b)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -55,7 +60,7 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await writeFile(a, "foo")
       await mkdir(b)
-      const res = await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: true })
+      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: true })
       const data = await readFileStr(b)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -67,7 +72,7 @@ describe("build staging helpers", () => {
       await writeFile(a, "foo")
       await mkdir(b)
 
-      await expectError(() => cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false }), {
+      await expectError(() => cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false }), {
         contains: `Build staging: Failed copying file from '${a}' to '${b}' because a directory exists at the target path`,
       })
     })
@@ -78,7 +83,7 @@ describe("build staging helpers", () => {
       await writeFile(a, "foo")
       await sleep(100)
 
-      await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false })
+      await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
 
       const statA = await statsHelper.extendedStat({ path: a })
       const statB = await statsHelper.extendedStat({ path: b })
@@ -91,9 +96,9 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await writeFile(a, "foo")
 
-      await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false })
+      await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
 
-      const res = await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
       expect(res.skipped).to.be.true
     })
 
@@ -102,7 +107,7 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "subdir", "b")
       await writeFile(a, "foo")
 
-      await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false })
+      await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
 
       const data = await readFileStr(b)
       expect(data).to.equal("foo")
@@ -114,10 +119,40 @@ describe("build staging helpers", () => {
       const c = join(tmpPath, "c")
       await writeFile(a, "foo")
       await symlink("a", b)
-      const res = await cloneFileAsync({ from: b, to: c, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, root: b, from: b, to: c, statsHelper, allowDelete: false })
       const data = await readFileStr(c)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
+    })
+
+    it("reproduces the symlink if it points to a directory", async () => {
+      const b = join(tmpPath, "b")
+      const a = join(tmpPath, "a")
+      const syml = "symlink"
+      const symlBroken = "broken"
+      const dir = "dir"
+      const file = join(dir, "fruit")
+      await mkdir(a)
+      await mkdir(join(a, dir))
+      await writeFile(join(a, file), "banana")
+      await symlink("dir", join(a, syml))
+      await symlink("target_does_not_exist", join(a, symlBroken))
+      const filesToClone = [syml, symlBroken, file]
+      for (const f of filesToClone) {
+        const res = await cloneFileAsync({
+          log,
+          root: a,
+          from: join(a, f),
+          to: join(b, f),
+          statsHelper,
+          allowDelete: false,
+        })
+        expect(res.skipped).to.be.false
+      }
+      expect(await readlink(join(b, syml))).to.equal("dir")
+      expect(await readlink(join(b, symlBroken))).to.equal("target_does_not_exist")
+      expect(await readFileStr(join(b, file))).to.equal("banana")
+      expect(await readFileStr(join(b, syml, "fruit"))).to.equal("banana")
     })
 
     it("clones a file that's within a symlinked directory", async () => {
@@ -130,7 +165,7 @@ describe("build staging helpers", () => {
       await symlink("dir", dirLink)
       await writeFile(a, "foo")
 
-      const res = await cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
       const data = await readFileStr(b)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -141,7 +176,7 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await ensureDir(a)
 
-      await expectError(() => cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false }), {
+      await expectError(() => cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false }), {
         contains: `Error while copying from '${a}' to '${b}': Source is neither a symbolic link, nor a file`,
       })
     })
@@ -403,12 +438,18 @@ describe("build staging helpers", () => {
     describe("resolveSymlink", () => {
       // A promisified version to simplify tests
       async function resolveSymlink(params: ResolveSymlinkParams) {
-        return new Promise<ExtendedStats | null>((resolve, reject) => {
-          statsHelper.resolveSymlink(params, (err, target) => {
+        return new Promise<{
+          target: ExtendedStats | null
+          targetPath: string | null
+        }>((resolve, reject) => {
+          statsHelper.resolveSymlink(params, (err, target, targetPath) => {
             if (err) {
               reject(err)
             } else {
-              resolve(target)
+              resolve({
+                target,
+                targetPath,
+              })
             }
           })
         })
@@ -420,7 +461,8 @@ describe("build staging helpers", () => {
         await writeFile(a, "foo")
         await symlink("a", b)
         const res = await resolveSymlink({ path: b })
-        expect(res?.path).to.equal(a)
+        expect(res?.target?.path).to.equal(a)
+        expect(res?.targetPath).to.equal("a")
       })
 
       it("resolves a symlink recursively", async () => {
@@ -431,7 +473,8 @@ describe("build staging helpers", () => {
         await symlink("a", b)
         await symlink("b", c)
         const res = await resolveSymlink({ path: c })
-        expect(res?.path).to.equal(a)
+        expect(res?.target?.path).to.equal(a)
+        expect(res?.targetPath).to.equal("b")
       })
 
       it("returns null for an absolute symlink", async () => {
@@ -440,7 +483,8 @@ describe("build staging helpers", () => {
         await writeFile(a, "foo")
         await symlink(a, b) // <- absolute link
         const res = await resolveSymlink({ path: b })
-        expect(res).to.equal(null)
+        expect(res.target).to.equal(null)
+        expect(res.targetPath).to.equal(null)
       })
 
       it("returns null for a recursive absolute symlink", async () => {
@@ -451,7 +495,9 @@ describe("build staging helpers", () => {
         await symlink(a, b) // <- absolute link
         await symlink("b", c)
         const res = await resolveSymlink({ path: c })
-        expect(res).to.equal(null)
+        expect(res.target).to.equal(null)
+        // target path can be resolved; If the build staging logic were only to reproduce relative symlinks, broken or not, it would all be much easier to understand.
+        expect(res.targetPath).to.equal("b")
       })
 
       it("resolves an absolute symlink if allowAbsolute=true", async () => {
@@ -460,7 +506,8 @@ describe("build staging helpers", () => {
         await writeFile(a, "foo")
         await symlink(a, b) // <- absolute link
         const res = await resolveSymlink({ path: b, allowAbsolute: true })
-        expect(res?.path).to.equal(a)
+        expect(res?.target?.path).to.equal(a)
+        expect(res?.targetPath).to.equal(a)
       })
 
       it("throws if a relative path is given", async () => {
@@ -479,7 +526,8 @@ describe("build staging helpers", () => {
         await symlink("a", b)
         await symlink("b", a)
         const res = await resolveSymlink({ path: b })
-        expect(res).to.equal(null)
+        expect(res.target).to.equal(null)
+        expect(res.targetPath).to.equal("a")
       })
 
       it("returns null if resolving a two-step circular symlink", async () => {
@@ -490,7 +538,8 @@ describe("build staging helpers", () => {
         await symlink("a", b)
         await symlink("b", c)
         const res = await resolveSymlink({ path: c })
-        expect(res).to.equal(null)
+        expect(res.target).to.equal(null)
+        expect(res.targetPath).to.equal("b")
       })
     })
   })

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -12,6 +12,7 @@ import { cloneFileAsync, FileStatsHelper, scanDirectoryForClone } from "../../..
 import type { TempDirectory } from "../../../../src/util/fs.js"
 import { makeTempDir } from "../../../../src/util/fs.js"
 import fsExtra from "fs-extra"
+
 const { realpath, symlink, writeFile, readFile, mkdir, ensureFile, ensureDir } = fsExtra
 import { expect } from "chai"
 import { expectError } from "../../../helpers.js"
@@ -465,7 +466,7 @@ describe("build staging helpers", () => {
           target: ExtendedStats | null
           targetPath: string | null
         }>((resolve, reject) => {
-          statsHelper.resolveSymlink(params, (err, target, targetPath) => {
+          statsHelper.resolveSymlink(params, ({ err, target, targetPath }) => {
             if (err) {
               reject(err)
             } else {

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -125,6 +125,29 @@ describe("build staging helpers", () => {
       expect(data).to.equal("foo")
     })
 
+    it("throws an error if symlink is out of bounds", async () => {
+      const b = join(tmpPath, "b")
+      const a = join(tmpPath, "a")
+      const symlPath = "symlink"
+      const symlTarget = ".."
+      await mkdir(a)
+      await symlink(symlTarget, join(a, symlPath))
+      await expectError(
+        () =>
+          cloneFileAsync({
+            log,
+            root: a,
+            from: join(a, symlPath),
+            to: join(b, symlPath),
+            statsHelper,
+            allowDelete: false,
+          }),
+        {
+          contains: ["Encountered a symlink", "whose target .. is out of bounds (not inside"],
+        }
+      )
+    })
+
     it("reproduces the symlink if it points to a directory", async () => {
       const b = join(tmpPath, "b")
       const a = join(tmpPath, "a")

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -49,7 +49,7 @@ describe("build staging helpers", () => {
       const a = join(tmpPath, "a")
       const b = join(tmpPath, "b")
       await writeFile(a, "foo")
-      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false })
       const data = await readFileStr(b)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -60,7 +60,7 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await writeFile(a, "foo")
       await mkdir(b)
-      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: true })
+      const res = await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: true })
       const data = await readFileStr(b)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -72,7 +72,7 @@ describe("build staging helpers", () => {
       await writeFile(a, "foo")
       await mkdir(b)
 
-      await expectError(() => cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false }), {
+      await expectError(() => cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false }), {
         contains: `Build staging: Failed copying file from '${a}' to '${b}' because a directory exists at the target path`,
       })
     })
@@ -83,7 +83,7 @@ describe("build staging helpers", () => {
       await writeFile(a, "foo")
       await sleep(100)
 
-      await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
+      await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false })
 
       const statA = await statsHelper.extendedStat({ path: a })
       const statB = await statsHelper.extendedStat({ path: b })
@@ -96,9 +96,9 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await writeFile(a, "foo")
 
-      await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
+      await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false })
 
-      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false })
       expect(res.skipped).to.be.true
     })
 
@@ -107,7 +107,7 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "subdir", "b")
       await writeFile(a, "foo")
 
-      await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
+      await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false })
 
       const data = await readFileStr(b)
       expect(data).to.equal("foo")
@@ -119,7 +119,7 @@ describe("build staging helpers", () => {
       const c = join(tmpPath, "c")
       await writeFile(a, "foo")
       await symlink("a", b)
-      const res = await cloneFileAsync({ log, root: b, from: b, to: c, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, sourceRoot: b, from: b, to: c, statsHelper, allowDelete: false })
       const data = await readFileStr(c)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -136,7 +136,7 @@ describe("build staging helpers", () => {
         () =>
           cloneFileAsync({
             log,
-            root: a,
+            sourceRoot: a,
             from: join(a, symlPath),
             to: join(b, symlPath),
             statsHelper,
@@ -164,7 +164,7 @@ describe("build staging helpers", () => {
       for (const f of filesToClone) {
         const res = await cloneFileAsync({
           log,
-          root: a,
+          sourceRoot: a,
           from: join(a, f),
           to: join(b, f),
           statsHelper,
@@ -188,7 +188,7 @@ describe("build staging helpers", () => {
       await symlink("dir", dirLink)
       await writeFile(a, "foo")
 
-      const res = await cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false })
+      const res = await cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false })
       const data = await readFileStr(b)
       expect(res.skipped).to.be.false
       expect(data).to.equal("foo")
@@ -199,7 +199,7 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await ensureDir(a)
 
-      await expectError(() => cloneFileAsync({ log, root: a, from: a, to: b, statsHelper, allowDelete: false }), {
+      await expectError(() => cloneFileAsync({ log, sourceRoot: a, from: a, to: b, statsHelper, allowDelete: false }), {
         contains: `Error while copying from '${a}' to '${b}': Source is neither a symbolic link, nor a file`,
       })
     })


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Allows using relative symlinks to directories and files when using build staging.

The goal is to reproduce symlinks in the target directory as-is, without having to resolve them.
The user would be responsible for making sure that both the relative symlink as well as the target
directory are included in the action.

If the symlink points to a file or directory outside the actions's source path, this throws an
error.

To avoid this becoming a breaking change, we keep the old behaviour if the symlink points to a
file. In that case, we resolve the symlink and copy the target file. If the target file is outside
 the action's source or build directory, log a warning.

In a future 0.14 release of Garden, we should remove that branch, only reproduce symlinks (without
resolving them recursively) and
throw an error if the link is out of bounds.



**Which issue(s) this PR fixes**:

Fixes #2382
