### PR TITLE
fix(core): avoid crash when using `copyFrom` together with symlinks

### DIFF
--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -140,8 +140,10 @@ export function cloneFile(
         }
       }
 
-      // if the target path exists, and it is a symlink, we must remove it first
-      if (toStats?.isSymbolicLink()) {
+      // if we are about to copy a symlink, and the target path exists, we must remove it first
+      // this allows for type changes (e.g. replacing a file with a symlink, then running garden build)
+      // at this point we know the target is a file or a symlink, so we can do this even if allowDelete=false (copy also overwrites the target)
+      if (fromStats.isSymbolicLink()) {
         return remove(to, (removeErr) => {
           if (removeErr) {
             return done(removeErr)

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -272,7 +272,7 @@ export async function scanDirectoryForClone(root: string, pattern?: string): Pro
     filter: (stats) => {
       // See if this is a file within a previously matched directory
       // Note: `stats.path` is always POSIX formatted, relative to `sourceRoot`
-      if (stats.isFile()) {
+      if (stats.isFile() || stats.isSymbolicLink()) {
         for (const dirPath of matchedDirectories) {
           if (stats.path.startsWith(dirPath + "/")) {
             // The file is in a matched directory. We need to map the target path, such that everything ahead of
@@ -286,7 +286,7 @@ export async function scanDirectoryForClone(root: string, pattern?: string): Pro
       if (mm.match(stats.path)) {
         if (stats.isDirectory()) {
           matchedDirectories.push(stats.path)
-        } else if (stats.isFile()) {
+        } else if (stats.isFile() || stats.isSymbolicLink()) {
           // When we match a file to the glob, we map it from the source path to just its basename under the target
           // directory. Again, this matches rsync behavior.
           mappedPaths.push([stats.path, basename(stats.path)])

--- a/core/src/vcs/git-sub-tree.ts
+++ b/core/src/vcs/git-sub-tree.ts
@@ -9,7 +9,7 @@
 import { Profile } from "../util/profiling.js"
 import { getStatsType, matchPath } from "../util/fs.js"
 import { isErrnoException } from "../exceptions.js"
-import { isAbsolute, join, normalize, relative, resolve } from "path"
+import { dirname, isAbsolute, join, normalize, relative, resolve } from "path"
 import fsExtra from "fs-extra"
 import PQueue from "p-queue"
 import { defer } from "../util/util.js"
@@ -29,7 +29,7 @@ import type {
 import { styles } from "../logger/styles.js"
 import type { Log } from "../logger/log-entry.js"
 
-const { lstat, pathExists, readlink, realpath, stat } = fsExtra
+const { pathExists, readlink, lstat } = fsExtra
 
 const submoduleErrorSuggestion = `Perhaps you need to run ${styles.underline(`git submodule update --recursive`)}?`
 
@@ -219,7 +219,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
 
         // Catch and show helpful message in case the submodule path isn't a valid directory
         try {
-          const pathStats = await stat(path)
+          const pathStats = await lstat(path)
 
           if (!pathStats.isDirectory()) {
             const pathType = getStatsType(pathStats)
@@ -304,24 +304,14 @@ export class GitSubTreeHandler extends AbstractGitHandler {
           if (isAbsolute(target)) {
             gitLog.verbose(`Ignoring symlink with absolute target at ${resolvedPath}`)
             return
-          } else if (target.startsWith("..")) {
-            try {
-              const realTarget = await realpath(resolvedPath)
-              const relPath = relative(path, realTarget)
-
-              if (relPath.startsWith("..")) {
-                gitLog.verbose(`Ignoring symlink pointing outside of ${pathDescription} at ${resolvedPath}`)
-                return
-              }
-              return ensureHash(output, stats, modifiedFiles)
-            } catch (err) {
-              if (isErrnoException(err) && err.code === "ENOENT") {
-                gitLog.verbose(`Ignoring dead symlink at ${resolvedPath}`)
-                return
-              }
-              throw err
-            }
           } else {
+            const realTarget = resolve(dirname(resolvedPath), target)
+            const relPath = relative(path, realTarget)
+
+            if (relPath.startsWith("..")) {
+              gitLog.verbose(`Ignoring symlink pointing outside of ${pathDescription} at ${resolvedPath}`)
+              return
+            }
             return ensureHash(output, stats, modifiedFiles)
           }
         } else {
@@ -420,7 +410,7 @@ export class GitSubTreeHandler extends AbstractGitHandler {
 
 async function isDirectory(path: string, gitLog: Log): Promise<boolean> {
   try {
-    const pathStats = await stat(path)
+    const pathStats = await lstat(path)
 
     if (!pathStats.isDirectory()) {
       gitLog.warn(`Expected directory at ${path}, but found ${getStatsType(pathStats)}.`)

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -23,7 +23,7 @@ import AsyncLock from "async-lock"
 import { isSha1 } from "../util/hashing.js"
 import { hashingStream } from "hasha"
 
-const { createReadStream, ensureDir, pathExists, readlink, stat } = fsExtra
+const { createReadStream, ensureDir, pathExists, readlink, lstat } = fsExtra
 
 export function getCommitIdFromRefList(refList: string[]): string {
   try {
@@ -393,7 +393,7 @@ export async function augmentGlobs(basePath: string, globs?: string[]): Promise<
 
       try {
         const path = joinWithPosix(basePath, pattern)
-        const stats = await stat(path)
+        const stats = await lstat(path)
         return stats.isDirectory() ? posix.join(pattern, "**", "*") : pattern
       } catch {
         return pattern

--- a/core/test/unit/src/build-staging/build-staging.ts
+++ b/core/test/unit/src/build-staging/build-staging.ts
@@ -177,6 +177,16 @@ describe("BuildStaging", () => {
       // second time
       await sync({ log, sourceRoot, targetRoot, withDelete: false })
       await assertIdentical(sourceRoot, targetRoot, expectedFiles)
+
+      // sync with pattern
+      targetRoot = join(tmpPath, "target3")
+      await ensureDir(targetRoot)
+      // first time
+      await sync({ log, sourceRoot, sourceRelPath: "*", targetRoot, withDelete: false })
+      await assertIdentical(sourceRoot, targetRoot, expectedFiles)
+      // second time
+      await sync({ log, sourceRoot, sourceRelPath: "*", targetRoot, withDelete: false })
+      await assertIdentical(sourceRoot, targetRoot, expectedFiles)
     })
 
     it("throws if source relative path is absolute", async () => {


### PR DESCRIPTION

**What this PR does / why we need it**:
This commit resolves an error "Failed copying a file because a directory
exists at the target path" which was a regression introduced in #6430.

**Which issue(s) this PR fixes**:

Fixes #6456

