### PR TITLE
feat(pulumi): add `spec.showSecretsInOutput` config to Pulumi deploy action

### DIFF
--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -441,6 +441,19 @@ The name of the pulumi stack to use. Defaults to the current environment name.
 | -------- | -------- |
 | `string` | No       |
 
+### `spec.showSecretsInOutput`
+
+[spec](#spec) > showSecretsInOutput
+
+When set to true, stack outputs which are marked as secrets will be shown in the output.
+
+By default, Pulumi will print secret stack outputs as the string '[secret]' instead of
+the true content of the output.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
 
 ## Outputs
 

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -255,6 +255,12 @@ deployFromPreview: false
 
 # The name of the pulumi stack to use. Defaults to the current environment name.
 stack:
+
+# When set to true, stack outputs which are marked as secrets will be shown in the output.
+#
+# By default, Pulumi will print secret stack outputs as the string '[secret]' instead of
+# the true content of the output.
+showSecretsInOutput: false
 ```
 
 ## Configuration Keys
@@ -706,6 +712,17 @@ The name of the pulumi stack to use. Defaults to the current environment name.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `showSecretsInOutput`
+
+When set to true, stack outputs which are marked as secrets will be shown in the output.
+
+By default, Pulumi will print secret stack outputs as the string '[secret]' instead of
+the true content of the output.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 
 ## Outputs

--- a/plugins/pulumi/src/action.ts
+++ b/plugins/pulumi/src/action.ts
@@ -23,6 +23,7 @@ export interface PulumiDeploySpec {
   deployFromPreview: boolean
   root: string
   stack?: string
+  showSecretsInOutput: boolean
 }
 
 export type PulumiDeployConfig = DeployActionConfig<"pulumi", PulumiDeploySpec>
@@ -129,6 +130,17 @@ export const pulumiDeploySchemaKeys = () => ({
     .string()
     .allow(null)
     .description("The name of the pulumi stack to use. Defaults to the current environment name."),
+  showSecretsInOutput: joi
+    .boolean()
+    .default(false)
+    .description(
+      dedent`
+      When set to true, stack outputs which are marked as secrets will be shown in the output.
+
+      By default, Pulumi will print secret stack outputs as the string '[secret]' instead of
+      the true content of the output.
+      `
+    ),
 })
 
 export const pulumiDeploySchema = createSchema({

--- a/plugins/pulumi/src/helpers.ts
+++ b/plugins/pulumi/src/helpers.ts
@@ -151,9 +151,13 @@ export async function previewStack(
 }
 
 export async function getStackOutputs({ log, ctx, provider, action }: PulumiParams): Promise<any> {
+  const args = ["stack", "output", "--json"]
+  if (action.getSpec("showSecretsInOutput")) {
+    args.push("--show-secrets")
+  }
   const res = await pulumi(ctx, provider).json({
     log,
-    args: ["stack", "output", "--json", "--show-secrets"],
+    args,
     env: ensureEnv({ log, ctx, provider, action }),
     cwd: getActionStackRoot(action),
   })

--- a/plugins/pulumi/src/helpers.ts
+++ b/plugins/pulumi/src/helpers.ts
@@ -153,7 +153,7 @@ export async function previewStack(
 export async function getStackOutputs({ log, ctx, provider, action }: PulumiParams): Promise<any> {
   const res = await pulumi(ctx, provider).json({
     log,
-    args: ["stack", "output", "--json"],
+    args: ["stack", "output", "--json", "--show-secrets"],
     env: ensureEnv({ log, ctx, provider, action }),
     cwd: getActionStackRoot(action),
   })

--- a/plugins/pulumi/src/index.ts
+++ b/plugins/pulumi/src/index.ts
@@ -124,6 +124,7 @@ export const gardenPlugin = () =>
                 cacheStatus: module.spec.cacheStatus || false,
                 stackReferences: module.spec.stackReferences || [],
                 deployFromPreview: module.spec.deployFromPreview || false,
+                showSecretsInOutput: module.spec.showSecretsInOutput || false,
                 root: module.spec.root || ".",
                 ...omit(module.spec, ["build", "dependencies"]),
               },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Some outputs in Pulumi are considered secrets, and you need to use the `--show-secrets` flag to show them. If you don't, secret outputs get replaced with `[secret]`. Because the Pulumi provider doesn't include the `--show-secrets` flag, you can't use outputs from Pulumi which are marked as secrets, which can really limit the usefulness of the Pulumi deploy action's outputs.

This PR makes it so that secret values are included in the output of the Pulumi deploy action.
