### PR TITLE
chore(k8s): push imagePullSecrets to existing for sync mode

### DIFF
--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -461,6 +461,9 @@ export async function configureSyncMode({
     if (!podSpec.initContainers) {
       podSpec.initContainers = []
     }
+    if (!podSpec.imagePullSecrets) {
+      podSpec.imagePullSecrets = []
+    }
     const k8sSyncUtilImageName = getK8sSyncUtilImageName()
     if (!podSpec.initContainers.find((c) => c.image === k8sSyncUtilImageName)) {
       const initContainer: V1Container = {
@@ -476,7 +479,7 @@ export async function configureSyncMode({
         volumeMounts: [gardenVolumeMount],
       }
       podSpec.initContainers.push(initContainer)
-      podSpec.imagePullSecrets = provider.config.imagePullSecrets
+      podSpec.imagePullSecrets.push(...provider.config.imagePullSecrets)
     }
 
     if (!targetContainer.volumeMounts) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Was thinking about this again and since the `imagePullSecrets` are added on the existing pod spec which could also come from a kubernetes or helm action we need to make sure we don't overwrite any `imagePullSecrets` that were specified on the pod spec from the original manifests since kuberenetes and helm type actions don't automatically use the provider `imagePullSecrets`.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
