### PR TITLE
improvement(git): print warnings on potential performance issues

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1867,7 +1867,7 @@ export async function resolveGardenParamsPartial(currentDirectory: string, opts:
   const gitHandler = new GitSubTreeHandler({
     projectRoot,
     gardenDirPath,
-    ignoreFile: defaultConfigFilename,
+    ignoreFile: defaultDotIgnoreFile,
     cache: treeCache,
   })
   const vcsInfo = await gitHandler.getPathInfo(log, projectRoot)

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -82,13 +82,7 @@ import {
 import type { Log } from "./logger/log-entry.js"
 import { EventBus } from "./events/events.js"
 import { Watcher } from "./watch.js"
-import {
-  findConfigPathsInPath,
-  getWorkingCopyId,
-  fixedProjectExcludes,
-  defaultConfigFilename,
-  defaultDotIgnoreFile,
-} from "./util/fs.js"
+import { findConfigPathsInPath, getWorkingCopyId, fixedProjectExcludes, defaultDotIgnoreFile } from "./util/fs.js"
 import type { Provider, GenericProviderConfig, ProviderMap } from "./config/provider.js"
 import { getAllProviderDependencyNames, defaultProvider } from "./config/provider.js"
 import { ResolveProviderTask } from "./tasks/resolve-provider.js"

--- a/core/src/vcs/git-sub-tree.ts
+++ b/core/src/vcs/git-sub-tree.ts
@@ -28,6 +28,7 @@ import type {
 } from "./vcs.js"
 import { normalize } from "path"
 import { styles } from "../logger/styles.js"
+import { access } from "node:fs/promises"
 
 const { lstat, pathExists, readlink, realpath, stat } = fsExtra
 
@@ -104,6 +105,20 @@ export class GitSubTreeHandler extends AbstractGitHandler {
           params.exclude || "(none)"
         }`
       )
+
+    if (!this.ignoreFile) {
+      gitLog.warn(
+        `Ignore file is not specified. This can slow down the git scan performance. Consider specifying ${styles.accent("dotIgnoreFile")} field of the project-level Garden configuration file.`
+      )
+    }
+    const ignoreFileExists = await access(this.ignoreFile)
+      .then(() => true)
+      .catch(() => false)
+    if (!ignoreFileExists) {
+      gitLog.warn(
+        `Ignore file ${this.ignoreFile} is specified but does not exists. This can slow down the git scan performance. Consider creating the ignore file and specifying it in the ${styles.accent("dotIgnoreFile")} field of the project-level Garden configuration file.`
+      )
+    }
 
     try {
       const pathStats = await stat(path)


### PR DESCRIPTION
**What this PR does / why we need it**:

Print warning when Git scan performance can be slow:

* On a large number of untracked files. Every untracked file is hashed and that can slow down the scanning performance.
* On an undefined or missing `dotIgnoreFile`.
 
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
