### PR TITLE
perf(git): avoid unnecessary file hashing while config files detection

### DIFF
--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -135,7 +135,7 @@ export async function findConfigPathsInPath({
     log,
     filter: (f) => isConfigFilename(basename(f)),
     scanRoot: dir,
-    skipHashCalculation: true
+    skipHashCalculation: true,
   })
 
   return paths.map((f) => f.path)

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -135,6 +135,7 @@ export async function findConfigPathsInPath({
     log,
     filter: (f) => isConfigFilename(basename(f)),
     scanRoot: dir,
+    skipHashCalculation: true
   })
 
   return paths.map((f) => f.path)

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -135,7 +135,7 @@ export async function findConfigPathsInPath({
     log,
     filter: (f) => isConfigFilename(basename(f)),
     scanRoot: dir,
-    skipHashCalculation: true,
+    hashUntrackedFiles: false,
   })
 
   return paths.map((f) => f.path)

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -27,7 +27,7 @@ import { realpath } from "fs/promises"
 
 const { pathExists } = fsExtra
 
-type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt" | "skipHashCalculation">
+type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt" | "hashUntrackedFiles">
 
 interface GitRepoGetFilesParams extends GetFilesParams {
   scanFromProjectRoot: boolean
@@ -162,7 +162,7 @@ export class GitRepoHandler extends AbstractGitHandler {
       path: scanRoot,
       pathDescription: pathDescription || "repository",
       failOnPrompt,
-      skipHashCalculation: params.skipHashCalculation,
+      hashUntrackedFiles: params.hashUntrackedFiles,
     })
 
     const filesAtPath = fileTree.getFilesAtPath(path)

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -27,7 +27,7 @@ import { realpath } from "fs/promises"
 
 const { pathExists } = fsExtra
 
-type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt">
+type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt" | "skipHashCalculation">
 
 interface GitRepoGetFilesParams extends GetFilesParams {
   scanFromProjectRoot: boolean
@@ -162,6 +162,7 @@ export class GitRepoHandler extends AbstractGitHandler {
       path: scanRoot,
       pathDescription: pathDescription || "repository",
       failOnPrompt,
+      skipHashCalculation: params.skipHashCalculation,
     })
 
     const filesAtPath = fileTree.getFilesAtPath(path)

--- a/core/src/vcs/git-sub-tree.ts
+++ b/core/src/vcs/git-sub-tree.ts
@@ -163,14 +163,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
       return []
     }
 
-    const {
-      log,
-      path,
-      pathDescription = "directory",
-      filter,
-      failOnPrompt = false,
-      skipHashCalculation = false,
-    } = params
+    const { log, path, pathDescription = "directory", filter, failOnPrompt = false, hashUntrackedFiles = true } = params
 
     const gitLog = log
       .createLog({ name: "git" })
@@ -253,7 +246,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
             matchPath(join(submoduleRelPath, p), augmentedIncludes, augmentedExcludes) && (!filter || filter(p)),
           scanRoot: submodulePath,
           failOnPrompt,
-          skipHashCalculation,
+          hashUntrackedFiles,
         })
       })
     }
@@ -302,7 +295,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
           file: output,
           stats: undefined,
           modifiedFiles,
-          skipHashCalculation,
+          hashUntrackedFiles,
         })
       }
 
@@ -330,7 +323,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
                 file: output,
                 stats,
                 modifiedFiles,
-                skipHashCalculation,
+                hashUntrackedFiles,
               })
             } catch (err) {
               if (isErrnoException(err) && err.code === "ENOENT") {
@@ -344,7 +337,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
               file: output,
               stats,
               modifiedFiles,
-              skipHashCalculation,
+              hashUntrackedFiles,
             })
           }
         } else {
@@ -352,7 +345,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
             file: output,
             stats,
             modifiedFiles,
-            skipHashCalculation,
+            hashUntrackedFiles,
           })
         }
       } catch (err) {
@@ -497,12 +490,12 @@ async function ensureHash({
   file,
   stats,
   modifiedFiles,
-  skipHashCalculation,
+  hashUntrackedFiles,
 }: {
   file: VcsFile
   stats: fsExtra.Stats | undefined
   modifiedFiles: Set<string>
-  skipHashCalculation: boolean
+  hashUntrackedFiles: boolean
 }): Promise<VcsFile> {
   // If the file has not been modified, then it's either committed or untracked.
   if (!modifiedFiles.has(file.path)) {
@@ -512,7 +505,7 @@ async function ensureHash({
     }
 
     // Otherwise, the file is untracked.
-    if (skipHashCalculation) {
+    if (!hashUntrackedFiles) {
       // So we can skip its hash calculation if we don't need the hashes of untracked files.
       // Hashes can be skipped while scanning the FS for Garden config files.
       return file

--- a/core/src/vcs/git-sub-tree.ts
+++ b/core/src/vcs/git-sub-tree.ts
@@ -514,12 +514,13 @@ async function ensureHash({
 
   // Don't attempt to hash directories. Directories (which will only come up via symlinks btw)
   // will by extension be filtered out of the list.
-  if (stats && !stats.isDirectory()) {
-    const hash = await hashObject(stats, file.path)
-    if (hash !== "") {
-      file.hash = hash
-      return file
-    }
+  if (!stats || stats.isDirectory()) {
+    return file
+  }
+
+  const hash = await hashObject(stats, file.path)
+  if (hash !== "") {
+    file.hash = hash
   }
 
   return file

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -122,7 +122,7 @@ export interface GetFilesParams {
   filter?: (path: string) => boolean
   failOnPrompt?: boolean
   scanRoot: string | undefined
-  skipHashCalculation?: boolean
+  hashUntrackedFiles?: boolean
 }
 
 export interface BaseIncludeExcludeFiles {

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -122,6 +122,7 @@ export interface GetFilesParams {
   filter?: (path: string) => boolean
   failOnPrompt?: boolean
   scanRoot: string | undefined
+  skipHashCalculation?: boolean
 }
 
 export interface BaseIncludeExcludeFiles {

--- a/core/test/unit/src/commands/build.ts
+++ b/core/test/unit/src/commands/build.ts
@@ -22,6 +22,7 @@ import { taskResultOutputs, getAllTaskResults } from "../../../helpers.js"
 import type { ModuleConfig } from "../../../../src/config/module.js"
 import type { Log } from "../../../../src/logger/log-entry.js"
 import fsExtra from "fs-extra"
+
 const { writeFile } = fsExtra
 import { join } from "path"
 import type { ProcessCommandResult } from "../../../../src/commands/base.js"
@@ -324,10 +325,8 @@ describe("BuildCommand", () => {
     })
 
     it("should rebuild module if a deep dependency has been modified", async () => {
-      let garden = await getFreshTestGarden()
-
       const { result: result1 } = await buildCommand.action({
-        garden,
+        garden: await getFreshTestGarden(),
         ...defaultOpts,
         args: { names: ["aaa-service"] },
         opts: withDefaultGlobalOpts({ "watch": false, "force": true, "with-dependants": false }),
@@ -336,8 +335,6 @@ describe("BuildCommand", () => {
       const allResults1 = getAllTaskResults(result1!.graphResults!)
 
       await writeFile(join(projectPath, "C/file.txt"), "module c has been modified")
-
-      garden = await getFreshTestGarden()
 
       const { result: result2 } = await buildCommand.action({
         garden: await getFreshTestGarden(),


### PR DESCRIPTION
**What this PR does / why we need it**:

As it was mentioned in #5920, Garden Core calls `AbstractGitHandler.getFiles()` method twice:

* While looking for Garden config files
* While actions/modules resolution

For big projects with a large amount of untracked files that can cause performance downgrade, because each calls trigger the hash calculation of the untracked files.

This PR makes a simple improvement by disabling hash-calculation in the config files detection phase.

It improves a performance only in a specific scenario, when too many files untracked by Git are included into the Garden.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The performance difference can be compared by running `validate -l3`  Garden command in the root of https://github.com/garden-io/garden repo with modified https://github.com/garden-io/garden/blob/main/.gardenignore file. Delete `node_modules` from `.gardenignore` before running.

**Before**

```console
ℹ git                       → [verbose] Scanning project root at /Users/vladimirvagaytsev/Repositories/garden
  → Includes: (none)
  → Excludes: (none)
ℹ git                       → [verbose] Ignoring symlink with absolute target at /Users/vladimirvagaytsev/Repositories/garden/core/test/data/test-projects/build-dir/symlink-absolute/symlink.txt
ℹ git                       → [verbose] Found 127156 files in project root /Users/vladimirvagaytsev/Repositories/garden (took 9.98 sec)
...
ℹ graph                     → Resolving actions and modules...
ℹ git                       → [verbose] Scanning module e2e-tests root at /Users/vladimirvagaytsev/Repositories/garden
  → Includes: (none)
  → Excludes: (none)
ℹ git                       → [verbose] Found 127156 files in module e2e-tests root /Users/vladimirvagaytsev/Repositories/garden (took 9.97 sec)
⚠ graph                     → Large number of files (127156) found in module e2e-tests. You may need to configure file exclusions.
See https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories for details.
✔ graph                     → Finished resolving graph (took 13.4 sec)
ℹ garden                    → Finished initializing Garden (took 25.1 sec)
```

**After**

```console
ℹ git                       → [verbose] Scanning project root at /Users/vladimirvagaytsev/Repositories/garden
  → Includes: (none)
  → Excludes: (none)
ℹ git                       → [verbose] Ignoring symlink with absolute target at /Users/vladimirvagaytsev/Repositories/garden/core/test/data/test-projects/build-dir/symlink-absolute/symlink.txt
ℹ git                       → [verbose] Found 127156 files in project root /Users/vladimirvagaytsev/Repositories/garden (took 1.73 sec)
...
ℹ graph                     → Resolving actions and modules...
ℹ git                       → [verbose] Scanning module e2e-tests root at /Users/vladimirvagaytsev/Repositories/garden
  → Includes: (none)
  → Excludes: (none)
ℹ git                       → [verbose] Found 127156 files in module e2e-tests root /Users/vladimirvagaytsev/Repositories/garden (took 10.79 sec)
⚠ graph                     → Large number of files (127156) found in module e2e-tests. You may need to configure file exclusions.
See https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories for details.
✔ graph                     → Finished resolving graph (took 15.8 sec)
ℹ garden                    → Finished initializing Garden (took 19.5 sec)
```