### PR TITLE
chore(ci): bump tools versions in circleci-runner image

### DIFF
--- a/images/circleci-runner/Dockerfile
+++ b/images/circleci-runner/Dockerfile
@@ -1,11 +1,11 @@
 #### gcloud base image ####
-FROM google/cloud-sdk:487.0.0@sha256:3827f5af870bb9aed17b0ab6d841381798df7344c2b1535818a4e731d3daaed5 as gcloud
+FROM google/cloud-sdk:495.0.0@sha256:19e21718258a1073f19bba970f6b22bcdc4b869d7b679bdddeb50985e69e75eb as gcloud
 
 #### ghr utility ####
 FROM cibuilds/github:0.13.0@sha256:a247975213771f2f4c61b806771ef6c22b225fdc46558738b7c935517c0dcdd4 AS ghr
 
 #### ldid utility ####
-FROM cimg/node:22.6.0@sha256:a2353f631cd52030a0de3bc4e59093cf4eaff02ae46bbbb9261581dd3e49d2d2 as ldid
+FROM cimg/node:22.9.0@sha256:a3571fd13f364b972a574a29bbf69d77af2403fc4abea9e9edce9c14bf37b4e3 as ldid
 
 RUN sudo apt-get update && sudo apt-get install -qq -y --no-install-recommends \
   git \
@@ -22,7 +22,7 @@ RUN cd /tmp && \
   sudo cp -f ./ldid /usr/local/bin/ldid
 
 #### main ####
-FROM cimg/node:22.6.0@sha256:a2353f631cd52030a0de3bc4e59093cf4eaff02ae46bbbb9261581dd3e49d2d2
+FROM cimg/node:22.9.0@sha256:a3571fd13f364b972a574a29bbf69d77af2403fc4abea9e9edce9c14bf37b4e3
 
 # install system deps
 RUN sudo apt-get update && sudo apt-get -y install rsync parallel python3 curl
@@ -48,8 +48,8 @@ RUN sudo ln -s /usr/lib/google-cloud-sdk/bin/* /usr/local/bin/ \
   && cd / && gcloud version # make sure it works
 
 # install kubectl
-RUN wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.30.2/bin/linux/amd64/kubectl && \
-  echo "c6e9c45ce3f82c90663e3c30db3b27c167e8b19d83ed4048b61c1013f6a7c66e  kubectl" | sha256sum -c && \
+RUN wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.30.4/bin/linux/amd64/kubectl && \
+  echo "2ffd023712bbc1a9390dbd8c0c15201c165a69d394787ef03eda3eccb4b9ac06  kubectl" | sha256sum -c && \
   chmod +x kubectl && \
   sudo mv kubectl /usr/local/bin/ && \
   cd / && kubectl version --client=true # make sure it works

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -4,7 +4,7 @@ name: circleci-runner
 description: Used for the core pipeline in CircleCI
 variables:
   image-name: gardendev/circleci-runner
-  release-tag: 22.6.0-0
+  release-tag: 22.9.0-0
 spec:
   publishId: ${var.image-name}:${var.release-tag}
   localId: ${var.image-name}


### PR DESCRIPTION
Updated tools:
* cimg/node 22.9.0
* google/cloud-sdk 495.0.0
* kubectl 1.30.4

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
