### PR TITLE
feat(k8s): allow using registry mirror for utility images

### DIFF
--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -15,7 +15,7 @@ import { KubeApi } from "../api.js"
 import type { Log } from "../../../logger/log-entry.js"
 import { containerHelpers } from "../../container/helpers.js"
 import { PodRunner } from "../run.js"
-import { dockerAuthSecretKey, getK8sUtilImageName, systemDockerAuthSecretName } from "../constants.js"
+import { dockerAuthSecretKey, getK8sUtilImagePath, systemDockerAuthSecretName } from "../constants.js"
 import { getAppNamespace, getSystemNamespace } from "../namespace.js"
 import { randomString } from "../../../util/string.js"
 import type { PluginContext } from "../../../plugin-context.js"
@@ -155,7 +155,7 @@ export async function pullBuild(params: PullParams) {
         containers: [
           {
             name: "main",
-            image: getK8sUtilImageName(),
+            image: getK8sUtilImagePath(ctx.provider.config.utilImageRegistryDomain),
             command: ["sleep", "" + (imagePullTimeoutSeconds + 10)],
             volumeMounts: [
               {

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -40,7 +40,7 @@ import type { SyncDefaults } from "./sync.js"
 import { syncDefaultsSchema } from "./sync.js"
 import { KUBECTL_DEFAULT_TIMEOUT } from "./kubectl.js"
 import { DOCS_BASE_URL } from "../../constants.js"
-import { defaultKanikoImageName, defaultSystemNamespace } from "./constants.js"
+import { defaultKanikoImageName, defaultUtilImageRegistryDomain, defaultSystemNamespace } from "./constants.js"
 import type { LocalKubernetesClusterType } from "./local/config.js"
 import type { EphemeralKubernetesClusterType } from "./ephemeral/config.js"
 
@@ -125,6 +125,7 @@ export interface ClusterBuildkitCacheConfig {
 export type KubernetesClusterType = LocalKubernetesClusterType | EphemeralKubernetesClusterType
 
 export interface KubernetesConfig extends BaseProviderConfig {
+  utilImageRegistryDomain: string
   buildMode: ContainerBuildMode
   clusterBuildkit?: {
     cache: ClusterBuildkitCacheConfig[]
@@ -407,9 +408,20 @@ const buildkitCacheConfigurationSchema = () =>
       ),
   })
 
+export const utilImageRegistryDomainSpec = joi.string().default(defaultUtilImageRegistryDomain).description(dedent`
+    The container registry domain that should be used for pulling Garden utility images (such as the
+    image used in the Kubernetes sync utility Pod).
+
+    If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+    will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+
+    Otherwise the utility images are pulled directly from Docker Hub by default.
+  `)
+
 export const kubernetesConfigBase = () =>
   providerConfigBaseSchema()
     .keys({
+      utilImageRegistryDomain: utilImageRegistryDomainSpec,
       buildMode: joi
         .string()
         .valid("local-docker", "kaniko", "cluster-buildkit")

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -10,9 +10,6 @@ import type { DockerImageWithDigest } from "../../util/string.js"
 import { gardenEnv } from "../../constants.js"
 import { makeDocsLinkPlain } from "../../docs/common.js"
 
-export const rsyncPortName = "garden-rsync"
-export const buildSyncVolumeName = `garden-sync`
-
 export const MAX_CONFIGMAP_DATA_SIZE = 1024 * 1024 // max ConfigMap data size is 1MB
 // max ConfigMap data size is 1MB but we need to factor in overhead, plus in some cases the log is duplicated in
 // the outputs field, so we cap at 250kB.
@@ -24,50 +21,85 @@ export const PROXY_CONTAINER_SSH_TUNNEL_PORT_NAME = "garden-prx-ssh"
 
 export const systemDockerAuthSecretName = "builder-docker-config"
 export const dockerAuthSecretKey = ".dockerconfigjson"
-
 export const skopeoDaemonContainerName = "util"
-
 export const defaultIngressClass = "nginx"
-
-// Docker images that Garden ships with
-export const k8sUtilImageNameLegacy: DockerImageWithDigest =
-  "gardendev/k8s-util:0.5.7@sha256:522da245a5e6ae7c711aa94f84fc83f82a8fdffbf6d8bc48f4d80fee0e0e631b"
-export const k8sUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-util:0.6.2@sha256:f51e7ce040e2e23bc0eaa7216e4d976f13786d96773ef7b8c8f349e7a63d74e9"
-
-export function getK8sUtilImageName(): DockerImageWithDigest {
-  return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sUtilImageName : k8sUtilImageNameLegacy
-}
-
-export const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
-  "gardendev/k8s-sync:0.1.5@sha256:28263cee5ac41acebb8c08f852c4496b15e18c0c94797d7a949a4453b5f91578"
-export const k8sSyncUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-sync:0.2.2@sha256:9ebcd84df4a3a55ae0ba95051cab521d249a4d2d7a15d04da7301c888c02347b"
-
+export const rsyncPortName = "garden-rsync"
+export const buildSyncVolumeName = `garden-sync`
 export const k8sSyncUtilContainerName = "garden-sync-init"
-
-export function getK8sSyncUtilImageName(): DockerImageWithDigest {
-  return gardenEnv.GARDEN_ENABLE_NEW_SYNC ? k8sSyncUtilImageName : k8sSyncUtilImageNameLegacy
-}
-
-export const k8sReverseProxyImageName: DockerImageWithDigest =
-  "gardendev/k8s-reverse-proxy:0.1.1@sha256:2dff2275fc8c32cc0eba50eebd7ace6fdb007d9b3f4bd48d94355057324b2394"
-export const buildkitImageName: DockerImageWithDigest =
-  "gardendev/buildkit:v-0.16.0@sha256:ee7aa12e6fdba79ee9838631995fa7c5a12aba9091a0753dedfe891d430c8182"
-export const buildkitRootlessImageName: DockerImageWithDigest =
-  "gardendev/buildkit:v-0.16.0-rootless@sha256:634506c016691b079e44614c5de65e0b0d4a98070304f6089e15f0279bfca411"
-export const defaultKanikoImageName: DockerImageWithDigest =
-  "gcr.io/kaniko-project/executor:v1.11.0-debug@sha256:32ba2214921892c2fa7b5f9c4ae6f8f026538ce6b2105a93a36a8b5ee50fe517"
-export const defaultGardenIngressControllerDefaultBackendImage: DockerImageWithDigest =
-  "gardendev/default-backend:v0.1@sha256:1b02920425eea569c6be53bb2e3d2c1182243212de229be375da7a93594498cf"
-export const defaultGardenIngressControllerImage: DockerImageWithDigest =
-  "k8s.gcr.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2"
-export const defaultGardenIngressControllerKubeWebhookCertGenImage: DockerImageWithDigest =
-  "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
-
 export const buildkitDeploymentName = "garden-buildkit"
 export const buildkitContainerName = "buildkitd"
 export const defaultSystemNamespace = "garden-system"
 
 export const syncGuideRelPath = "guides/code-synchronization"
 export const syncGuideLink = makeDocsLinkPlain(syncGuideRelPath)
+
+export const defaultUtilImageRegistryDomain = "docker.io"
+
+function makeImagePath({
+  imageName,
+  registryDomain,
+}: {
+  imageName: DockerImageWithDigest
+  registryDomain: string
+}): DockerImageWithDigest {
+  const domainWithoutTrailingSlash = registryDomain.replace(/\/$/, "")
+
+  return `${domainWithoutTrailingSlash}/${imageName}`
+}
+
+export function getK8sUtilImagePath(registryDomain: string): DockerImageWithDigest {
+  const k8sUtilImageNameLegacy: DockerImageWithDigest =
+    "gardendev/k8s-util:0.5.7@sha256:522da245a5e6ae7c711aa94f84fc83f82a8fdffbf6d8bc48f4d80fee0e0e631b"
+  const k8sUtilImageName: DockerImageWithDigest =
+    "gardendev/k8s-util:0.6.2@sha256:f51e7ce040e2e23bc0eaa7216e4d976f13786d96773ef7b8c8f349e7a63d74e9"
+
+  return gardenEnv.GARDEN_ENABLE_NEW_SYNC
+    ? makeImagePath({ imageName: k8sUtilImageName, registryDomain })
+    : makeImagePath({ imageName: k8sUtilImageNameLegacy, registryDomain })
+}
+
+export function getK8sSyncUtilImagePath(registryDomain: string): DockerImageWithDigest {
+  const k8sSyncUtilImageName: DockerImageWithDigest =
+    "gardendev/k8s-sync:0.2.2@sha256:9ebcd84df4a3a55ae0ba95051cab521d249a4d2d7a15d04da7301c888c02347b"
+  const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
+    "gardendev/k8s-sync:0.1.5@sha256:28263cee5ac41acebb8c08f852c4496b15e18c0c94797d7a949a4453b5f91578"
+
+  return gardenEnv.GARDEN_ENABLE_NEW_SYNC
+    ? makeImagePath({ imageName: k8sSyncUtilImageName, registryDomain })
+    : makeImagePath({ imageName: k8sSyncUtilImageNameLegacy, registryDomain })
+}
+
+export function getK8sReverseProxyImagePath(registryDomain: string): DockerImageWithDigest {
+  const k8sReverseProxyImageName: DockerImageWithDigest =
+    "gardendev/k8s-reverse-proxy:0.1.1@sha256:2dff2275fc8c32cc0eba50eebd7ace6fdb007d9b3f4bd48d94355057324b2394"
+
+  return makeImagePath({ imageName: k8sReverseProxyImageName, registryDomain })
+}
+export function getBuildkitImagePath(registryDomain: string): DockerImageWithDigest {
+  const buildkitImageName: DockerImageWithDigest =
+    "gardendev/buildkit:v-0.16.0@sha256:ee7aa12e6fdba79ee9838631995fa7c5a12aba9091a0753dedfe891d430c8182"
+
+  return makeImagePath({ imageName: buildkitImageName, registryDomain })
+}
+
+export function getBuildkitRootlessImagePath(registryDomain: string): DockerImageWithDigest {
+  const buildkitRootlessImageName: DockerImageWithDigest =
+    "gardendev/buildkit:v-0.16.0-rootless@sha256:634506c016691b079e44614c5de65e0b0d4a98070304f6089e15f0279bfca411"
+
+  return makeImagePath({ imageName: buildkitRootlessImageName, registryDomain })
+}
+export function getDefaultGardenIngressControllerDefaultBackendImagePath(
+  registryDomain: string
+): DockerImageWithDigest {
+  const defaultGardenIngressControllerDefaultBackendImage: DockerImageWithDigest =
+    "gardendev/default-backend:v0.1@sha256:1b02920425eea569c6be53bb2e3d2c1182243212de229be375da7a93594498cf"
+
+  return makeImagePath({ imageName: defaultGardenIngressControllerDefaultBackendImage, registryDomain })
+}
+
+export const defaultKanikoImageName: DockerImageWithDigest =
+  "gcr.io/kaniko-project/executor:v1.11.0-debug@sha256:32ba2214921892c2fa7b5f9c4ae6f8f026538ce6b2105a93a36a8b5ee50fe517"
+export const defaultGardenIngressControllerImage: DockerImageWithDigest =
+  "k8s.gcr.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2"
+export const defaultGardenIngressControllerKubeWebhookCertGenImage: DockerImageWithDigest =
+  "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -13,9 +13,9 @@ import {
   buildSyncVolumeName,
   buildkitContainerName,
   buildkitDeploymentName,
-  buildkitImageName,
-  buildkitRootlessImageName,
   dockerAuthSecretKey,
+  getBuildkitImagePath,
+  getBuildkitRootlessImagePath,
 } from "../../constants.js"
 import { KubeApi } from "../../api.js"
 import type { KubernetesDeployment } from "../../types.js"
@@ -472,7 +472,7 @@ export function getBuildkitDeployment(
           containers: [
             {
               name: buildkitContainerName,
-              image: buildkitImageName,
+              image: getBuildkitImagePath(provider.config.utilImageRegistryDomain),
               args: ["--addr", "unix:///run/buildkit/buildkitd.sock"],
               readinessProbe: {
                 exec: {
@@ -538,7 +538,7 @@ export function getBuildkitDeployment(
       "container.apparmor.security.beta.kubernetes.io/buildkitd": "unconfined",
       "container.seccomp.security.alpha.kubernetes.io/buildkitd": "unconfined",
     }
-    buildkitContainer.image = buildkitRootlessImageName
+    buildkitContainer.image = getBuildkitRootlessImagePath(provider.config.utilImageRegistryDomain)
     buildkitContainer.args = [
       "--addr",
       "unix:///run/user/1000/buildkit/buildkitd.sock",

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -29,7 +29,7 @@ import type { Resolved } from "../../../../actions/types.js"
 import { stringifyResources } from "../util.js"
 import { getKubectlExecDestination } from "../../sync.js"
 import { getRunningDeploymentPod } from "../../util.js"
-import { buildSyncVolumeName, dockerAuthSecretKey, getK8sUtilImageName, rsyncPortName } from "../../constants.js"
+import { buildSyncVolumeName, dockerAuthSecretKey, getK8sUtilImagePath, rsyncPortName } from "../../constants.js"
 import { styles } from "../../../../logger/styles.js"
 import type { StringMap } from "../../../../config/common.js"
 import { LogLevel } from "../../../../logger/logger.js"
@@ -578,7 +578,7 @@ export function getBuilderServiceAccountSpec(namespace: string, annotations?: St
 export function getUtilContainer(authSecretName: string, provider: KubernetesProvider): V1Container {
   return {
     name: utilContainerName,
-    image: getK8sUtilImageName(),
+    image: getK8sUtilImagePath(provider.config.utilImageRegistryDomain),
     imagePullPolicy: "IfNotPresent",
     command: ["/rsync-server.sh"],
     env: [

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -11,7 +11,7 @@ import {
   skopeoDaemonContainerName,
   dockerAuthSecretKey,
   defaultKanikoImageName,
-  getK8sUtilImageName,
+  getK8sUtilImagePath,
 } from "../../constants.js"
 import { KubeApi } from "../../api.js"
 import type { Log } from "../../../../logger/log-entry.js"
@@ -320,7 +320,7 @@ export function getKanikoBuilderPodManifest({
     initContainers: [
       {
         name: "init",
-        image: getK8sUtilImageName(),
+        image: getK8sUtilImagePath(provider.config.utilImageRegistryDomain),
         command: [
           "/bin/sh",
           "-c",

--- a/core/src/plugins/kubernetes/ephemeral/config.ts
+++ b/core/src/plugins/kubernetes/ephemeral/config.ts
@@ -17,7 +17,7 @@ import { ConfigurationError } from "../../../exceptions.js"
 import type { ConfigureProviderParams } from "../../../plugin/handlers/Provider/configureProvider.js"
 import { dedent } from "../../../util/string.js"
 import type { KubernetesConfig } from "../config.js"
-import { defaultResources } from "../config.js"
+import { defaultResources, utilImageRegistryDomainSpec } from "../config.js"
 import { namespaceSchema } from "../config.js"
 import { EPHEMERAL_KUBERNETES_PROVIDER_NAME } from "./ephemeral.js"
 import { DEFAULT_GARDEN_CLOUD_DOMAIN } from "../../../constants.js"
@@ -30,6 +30,7 @@ export const configSchema = () =>
   providerConfigBaseSchema()
     .keys({
       name: joiProviderName(EPHEMERAL_KUBERNETES_PROVIDER_NAME),
+      utilImageRegistryDomain: utilImageRegistryDomainSpec,
       namespace: namespaceSchema().description(
         "Specify which namespace to deploy services to (defaults to the project name). " +
           "Note that the framework generates other namespaces as well with this name as a prefix."

--- a/core/src/plugins/kubernetes/nginx/default-backend.ts
+++ b/core/src/plugins/kubernetes/nginx/default-backend.ts
@@ -12,7 +12,7 @@ import type { DeployState } from "../../../types/service.js"
 import { KubeApi } from "../api.js"
 import { checkResourceStatus, waitForResources } from "../status/status.js"
 import type { KubernetesDeployment, KubernetesService } from "../types.js"
-import { defaultGardenIngressControllerDefaultBackendImage } from "../constants.js"
+import { getDefaultGardenIngressControllerDefaultBackendImagePath } from "../constants.js"
 import { GardenIngressComponent } from "./ingress-controller-base.js"
 
 export class GardenDefaultBackend extends GardenIngressComponent {
@@ -111,7 +111,7 @@ function defaultBackendGetManifests(ctx: KubernetesPluginContext): {
         spec: {
           containers: [
             {
-              image: defaultGardenIngressControllerDefaultBackendImage,
+              image: getDefaultGardenIngressControllerDefaultBackendImagePath(provider.config.utilImageRegistryDomain),
               imagePullPolicy: "IfNotPresent",
               name: "default-backend",
               ports: [

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -58,7 +58,7 @@ import { isConfiguredForSyncMode } from "./status/status.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { SyncConfig, SyncSession } from "../../mutagen.js"
 import { haltedStatuses, Mutagen, mutagenAgentPath, mutagenStatusDescriptions } from "../../mutagen.js"
-import { getK8sSyncUtilImageName, k8sSyncUtilContainerName, syncGuideLink } from "./constants.js"
+import { getK8sSyncUtilImagePath, k8sSyncUtilContainerName, syncGuideLink } from "./constants.js"
 import { isAbsolute, relative, resolve } from "path"
 import type { Resolved } from "../../actions/types.js"
 import { joinWithPosix } from "../../util/fs.js"
@@ -465,8 +465,8 @@ export async function configureSyncMode({
     if (!podSpec.imagePullSecrets) {
       podSpec.imagePullSecrets = []
     }
-    const k8sSyncUtilImageName = getK8sSyncUtilImageName()
 
+    const k8sSyncUtilImageName = getK8sSyncUtilImagePath(provider.config.utilImageRegistryDomain)
     if (!podSpec.initContainers.find((c) => c.image === k8sSyncUtilImageName)) {
       const initContainer: V1Container = {
         name: k8sSyncUtilContainerName,

--- a/core/test/integ/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/ingress.ts
@@ -27,7 +27,10 @@ import { actionFromConfig } from "../../../../../../src/graph/actions.js"
 import type { DeployAction } from "../../../../../../src/actions/deploy.js"
 import { DEFAULT_DEPLOY_TIMEOUT_SEC } from "../../../../../../src/constants.js"
 import { uuidv4 } from "../../../../../../src/util/random.js"
-import { defaultSystemNamespace } from "../../../../../../src/plugins/kubernetes/constants.js"
+import {
+  defaultSystemNamespace,
+  defaultUtilImageRegistryDomain,
+} from "../../../../../../src/plugins/kubernetes/constants.js"
 
 const namespace = "my-namespace"
 const ports = [
@@ -43,6 +46,7 @@ type PartialConfig = PartialBy<KubernetesConfig, "context">
 
 const basicConfig: PartialConfig = {
   name: "local-kubernetes",
+  utilImageRegistryDomain: defaultUtilImageRegistryDomain,
   buildMode: "local-docker",
   defaultHostname: "hostname.invalid",
   deploymentRegistry: {

--- a/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
@@ -15,7 +15,11 @@ import {
 import { expect } from "chai"
 import type { KubernetesProvider } from "../../../../../../../src/plugins/kubernetes/config.js"
 import { defaultResources } from "../../../../../../../src/plugins/kubernetes/config.js"
-import { defaultKanikoImageName, getK8sUtilImageName } from "../../../../../../../src/plugins/kubernetes/constants.js"
+import {
+  defaultKanikoImageName,
+  defaultUtilImageRegistryDomain,
+  getK8sUtilImagePath,
+} from "../../../../../../../src/plugins/kubernetes/constants.js"
 import type { DeepPartial } from "utility-types"
 import { inClusterBuilderServiceAccount } from "../../../../../../../src/plugins/kubernetes/container/build/common.js"
 
@@ -60,6 +64,7 @@ describe("kaniko build", () => {
   describe("getKanikoBuilderPodManifest", () => {
     const _provider: DeepPartial<KubernetesProvider> = {
       config: {
+        utilImageRegistryDomain: defaultUtilImageRegistryDomain,
         kaniko: {},
         resources: {
           ...defaultResources,
@@ -132,7 +137,7 @@ describe("kaniko build", () => {
                 "-c",
                 'echo "Copying from $SYNC_SOURCE_URL to $SYNC_CONTEXT_PATH"\nmkdir -p "$SYNC_CONTEXT_PATH"\nn=0\nuntil [ "$n" -ge 30 ]\ndo\n  rsync \'arg1\' \'arg2\' && break\n  n=$((n+1))\n  sleep 1\ndone\necho "Done!"',
               ],
-              image: getK8sUtilImageName(),
+              image: getK8sUtilImagePath(provider.config.utilImageRegistryDomain),
               imagePullPolicy: "IfNotPresent",
               name: "init",
               volumeMounts: [

--- a/core/test/unit/src/plugins/kubernetes/init.ts
+++ b/core/test/unit/src/plugins/kubernetes/init.ts
@@ -11,7 +11,11 @@ import { join } from "path"
 import * as td from "testdouble"
 import type { Garden } from "../../../../../src/garden.js"
 import { prepareDockerAuth, getIngressMisconfigurationWarnings } from "../../../../../src/plugins/kubernetes/init.js"
-import { defaultSystemNamespace, dockerAuthSecretKey } from "../../../../../src/plugins/kubernetes/constants.js"
+import {
+  defaultSystemNamespace,
+  defaultUtilImageRegistryDomain,
+  dockerAuthSecretKey,
+} from "../../../../../src/plugins/kubernetes/constants.js"
 import { ConfigurationError } from "../../../../../src/exceptions.js"
 import type { KubernetesProvider, KubernetesConfig } from "../../../../../src/plugins/kubernetes/config.js"
 import { defaultResources } from "../../../../../src/plugins/kubernetes/config.js"
@@ -27,6 +31,7 @@ import { uuidv4 } from "../../../../../src/util/random.js"
 
 const basicConfig: KubernetesConfig = {
   name: "kubernetes",
+  utilImageRegistryDomain: defaultUtilImageRegistryDomain,
   buildMode: "local-docker",
   context: "my-cluster",
   defaultHostname: "hostname.invalid",

--- a/core/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/core/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -15,11 +15,15 @@ import { makeTempDir } from "../../../../helpers.js"
 import { providerFromConfig } from "../../../../../src/config/provider.js"
 import type { Garden } from "../../../../../src/garden.js"
 import { makeDummyGarden } from "../../../../../src/garden.js"
-import { defaultSystemNamespace } from "../../../../../src/plugins/kubernetes/constants.js"
+import {
+  defaultSystemNamespace,
+  defaultUtilImageRegistryDomain,
+} from "../../../../../src/plugins/kubernetes/constants.js"
 
 describe("kubernetes configureProvider", () => {
   const basicConfig: KubernetesConfig = {
     name: "kubernetes",
+    utilImageRegistryDomain: defaultUtilImageRegistryDomain,
     buildMode: "local-docker",
     context: "my-cluster",
     defaultHostname: "hostname.invalid",

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@
     * [AWS](./k8s-plugins/remote-k8s/configure-registry/aws.md)
     * [GCP](./k8s-plugins/remote-k8s/configure-registry/gcp.md)
     * [Azure](./k8s-plugins/remote-k8s/configure-registry/azure.md)
+    * [Docker Hub](./k8s-plugins/remote-k8s/configure-registry/docker-hub.md)
   * [3. Set Up Ingress, TLS and DNS](./k8s-plugins/remote-k8s/ingress-and-dns.md)
   * [4. Configure the Provider](./k8s-plugins/remote-k8s/configure-provider.md)
 * [Local K8s Plugin Configuration](./k8s-plugins/local-k8s/README.md)
@@ -88,6 +89,7 @@
   * [In-Cluster Building](./k8s-plugins/guides/in-cluster-building.md)
   * [Minimal RBAC Configuration for Development Clusters](./k8s-plugins/guides/rbac-config.md)
   * [Deploying to Production](./k8s-plugins/guides/deploying-to-production.md)
+  * [Using a Registry Mirror](./k8s-plugins/guides/registry-mirror.md)
 
 ## ☘️ Terraform Plugin
 

--- a/docs/k8s-plugins/guides/registry-mirror.md
+++ b/docs/k8s-plugins/guides/registry-mirror.md
@@ -1,0 +1,25 @@
+---
+title: Using a Registry Mirror
+order: 4
+---
+
+# Using a Registry Mirror
+
+Garden uses a handful of utility container images that are hosted on [Docker Hub](https://hub.docker.com/) under the `gardendev` repository. These are used for various Kubernetes tasks such as managing syncs and are usually deployed into a given project namespace along with the rest of the project services.
+
+If you have your own Docker Hub registry mirror you can configure Garden to use that instead of Docker Hub. Using your own registry mirror can improve performance because the mirror is typically in your VPC and prevents you from being rate limited by Docker Hub (see also [this FAQ entry](../../misc/faq.md#how-do-i-avoid-being-rate-limited-by-docker-hub) on Docker Hub rate limiting).
+
+To tell Garden to use your custom registry mirror instead of Docker Hub, set the `utilImageRegistryDomain` field on the Kubernetes provider, for example:
+
+```yaml
+kind: Project
+name: my-project
+#...
+providers:
+  - name: kubernetes
+    utilImageRegistryDomain: https://<my-private-registry-domain>
+```
+
+This option is available on all the Kubernetes plugins (i.e. `local-kubernetes`, `ephemeral-kubernetes`, and `kubernetes`).
+
+Now when you run a Garden command, the utility images will be pulled from the registry mirror.

--- a/docs/k8s-plugins/remote-k8s/configure-provider.md
+++ b/docs/k8s-plugins/remote-k8s/configure-provider.md
@@ -42,7 +42,11 @@ providers:
     context: <THE KUBE CONTEXT FROM STEP 1>
     defaultHostname: <THE HOSTNAME FROM STEP 3>
 ```
-**NOTE:** If you are using `kubernetes deploy` the `imagePullSecret` won't be automatically propagated to manifests. Make sure to use `imagePullSecrets` in your manifest as specified in kubernetes [docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
+
+{% hint style="warning" %}
+Garden does NOT inject the image pull secret into the Deployment (unless you're using the `container` Deploy type). So if you're using e.g. the `kubernetes` or `helm` action types you need to make sure the `imagePullSecret` field is set in the corresponding manifest / Helm chart. See also the [official Kubernetes docs for setting image pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
+{% endhint %}
+
 ### 2. Select build mode
 
 Next, select a "build mode".

--- a/docs/k8s-plugins/remote-k8s/configure-registry/README.md
+++ b/docs/k8s-plugins/remote-k8s/configure-registry/README.md
@@ -25,6 +25,7 @@ Below you'll find guides for specific cloud providers:
 * [AWS](./aws.md)
 * [GCP](./gcp.md)
 * [Azure](./azure.md)
+* [Docker Hub](./docker-hub.md)
 
 As always, feel free to pick a different approach. The end goal having a container registry that Garden can push to and that your cluster can pull from.
 

--- a/docs/k8s-plugins/remote-k8s/configure-registry/docker-hub.md
+++ b/docs/k8s-plugins/remote-k8s/configure-registry/docker-hub.md
@@ -1,0 +1,51 @@
+---
+title: Docker Hub
+order: 4
+---
+
+# Docker Hub
+
+To pull and push images from private Docker Hub repositories you need to create an image pull secret for Docker Hub. Creating an image pull secret for Docker Hub also reduces the chance of being [rate limited](../../../misc/faq.md#how-do-i-avoid-being-rate-limited-by-docker-hub) (e.g. when deploying Garden utility images).
+
+
+{% hint style="info" %}
+For a more in-depth guide on creating image pull secrets, check out the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+{% endhint %}
+
+### Step 1 — Log in
+
+Log in to the Docker Hub account you want to use with:
+
+```sh
+docker login
+```
+
+The login process creates or updates a `config.json` file that holds an authorization token. You can view it with:
+
+```sh
+cat ~/.docker/config.json
+```
+
+The output contains a section similar to this:
+
+```json
+{
+    "auths": {
+        "https://index.docker.io/v1/": {
+            "auth": "c3R...zE2"
+        }
+    }
+}
+```
+
+### Step 2 — Create the secret
+
+You can now create the image pull secret with the following command:
+
+```
+kubectl create secret generic regcred \
+    --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
+    --type=kubernetes.io/dockerconfigjson
+```
+
+Here we're creating a secret called `regcred` in the `default` namespace. Take note of the name and namespace as you'll need it when configuring the Kubernetes provider in [step 4](../configure-provider.md).

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -250,6 +250,49 @@ Garden interfaces with your cluster via `kubectl` and by using the Kubernetes AP
 
 No, you have to use the [`kubernetes`](../k8s-plugins/actions/deploy/kubernetes.md) action type for that.
 
+### How do I avoid being rate limited by Docker Hub?
+
+Garden uses a handful of utility images that are hosted on [Docker Hub](https://hub.docker.com) under the `gardendev` repository and under heavy usage, users can get rate limited when deploying them.
+
+We're in the process of applying for becoming a Verified Docker Publisher which should significantly reduce the chance of being rate limited.
+
+In the meantime, you have the following options:
+
+**Option 1 — Crate a Docker Hub image pull secret:**
+
+First follow the steps in [this guide](../k8s-plugins/remote-k8s/configure-registry/docker-hub.md) to create an image pull secret for
+Docker Hub.
+
+Then add the name and namespace of the secret you created to the `imagePullSecrets` field of the Kubernetes provider:
+
+```yaml
+kind: Project
+name: my-project
+#...
+providers:
+  - name: kubernetes
+    imagePullSecrets:
+      - name: <the-secret-name>
+        namespace: <the-secret-namespace>
+```
+
+This also works for the `local-kubernetes` and `ephemeral-kubernetes` providers.
+
+**Option 2 — Use a registry mirror:**
+
+If you already have your own Docker Hub registry mirror set up you can use that by setting the `utilImageRegistryDomain` field on the Kubernetes provider:
+
+```yaml
+kind: Project
+name: my-project
+#...
+providers:
+  - name: kubernetes
+    utilImageRegistryDomain: https://<my-private-registry-domain>
+```
+
+This also works for the `local-kubernetes` and `ephemeral-kubernetes` providers.
+
 ## Local scripts
 
 ### How do I execute long running local scripts?

--- a/docs/reference/providers/ephemeral-kubernetes.md
+++ b/docs/reference/providers/ephemeral-kubernetes.md
@@ -35,6 +35,15 @@ providers:
     # The name of the provider plugin to use.
     name: ephemeral-kubernetes
 
+    # The container registry domain that should be used for pulling Garden utility images (such as the
+    # image used in the Kubernetes sync utility Pod).
+    #
+    # If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+    # will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+    #
+    # Otherwise the utility images are pulled directly from Docker Hub by default.
+    utilImageRegistryDomain: docker.io
+
     # Specify which namespace to deploy services to (defaults to the project name). Note that the framework generates
     # other namespaces as well with this name as a prefix.
     namespace:
@@ -114,6 +123,22 @@ Example:
 providers:
   - name: "ephemeral-kubernetes"
 ```
+
+### `providers[].utilImageRegistryDomain`
+
+[providers](#providers) > utilImageRegistryDomain
+
+The container registry domain that should be used for pulling Garden utility images (such as the
+image used in the Kubernetes sync utility Pod).
+
+If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+
+Otherwise the utility images are pulled directly from Docker Hub by default.
+
+| Type     | Default       | Required |
+| -------- | ------------- | -------- |
+| `string` | `"docker.io"` | No       |
 
 ### `providers[].namespace`
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -37,6 +37,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    # The container registry domain that should be used for pulling Garden utility images (such as the
+    # image used in the Kubernetes sync utility Pod).
+    #
+    # If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+    # will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+    #
+    # Otherwise the utility images are pulled directly from Docker Hub by default.
+    utilImageRegistryDomain: docker.io
+
     # Choose the mechanism for building container images before deploying. By default your local Docker daemon is
     # used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container
     # images there. This removes the need to run Docker locally, and allows you to share layer and image caches
@@ -572,6 +581,22 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].utilImageRegistryDomain`
+
+[providers](#providers) > utilImageRegistryDomain
+
+The container registry domain that should be used for pulling Garden utility images (such as the
+image used in the Kubernetes sync utility Pod).
+
+If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+
+Otherwise the utility images are pulled directly from Docker Hub by default.
+
+| Type     | Default       | Required |
+| -------- | ------------- | -------- |
+| `string` | `"docker.io"` | No       |
 
 ### `providers[].buildMode`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -30,6 +30,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    # The container registry domain that should be used for pulling Garden utility images (such as the
+    # image used in the Kubernetes sync utility Pod).
+    #
+    # If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+    # will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+    #
+    # Otherwise the utility images are pulled directly from Docker Hub by default.
+    utilImageRegistryDomain: docker.io
+
     # Choose the mechanism for building container images before deploying. By default your local Docker daemon is
     # used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container
     # images there. This removes the need to run Docker locally, and allows you to share layer and image caches
@@ -517,6 +526,22 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].utilImageRegistryDomain`
+
+[providers](#providers) > utilImageRegistryDomain
+
+The container registry domain that should be used for pulling Garden utility images (such as the
+image used in the Kubernetes sync utility Pod).
+
+If you have your own Docker Hub registry mirror, you can set the domain here and the utility images
+will be pulled from there. This can be useful to e.g. avoid Docker Hub rate limiting.
+
+Otherwise the utility images are pulled directly from Docker Hub by default.
+
+| Type     | Default       | Required |
+| -------- | ------------- | -------- |
+| `string` | `"docker.io"` | No       |
 
 ### `providers[].buildMode`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Garden uses various utility container images, e.g. for the K8s sync utility pod, and hosts them on Docker Hub.

Some users have their own mirror of Docker Hub that they'd rather use instead of Docker Hub itself. This avoids issues with rate limiting among other things.

This commit adds a config field on the Kubernetes provider spec that allows users to configure what registry is used.

Note that it only allows users to specify the registry domain, not the repository, image name, or tag. So the assumption is that mirror has the exact same "layout" as Docker Hub itself which is usually (always?) the case.

If needed, we can later expose more granular control, e.g. setting the image tag, but that's not required for now.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
