### PR TITLE
docs: fix header on migrating back to old mutagen

### DIFF
--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -340,7 +340,7 @@ GARDEN_ENABLE_NEW_SYNC=false garden util mutagen daemon stop
 GARDEN_ENABLE_NEW_SYNC=true garden deploy --sync
 ```
 
-#### Switching from the old sync machinery to the new one
+#### Switching from the new sync machinery to the old one
 
 To stop the new sync daemon and to deploy with old sync mode, you need to run the following commands from the project
 root directory:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Updates the header on the docs for switching from the new mutagen back to old to match the content (new to old.) Docs are less confusing after the change.

**Which issue(s) this PR fixes**:

I haven't checked if there is an existing issue. I assumed not, since it is minor.

**Special notes for your reviewer**:
