### PR TITLE
fix: misleading warning message when cloud session is expired

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -262,10 +262,10 @@ ${renderCommands(commands)}
         } catch (err) {
           if (err instanceof CloudApiTokenRefreshError) {
             log.warn(dedent`
-              Unable to authenticate against ${distroName} with the current session token.
-              Command results for this command run will not be available in ${distroName}. If this not a
-              ${distroName} project you can ignore this warning. Otherwise, please try logging out with
-              \`garden logout\` and back in again with \`garden login\`.
+              The current ${distroName} session is not valid or it's expired.
+              Command results for this command run will not be available in ${distroName}.
+              To avoid losing command results and logs, please try logging back in by running \`garden login\`.
+              If this not a ${distroName} project you can ignore this warning.
             `)
 
             // Project is configured for cloud usage => fail early to force re-auth


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
