### PR TITLE
fix(sync): use right arch of `mutagen-agent` binary in `k8s-sync` image

### DIFF
--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -13,7 +13,7 @@ RUN MUTAGEN_VERSION="0.17.6" && \
     echo "2a383cb572a1bdad83f7c4be3cc4a541a58e6c9e11e326ee4cc2d0e14f9d003a ${mutagen_distr_name}" | sha256sum -c; \
   fi && \
   tar xzf ${mutagen_distr_name} --to-stdout mutagen-agents.tar.gz \
-  | tar xz --to-stdout linux_amd64 > /usr/local/bin/mutagen-agent && \
+  | tar xz --to-stdout linux_${TARGETARCH} > /usr/local/bin/mutagen-agent && \
   rm ${mutagen_distr_name} && \
   chmod +x /usr/local/bin/mutagen-agent && \
   mkdir -p /.garden && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

The `mutagen-agent` binary in arm64 builds of `k8s-sync` (and therefore also `k8s-util`) were the binaries for amd64 instead. This updates the Dockerfile for `k8s-sync` to copy the correct binary for `mutagen-agent`.
