### PR TITLE
fix(template): avoid premature `disabled` flag evaluation on actions

### DIFF
--- a/core/src/config/template-contexts/actions.ts
+++ b/core/src/config/template-contexts/actions.ts
@@ -19,7 +19,6 @@ import { ConfigContext, ErrorContext, ParentContext, schema, TemplateContext } f
 import { exampleVersion, OutputConfigContext } from "./module.js"
 import { TemplatableConfigContext } from "./project.js"
 import { DOCS_BASE_URL } from "../../constants.js"
-import type { WorkflowConfig } from "../workflow.js"
 import { styles } from "../../logger/styles.js"
 
 function mergeVariables({ garden, variables }: { garden: Garden; variables: DeepPrimitiveMap }): DeepPrimitiveMap {
@@ -64,7 +63,7 @@ class ActionConfigThisContext extends ConfigContext {
 
 interface ActionConfigContextParams {
   garden: Garden
-  config: ActionConfig | WorkflowConfig
+  config: ActionConfig
   thisContextParams: ActionConfigThisContextParams
   variables: DeepPrimitiveMap
 }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1522,10 +1522,16 @@ export class Garden {
     }
 
     const context = new TemplatableConfigContext(this, config)
-    // Inject action's variables
-    context.variables = context.var = {
-      ...context.variables,
-      ...config.variables,
+    // Hack: deny variables contexts here, because those have not been fully resolved yet.
+    const deniedContexts = ["var", "variables"]
+    for (const deniedContext of deniedContexts) {
+      Object.defineProperty(context, "var", {
+        get: () => {
+          throw new ConfigurationError({
+            message: `If you have duplicate action names, the ${styles.accent("`disabled`")} flag cannot depend on the ${styles.accent(`\`${deniedContext}\``)} context.`,
+          })
+        },
+      })
     }
 
     return resolveTemplateString({
@@ -1543,10 +1549,11 @@ export class Garden {
     const key = actionReferenceToString(config)
     const existing = this.actionConfigs[config.kind][config.name]
 
-    // Resolve the actual values of the `disabled` flag
-    config.disabled = this.evaluateDisabledFlag(config)
-
     if (existing) {
+      // Resolve the actual values of the `disabled` flag
+      config.disabled = this.evaluateDisabledFlag(config)
+      existing.disabled = this.evaluateDisabledFlag(existing)
+
       if (actionIsDisabled(config, this.environmentName)) {
         this.log.silly(
           () => `Skipping action ${key} because it is disabled and another action with the same key exists`

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1525,7 +1525,7 @@ export class Garden {
     // Hack: deny variables contexts here, because those have not been fully resolved yet.
     const deniedContexts = ["var", "variables"]
     for (const deniedContext of deniedContexts) {
-      Object.defineProperty(context, "var", {
+      Object.defineProperty(context, deniedContext, {
         get: () => {
           throw new ConfigurationError({
             message: `If you have duplicate action names, the ${styles.accent("`disabled`")} flag cannot depend on the ${styles.accent(`\`${deniedContext}\``)} context.`,

--- a/core/test/data/test-projects/disabled-action-with-var-context/project.garden.yml
+++ b/core/test/data/test-projects/disabled-action-with-var-context/project.garden.yml
@@ -1,0 +1,10 @@
+apiVersion: garden.io/v1
+kind: Project
+name: disabled-action-with-var-context
+defaultEnvironment: local
+environments:
+  - name: local
+  - name: remote
+providers:
+  - name: exec
+    environments: [ local, remote ]

--- a/core/test/data/test-projects/disabled-action-with-var-context/runs.garden.yml
+++ b/core/test/data/test-projects/disabled-action-with-var-context/runs.garden.yml
@@ -3,7 +3,6 @@ name: run-script
 type: exec
 var:
   foo: bar
-disabled: "${var.foo == 'bar'}"
 spec:
   command: ["sh", "-c", "echo 'Hello from local'"]
 
@@ -13,7 +12,7 @@ kind: Run
 name: run-script
 type: exec
 var:
-  foo: bar
+  $merge: ${actions.run["run-script"].var}
 disabled: "${var.foo != 'bar'}"
 spec:
   command: ["sh", "-c", "echo 'Hello from remote'"]

--- a/core/test/data/test-projects/disabled-action-with-var-context/runs.garden.yml
+++ b/core/test/data/test-projects/disabled-action-with-var-context/runs.garden.yml
@@ -1,0 +1,19 @@
+kind: Run
+name: run-script
+type: exec
+var:
+  foo: bar
+disabled: "${var.foo == 'bar'}"
+spec:
+  command: ["sh", "-c", "echo 'Hello from local'"]
+
+---
+
+kind: Run
+name: run-script
+type: exec
+var:
+  foo: bar
+disabled: "${var.foo != 'bar'}"
+spec:
+  command: ["sh", "-c", "echo 'Hello from remote'"]

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3096,7 +3096,6 @@ describe("Garden", () => {
         kind: "Run",
         type: "exec",
         name: runNameA,
-        disabled: false,
         spec: {
           command: ["echo", runNameA],
         },
@@ -3109,7 +3108,6 @@ describe("Garden", () => {
         kind: "Run",
         type: "exec",
         name: runNameB,
-        disabled: false,
         spec: {
           command: ["echo", runNameB],
         },

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3052,6 +3052,22 @@ describe("Garden", () => {
       expect(runScript.getConfig().spec.command).to.eql(["sh", "-c", "echo 'Hello from local'"])
     })
 
+    it("should deny variables context in disabled flag for actions with duplicate names", async () => {
+      const garden = await makeTestGarden(getDataDir("test-projects", "disabled-action-with-var-context"))
+
+      // There are 2 'run-script' actions defined in the project, one per environment.
+      await expectError(() => garden.getConfigGraph({ log: garden.log, emit: false }), {
+        contains: [
+          "If you have duplicate action names",
+          "the",
+          "disabled",
+          "flag cannot depend on the",
+          "variables",
+          "context",
+        ],
+      })
+    })
+
     it("should resolve actions from templated config templates", async () => {
       const garden = await makeTestGarden(getDataDir("test-projects", "config-templates-with-templating"))
       await garden.scanAndAddConfigs()

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3062,7 +3062,7 @@ describe("Garden", () => {
           "the",
           "disabled",
           "flag cannot depend on the",
-          "variables",
+          "var",
           "context",
         ],
       })


### PR DESCRIPTION
**What this PR does / why we need it**:

* Do early `disabled` flag evaluation only for actions with duplicate names.
* Deny the usage of `var` and `variables` contexts in early `disabled` flag evaluation.

The contexts `var` and `variables` contexts are not fully resolved at that stage.
That can lead to incorrectly resolved `disabled` flag values.

**Which issue(s) this PR fixes**:

Patches #4805, #5686, #6293, and #6406.

**Special notes for your reviewer**:
