### PR TITLE
fix(pulumi): prevent existing pulumi configs from being overwritten

### DIFF
--- a/plugins/pulumi/src/helpers.ts
+++ b/plugins/pulumi/src/helpers.ts
@@ -301,9 +301,6 @@ export async function applyConfig(params: PulumiParams & { previewDirPath?: stri
   }
   vars = <DeepPrimitiveMap>merge(vars, pulumiVars || {})
   log.debug(`merged vars: ${JSON.stringify(vars, null, 2)}`)
-  // TODO [!!!] Note the fact that this overwrites any existing pulumi config contents
-  //            instead of merging them in in the PR, since I'm not sure if that
-  //            behaviour is intentional or not.
   stackConfig.config = vars
 
   stackConfig.backend = { url: params.provider.config.backendURL }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR addresses an issue where existing pulumi config files fail to be read in, and are then overwritten by Garden, essentially deleting all existing config from the file.

**Special notes for your reviewer**:

In `applyConfig()`, there's this line here that overwrites the pulumi config that gets read in:

```python
stackConfig.config = vars
```

The docs for the pulumi provider and actions aren't clear about how existing pulumi config files are handled, so I'm not sure if this is intentional or not, but I'm pretty sure this is meant to merge these values into the existing pulumi config, rather than overwriting it. Since I wasn't certain about whether or not this was intentional, I left it alone and just called it out here.
