### PR TITLE
refactor(git): avoid unnecessary Git handler creation

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -167,6 +167,7 @@ import { styles } from "./logger/styles.js"
 import { renderDuration } from "./logger/util.js"
 import { getCloudDistributionName, getCloudLogSectionName } from "./util/cloud.js"
 import { makeDocsLinkStyled } from "./docs/common.js"
+import { getPathInfo } from "./vcs/git.js"
 
 const defaultLocalAddress = "localhost"
 
@@ -1856,15 +1857,7 @@ export async function resolveGardenParamsPartial(currentDirectory: string, opts:
   const commandInfo = opts.commandInfo
 
   const treeCache = new TreeCache()
-
-  // Note: another VcsHandler is created later, this one is temporary
-  const gitHandler = new GitSubTreeHandler({
-    projectRoot,
-    gardenDirPath,
-    ignoreFile: defaultDotIgnoreFile,
-    cache: treeCache,
-  })
-  const vcsInfo = await gitHandler.getPathInfo(log, projectRoot)
+  const vcsInfo = await getPathInfo(log, projectRoot)
 
   // Since we iterate/traverse them before fully validating them (which we do after resolving template strings), we
   // validate that `config.environments` and `config.providers` are both arrays.

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -274,31 +274,7 @@ export abstract class AbstractGitHandler extends VcsHandler {
   }
 
   async getPathInfo(log: Log, path: string, failOnPrompt = false): Promise<VcsInfo> {
-    const git = new GitCli({ log, cwd: path, failOnPrompt })
-
-    const output: VcsInfo = {
-      branch: "",
-      commitHash: "",
-      originUrl: "",
-    }
-
-    try {
-      output.branch = await git.getBranchName()
-      output.commitHash = await git.getLastCommitHash()
-    } catch (err) {
-      if (err instanceof ChildProcessError && err.details.code !== 128) {
-        throw err
-      }
-    }
-
-    try {
-      output.originUrl = await git.getOriginUrl()
-    } catch (err) {
-      // Just ignore if not available
-      log.silly(`Tried to retrieve git remote.origin.url but encountered an error: ${err}`)
-    }
-
-    return output
+    return await getPathInfo(log, path, failOnPrompt)
   }
 }
 
@@ -396,4 +372,32 @@ export async function augmentGlobs(basePath: string, globs?: string[]): Promise<
       }
     })
   )
+}
+
+export async function getPathInfo(log: Log, path: string, failOnPrompt = false): Promise<VcsInfo> {
+  const git = new GitCli({ log, cwd: path, failOnPrompt })
+
+  const output: VcsInfo = {
+    branch: "",
+    commitHash: "",
+    originUrl: "",
+  }
+
+  try {
+    output.branch = await git.getBranchName()
+    output.commitHash = await git.getLastCommitHash()
+  } catch (err) {
+    if (err instanceof ChildProcessError && err.details.code !== 128) {
+      throw err
+    }
+  }
+
+  try {
+    output.originUrl = await git.getOriginUrl()
+  } catch (err) {
+    // Just ignore if not available
+    log.silly(`Tried to retrieve git remote.origin.url but encountered an error: ${err}`)
+  }
+
+  return output
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Extract `getPathInfo()` function as a standalone helper and use it directly instead of unnecessary `GitHandler` instance creation.

Also, move the logic of `getPathInfo()` helper to `GitCli` class, and retain the standalone helper function, because It can be used directly in the case above.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

A follow-up PR for #6455.