### PR TITLE
fix: fail-safe dependency config lookup in action config processing

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1455,7 +1455,7 @@ export class Garden {
       const workflowsFromTemplates = renderResults.flatMap((r) => r.configs.filter(isWorkflowConfig))
 
       if (renderConfigs.length) {
-        this.log.silly(
+        this.log.debug(
           `Rendered ${actionsFromTemplates.length} actions, ${modulesFromTemplates.length} modules, and ${workflowsFromTemplates.length} workflows from templates`
         )
       }
@@ -1543,7 +1543,11 @@ export class Garden {
    * Add an action config to the context, after validating and calling the appropriate configure plugin handler.
    */
   protected addActionConfig(config: BaseActionConfig) {
-    this.log.silly(() => `Adding action config for ${config.kind} ${config.name}`)
+    const parentTemplateName = config.internal.templateName
+    this.log.silly(
+      () =>
+        `Adding action config for ${config.kind} ${styles.highlight(config.name)} ${!!parentTemplateName ? `(from template ${styles.highlight(parentTemplateName)})` : ""}`
+    )
     const key = actionReferenceToString(config)
     const existing = this.actionConfigs[config.kind][config.name]
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -996,7 +996,7 @@ function dependenciesFromActionConfig({
         if (weirdActionNames.has(name)) {
           const highlightedWeirdName = styles.highlight(`"${name}"`)
           log.warn(
-            `Found a dependency with suspicious name ${highlightedWeirdName}. It looks like it was rendered as ${highlightedWeirdName} string from the configuration template ${styles.highlight(config.internal.templateName)}`
+            `Found a dependency with suspicious name ${highlightedWeirdName}. It was rendered from the configuration template ${styles.highlight(config.internal.templateName)}. The template expression for this action name may have resolved to null or undefined, which is probably a mistake. Please take a look at the template expression in question.`
           )
           return undefined
         }

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -985,17 +985,19 @@ function dependenciesFromActionConfig({
       const depKey = actionReferenceToString(d)
       const depConfig = configsByKey[depKey]
 
-      // When an action has one of these names, 99% of the time this indicates a user error in a templated action name
-      // from a config template (e.g. an expression evaluating to null or undefined,
+      // When a dependency config is missing here, 99% of the time this indicates a user error in a templated action name
+      // from a config template (e.g. an expression or part of an expression evaluating to null or undefined,
       // and this then being interpolated into the string value for the action name).
       if (!depConfig) {
-        const highlightedWeirdName = styles.highlight(`"${name}"`)
+        const highlightedMissingName = styles.highlight(`"${name}"`)
+        const configTemplateName = styles.highlight(config.internal.templateName)
         log.warn(
           deline`
-          Found a dependency with suspicious name ${highlightedWeirdName}.
-          It was rendered from the configuration template ${styles.highlight(config.internal.templateName)}.
-          The template expression for this action name may have resolved to null or undefined, which is probably a mistake.
-          Please take a look at the template expression in question.
+          Found a missing dependency with name ${highlightedMissingName}.
+          It was rendered from the configuration template ${configTemplateName}.
+          The template expression for this action name (or part of it) may have unintentionally resolved to null or
+          undefined. Please take a look at the template expression in question in the configuration
+          for ${configTemplateName}.
           `
         )
         return undefined


### PR DESCRIPTION
**What this PR does / why we need it**:

Handle potentially wrong action names produced from configuration templates,
when a templated action name from a config template is evaluated to `null` or `undefined`.
Such resolved template values are interpolated into the string values for the action names.
This is how the current template resolution engine works.

We should skip such dependencies instead of failing fast with an error.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
