### PR TITLE
chore(deps): bump mockhttp to 3.15.2

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -231,7 +231,7 @@
     "google-auth-library": "^9.6.3",
     "md5": "^2.3.0",
     "mocha": "^10.6.0",
-    "mockttp": "^3.10.1",
+    "mockttp": "^3.15.2",
     "nock": "^12.0.3",
     "nodemon": "^3.0.3",
     "p-event": "^6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1284,7 +1284,7 @@
         "google-auth-library": "^9.6.3",
         "md5": "^2.3.0",
         "mocha": "^10.6.0",
-        "mockttp": "^3.10.1",
+        "mockttp": "^3.15.2",
         "nock": "^12.0.3",
         "nodemon": "^3.0.3",
         "p-event": "^6.0.1",
@@ -5372,7 +5372,9 @@
       }
     },
     "core/node_modules/mockttp": {
-      "version": "3.10.1",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/mockttp/-/mockttp-3.15.2.tgz",
+      "integrity": "sha512-/zvEHam3SiHX0uIbtoJsqe85SMYHq5x4Tqgl0E5rBrI7D714UhS+rCU+q6Q3fMWI+NlDyW2xJ3lploJ4cwI/Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5383,6 +5385,7 @@
         "@httptoolkit/websocket-stream": "^6.0.1",
         "@types/cors": "^2.8.6",
         "@types/node": "*",
+        "async-mutex": "^0.5.0",
         "base64-arraybuffer": "^0.1.5",
         "body-parser": "^1.15.2",
         "cacheable-lookup": "^6.0.0",
@@ -5391,13 +5394,14 @@
         "cors": "^2.8.4",
         "cors-gate": "^1.1.3",
         "cross-fetch": "^3.1.5",
-        "destroyable-server": "^1.0.0",
+        "destroyable-server": "^1.0.2",
         "express": "^4.14.0",
+        "fast-json-patch": "^3.1.1",
         "graphql": "^14.0.2 || ^15.5",
         "graphql-http": "^1.22.0",
         "graphql-subscriptions": "^1.1.0",
         "graphql-tag": "^2.12.6",
-        "http-encoding": "^1.5.1",
+        "http-encoding": "^2.0.1",
         "http2-wrapper": "^2.2.1",
         "https-proxy-agent": "^5.0.1",
         "isomorphic-ws": "^4.0.1",
@@ -5408,11 +5412,12 @@
         "pac-proxy-agent": "^7.0.0",
         "parse-multipart-data": "^1.4.0",
         "performance-now": "^2.1.0",
-        "portfinder": "1.0.28",
+        "portfinder": "^1.0.32",
         "read-tls-client-hello": "^1.0.0",
         "semver": "^7.5.3",
         "socks-proxy-agent": "^7.0.0",
         "typed-error": "^3.0.2",
+        "urlpattern-polyfill": "^8.0.0",
         "uuid": "^8.3.2",
         "ws": "^8.8.0"
       },
@@ -5675,6 +5680,23 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "core/node_modules/mockttp/node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "core/node_modules/mockttp/node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
     },
     "core/node_modules/mockttp/node_modules/base64-arraybuffer": {
       "version": "0.1.5",
@@ -6246,7 +6268,9 @@
       }
     },
     "core/node_modules/mockttp/node_modules/destroyable-server": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/destroyable-server/-/destroyable-server-1.0.2.tgz",
+      "integrity": "sha512-Ln7ZKRq+7kr/3e4FCI8+jAjRbqbdaET8/ZBoUVvn+sDSAD7zDZA5mykkPRcrjBcaGy+LOM4ntMlIp1NMj1kMxw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -7075,6 +7099,13 @@
         "node": ">= 0.8"
       }
     },
+    "core/node_modules/mockttp/node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "core/node_modules/mockttp/node_modules/graphql": {
       "version": "15.8.0",
       "dev": true,
@@ -7133,22 +7164,34 @@
       "license": "0BSD"
     },
     "core/node_modules/mockttp/node_modules/http-encoding": {
-      "version": "1.5.1",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-encoding/-/http-encoding-2.0.1.tgz",
+      "integrity": "sha512-vqe8NzlqqvDgcrwI2JTPAiB/6Zs1zTEVZNnTZBJeBhaejLGSpXQtNf87ifumq/P4X82G9E4WWfJMNmwb6vsuGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "brotli-wasm": "^1.1.0",
+        "brotli-wasm": "^3.0.0",
         "pify": "^5.0.0",
-        "zstd-codec": "^0.1.4"
+        "zstd-codec": "^0.1.5"
+      },
+      "engines": {
+        "node": ">=v18.0.0"
       }
     },
     "core/node_modules/mockttp/node_modules/http-encoding/node_modules/brotli-wasm": {
-      "version": "1.3.1",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
+      "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=v18.0.0"
+      }
     },
     "core/node_modules/mockttp/node_modules/http-encoding/node_modules/pify": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7159,7 +7202,9 @@
       }
     },
     "core/node_modules/mockttp/node_modules/http-encoding/node_modules/zstd-codec": {
-      "version": "0.1.4",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/zstd-codec/-/zstd-codec-0.1.5.tgz",
+      "integrity": "sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==",
       "dev": true,
       "license": "MIT"
     },
@@ -7245,6 +7290,8 @@
     },
     "core/node_modules/mockttp/node_modules/lodash": {
       "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7544,13 +7591,15 @@
       "license": "MIT"
     },
     "core/node_modules/mockttp/node_modules/portfinder": {
-      "version": "1.0.28",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.5"
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
       },
       "engines": {
         "node": ">= 0.12.0"
@@ -7558,6 +7607,8 @@
     },
     "core/node_modules/mockttp/node_modules/portfinder/node_modules/async": {
       "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7566,6 +7617,8 @@
     },
     "core/node_modules/mockttp/node_modules/portfinder/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7574,11 +7627,15 @@
     },
     "core/node_modules/mockttp/node_modules/portfinder/node_modules/debug/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "core/node_modules/mockttp/node_modules/portfinder/node_modules/mkdirp": {
       "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7695,6 +7752,13 @@
         "node": ">=6.0.0",
         "npm": ">=3.0.0"
       }
+    },
+    "core/node_modules/mockttp/node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "core/node_modules/mockttp/node_modules/uuid": {
       "version": "8.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5691,7 +5691,9 @@
       }
     },
     "core/node_modules/mockttp/node_modules/body-parser": {
-      "version": "1.20.2",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5703,7 +5705,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -5833,11 +5835,13 @@
       "license": "MIT"
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs": {
-      "version": "6.11.0",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -5848,6 +5852,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5865,6 +5871,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5883,6 +5891,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind/node_modules/es-define-property": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5894,6 +5904,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind/node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5902,6 +5914,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind/node_modules/set-function-length": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5918,6 +5932,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind/node_modules/set-function-length/node_modules/define-data-property": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5934,6 +5950,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind/node_modules/set-function-length/node_modules/gopd": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5945,6 +5963,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/call-bind/node_modules/set-function-length/node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5956,6 +5976,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5964,6 +5986,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/get-intrinsic": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5982,6 +6006,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/get-intrinsic/node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5990,6 +6016,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/get-intrinsic/node_modules/has-proto": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6001,6 +6029,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/get-intrinsic/node_modules/has-symbols": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6012,6 +6042,8 @@
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/get-intrinsic/node_modules/hasown": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6022,9 +6054,14 @@
       }
     },
     "core/node_modules/mockttp/node_modules/body-parser/node_modules/qs/node_modules/side-channel/node_modules/object-inspect": {
-      "version": "1.13.1",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6350,98 +6387,6 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser/node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser/node_modules/iconv-lite/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "core/node_modules/mockttp/node_modules/express/node_modules/body-parser/node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "core/node_modules/mockttp/node_modules/express/node_modules/content-disposition": {
       "version": "0.5.4",


### PR DESCRIPTION
**What this PR does / why we need it**:

This might help to create an auto-fix PR for one security alert from dependabot.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
