### PR TITLE
fix(k8s): add imagePullSecret from kubernetes provider to sync init container

### DIFF
--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -72,6 +72,7 @@ import { gardenEnv } from "../../constants.js"
 import { styles } from "../../logger/styles.js"
 import { commandListToShellScript } from "../../util/escape.js"
 import { toClearText } from "../../util/secrets.js"
+import type { V1Container } from "@kubernetes/client-node"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 
@@ -462,7 +463,7 @@ export async function configureSyncMode({
     }
     const k8sSyncUtilImageName = getK8sSyncUtilImageName()
     if (!podSpec.initContainers.find((c) => c.image === k8sSyncUtilImageName)) {
-      const initContainer = {
+      const initContainer: V1Container = {
         name: k8sSyncUtilContainerName,
         image: k8sSyncUtilImageName,
         command: [
@@ -475,6 +476,7 @@ export async function configureSyncMode({
         volumeMounts: [gardenVolumeMount],
       }
       podSpec.initContainers.push(initContainer)
+      podSpec.imagePullSecrets = provider.config.imagePullSecrets
     }
 
     if (!targetContainer.volumeMounts) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #6525

**Special notes for your reviewer**:
