### PR TITLE
chore(sync): use new `k8s-sync` and `k8s-util` images

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -33,7 +33,7 @@ export const defaultIngressClass = "nginx"
 export const k8sUtilImageNameLegacy: DockerImageWithDigest =
   "gardendev/k8s-util:0.5.7@sha256:522da245a5e6ae7c711aa94f84fc83f82a8fdffbf6d8bc48f4d80fee0e0e631b"
 export const k8sUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-util:0.6.1@sha256:e48d67309f97ac698bea4ae270d36884af1b6df0a2ac9a5c40e6acb27a2a6fb2"
+  "gardendev/k8s-util:0.6.2@sha256:f51e7ce040e2e23bc0eaa7216e4d976f13786d96773ef7b8c8f349e7a63d74e9"
 
 export function getK8sUtilImageName(): DockerImageWithDigest {
   return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sUtilImageName : k8sUtilImageNameLegacy
@@ -42,7 +42,7 @@ export function getK8sUtilImageName(): DockerImageWithDigest {
 export const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
   "gardendev/k8s-sync:0.1.5@sha256:28263cee5ac41acebb8c08f852c4496b15e18c0c94797d7a949a4453b5f91578"
 export const k8sSyncUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-sync:0.2.1@sha256:90a583672c63e61031a036900753cb6a8a6b0b7dc20909e2abcc079a1120127b"
+  "gardendev/k8s-sync:0.2.2@sha256:9ebcd84df4a3a55ae0ba95051cab521d249a4d2d7a15d04da7301c888c02347b"
 
 export const k8sSyncUtilContainerName = "garden-sync-init"
 

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
+FROM alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
 
 RUN apk add --no-cache wget
 

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -4,7 +4,7 @@ name: k8s-sync
 description: Used by the kubernetes provider for sync setup
 variables:
   image-name: gardendev/k8s-sync
-  release-tag: 0.2.1 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
+  release-tag: 0.2.2 # Starting from version 0.2.0 Garden uses original Mutagen binaries instead of own fork.
 spec:
   publishId: ${var.image-name}:${var.release-tag}
   localId: ${var.image-name}

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -5,8 +5,7 @@ description: Used by the kubernetes provider for build-related activities
 dependencies: [build.k8s-sync]
 variables:
   image-name: gardendev/k8s-util
-  #release-tag: 0.6.1 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
-  release-tag: dev
+  release-tag: 0.6.2 # Starting from version 0.6.0 k8s-util uses k8s-sync 0.2.x.
 spec:
   publishId: ${var.image-name}:${var.release-tag}
   localId: ${var.image-name}


### PR DESCRIPTION
**What this PR does / why we need it**:

A follow-up PR for #6465.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The new images were already built and pushed.