### PR TITLE
feat(exec): separate `stdout` and `stderr` in Run and Test `exec`-action outputs

### DIFF
--- a/core/src/plugins/exec/config.ts
+++ b/core/src/plugins/exec/config.ts
@@ -31,6 +31,18 @@ export const execRuntimeOutputsSchema = s.object({
     .describe(
       "The full log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)"
     ),
+  stdout: s
+    .string()
+    .default("")
+    .describe(
+      "The stdout log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)"
+    ),
+  stderr: s
+    .string()
+    .default("")
+    .describe(
+      "The stderr log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)"
+    ),
 })
 
 export const execCommonSchema = s.object({

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -82,6 +82,8 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
     detail,
     outputs: {
       log: commandResult.outputLog,
+      stdout: commandResult.stdout,
+      stderr: commandResult.stderr,
     },
   } as const
 

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -84,6 +84,8 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
     detail,
     outputs: {
       log: commandResult.outputLog,
+      stdout: commandResult.stdout,
+      stderr: commandResult.stderr,
     },
   } as const
 
@@ -102,5 +104,6 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
       })
     )
   }
+
   return result
 })

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -443,6 +443,7 @@ describe("exec plugin", () => {
         })
 
         expect(res.outputs.log).to.eql(basePath)
+        expect(res.outputs.stdout).to.eql(basePath)
       })
 
       it("should receive version as an env var", async () => {
@@ -480,6 +481,7 @@ describe("exec plugin", () => {
           silent: false,
         })
         expect(res.outputs.log).to.equal(action.versionString())
+        expect(res.outputs.stdout).to.equal(action.versionString())
       })
     })
 

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -460,3 +460,19 @@ The full log output from the executed command. (Pro-tip: Make it machine readabl
 | -------- | ------- |
 | `string` | `""`    |
 
+### `${actions.build.<name>.outputs.stdout}`
+
+The stdout log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+
+### `${actions.build.<name>.outputs.stderr}`
+
+The stderr log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -459,3 +459,19 @@ The full log output from the executed command. (Pro-tip: Make it machine readabl
 | -------- | ------- |
 | `string` | `""`    |
 
+### `${actions.deploy.<name>.outputs.stdout}`
+
+The stdout log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+
+### `${actions.deploy.<name>.outputs.stderr}`
+
+The stderr log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -439,3 +439,19 @@ The full log output from the executed command. (Pro-tip: Make it machine readabl
 | -------- | ------- |
 | `string` | `""`    |
 
+### `${actions.run.<name>.outputs.stdout}`
+
+The stdout log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+
+### `${actions.run.<name>.outputs.stderr}`
+
+The stderr log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -439,3 +439,19 @@ The full log output from the executed command. (Pro-tip: Make it machine readabl
 | -------- | ------- |
 | `string` | `""`    |
 
+### `${actions.test.<name>.outputs.stdout}`
+
+The stdout log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+
+### `${actions.test.<name>.outputs.stderr}`
+
+The stderr log output from the executed command. (Pro-tip: Make it machine readable so it can be parsed by dependants)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #6556

**Special notes for your reviewer**:
