### PR TITLE
fix(pulumi): stack not being selected before getting outputs when autoApply = false

### DIFF
--- a/plugins/pulumi/src/handlers.ts
+++ b/plugins/pulumi/src/handlers.ts
@@ -72,6 +72,7 @@ export const deployPulumi: DeployActionHandlers<PulumiDeploy>["deploy"] = async 
 
   if (!autoApply && !deployFromPreview) {
     log.info(`${action.longDescription()} has autoApply = false, but no planPath was provided. Skipping deploy.`)
+    await selectStack(pulumiParams)
     return {
       state: "ready",
       outputs: await getStackOutputs(pulumiParams),


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

When you set `autoApply` to `false` in a Pulumi deploy action, the correct stack hasn't been selected yet, so it'll pull outputs from whichever stack was last selected.

**Special notes for your reviewer**:

I don't know whether or not it's worth the effort right now, but I think it might be less error prone if you were able to set the stack with `--stack` on every pulumi command by having that set at the `CliWrapper` level somehow. This would also avoid the overhead of spinning up a pulumi process to change stacks.
