### PR TITLE
refactor: convert `Garden.treeCache` from class field to property

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -459,6 +459,10 @@ export class Garden {
     }
   }
 
+  /**
+   * We intentionally share the instance of the tree cache between Garden and VCS handler.
+   * Some code flows and legacy logic rely on that fact.
+   */
   get treeCache(): TreeCache {
     return this.vcs.cache
   }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -277,7 +277,6 @@ export class Garden {
   public readonly localConfigStore: LocalConfigStore
   public globalConfigStore: GlobalConfigStore
   public readonly vcs: VcsHandler
-  public readonly treeCache: TreeCache
   public events: EventBus
   private tools?: { [key: string]: PluginTool }
   public readonly configTemplates: { [name: string]: ConfigTemplateConfig }
@@ -375,7 +374,6 @@ export class Garden {
     const handlerCls = gitMode === "repo" ? GitRepoHandler : GitSubTreeHandler
 
     const treeCache = new TreeCache()
-    this.treeCache = treeCache
     this.vcs = new handlerCls({
       garden: this,
       projectRoot: params.projectRoot,
@@ -460,6 +458,10 @@ export class Garden {
       this.log.silly(() => "No OTEL collector configured, setting no-op exporter")
       configureNoOpExporter()
     }
+  }
+
+  get treeCache(): TreeCache {
+    return this.vcs.cache
   }
 
   static async factory<T extends typeof Garden>(

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -199,7 +199,6 @@ export interface GardenParams {
   vcsInfo: VcsInfo
   projectId?: string
   cloudDomain?: string
-  cache: TreeCache
   dotIgnoreFile: string
   proxy: ProxyConfig
   environmentName: string
@@ -364,7 +363,6 @@ export class Garden {
     this.forceRefresh = !!params.forceRefresh
     this.cloudApi = params.cloudApi || null
     this.commandInfo = params.opts.commandInfo
-    this.treeCache = params.cache
     this.isGarden = true
     this.configTemplates = {}
     this.emittedWarnings = new Set()
@@ -376,12 +374,14 @@ export class Garden {
     const gitMode = params.projectConfig.scan?.git?.mode || gardenEnv.GARDEN_GIT_SCAN_MODE
     const handlerCls = gitMode === "repo" ? GitRepoHandler : GitSubTreeHandler
 
+    const treeCache = new TreeCache()
+    this.treeCache = treeCache
     this.vcs = new handlerCls({
       garden: this,
       projectRoot: params.projectRoot,
       gardenDirPath: params.gardenDirPath,
       ignoreFile: params.dotIgnoreFile,
-      cache: params.cache,
+      cache: treeCache,
     })
 
     // Use the legacy build sync mode if

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -373,13 +373,12 @@ export class Garden {
     const gitMode = params.projectConfig.scan?.git?.mode || gardenEnv.GARDEN_GIT_SCAN_MODE
     const handlerCls = gitMode === "repo" ? GitRepoHandler : GitSubTreeHandler
 
-    const treeCache = new TreeCache()
     this.vcs = new handlerCls({
       garden: this,
       projectRoot: params.projectRoot,
       gardenDirPath: params.gardenDirPath,
       ignoreFile: params.dotIgnoreFile,
-      cache: treeCache,
+      cache: new TreeCache(),
     })
 
     // Use the legacy build sync mode if

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -170,8 +170,8 @@ export abstract class VcsHandler {
   protected readonly garden?: Garden
   protected readonly gardenDirPath: string
   protected readonly ignoreFile: string
-  protected readonly cache: TreeCache
   protected readonly profiler: Profiler
+  public readonly cache: TreeCache
 
   constructor(params: VcsHandlerParams) {
     this.garden = params.garden


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid keeping 2 different references to the same cache instance in `VcsHandler` and `Garden`.
Having `Garden.treeCache` as a property delegating to `VcsHandler.cache` makes it more clear.
Otherwise, it's not obvious that the cache instance in shared between 2 classes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

An alternative approach is to keep 2 independent cache instances for module versions and VCS files. Such attempt was taken in #6458.

That would not make the code simpler, because in some scenarios we need to `invalidateUp` or `invalidateDown` both caches synchronously. That would be error-prone, so let's keep the semantics as it is, and avoid more complex refactoring if that's not necessary.