### PR TITLE
chore: restore fixed action config proc batch size

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -68,11 +68,6 @@ export const gardenEnv = {
   // Support the NO_COLOR env var (see https://no-color.org/)
   NO_COLOR: env.get("NO_COLOR").required(false).default("false").asBool(),
   GARDEN_AUTH_TOKEN: env.get("GARDEN_AUTH_TOKEN").required(false).asString(),
-  GARDEN_PROC_ACTION_CONFIG_BATCH_SIZE: env
-    .get("GARDEN_PROC_ACTION_CONFIG_BATCH_SIZE")
-    .required(false)
-    .default(10)
-    .asInt(),
   GARDEN_CACHE_TTL: env.get("GARDEN_CACHE_TTL").required(false).asInt(),
   GARDEN_DB_DIR: env.get("GARDEN_DB_DIR").required(false).default(GARDEN_GLOBAL_PATH).asString(),
   GARDEN_DISABLE_ANALYTICS: env.get("GARDEN_DISABLE_ANALYTICS").required(false).asBool(),

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -69,7 +69,6 @@ import { profile, profileAsync } from "../util/profiling.js"
 import { uuidv4 } from "../util/random.js"
 import { getSourcePath } from "../vcs/vcs.js"
 import { styles } from "../logger/styles.js"
-import { gardenEnv } from "../constants.js"
 
 function* sliceToBatches<T>(dict: Record<string, T>, batchSize: number) {
   const entries = Object.entries(dict)
@@ -81,6 +80,8 @@ function* sliceToBatches<T>(dict: Record<string, T>, batchSize: number) {
     position += batchSize
   }
 }
+
+const actionConfigProcBatchSize = 100
 
 function addActionConfig({
   garden,
@@ -169,7 +170,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
 
   const preprocessActions = async (predicate: (config: ActionConfig) => boolean = () => true) => {
     let batchNo = 1
-    for (const batch of sliceToBatches(configsByKey, gardenEnv.GARDEN_PROC_ACTION_CONFIG_BATCH_SIZE)) {
+    for (const batch of sliceToBatches(configsByKey, actionConfigProcBatchSize)) {
       log.silly(`Preprocessing actions batch #${batchNo} (${batch.length} items)`)
       const startTime = new Date().getTime()
       await Promise.all(
@@ -303,7 +304,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
   const actionConfigCount = Object.keys(preprocessResults).length
   log.debug(`Processing ${actionConfigCount} action configs...`)
   let batchNo = 1
-  for (const batch of sliceToBatches(preprocessResults, gardenEnv.GARDEN_PROC_ACTION_CONFIG_BATCH_SIZE)) {
+  for (const batch of sliceToBatches(preprocessResults, actionConfigProcBatchSize)) {
     log.silly(`Processing actions batch #${batchNo} (${batch.length} items)`)
     const startTime = new Date().getTime()
     await Promise.all(

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -198,7 +198,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
       )
       batchNo++
       const endTime = new Date().getTime()
-      log.silly(`Preprocessed actions batch #${batchNo} (${batch.length} items in ${endTime - startTime}ms`)
+      log.silly(`Preprocessed actions batch #${batchNo} (${batch.length} items) in ${endTime - startTime}ms`)
     }
   }
 
@@ -352,7 +352,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
     )
     batchNo++
     const endTime = new Date().getTime()
-    log.silly(`Processed actions batch #${batchNo} (${batch.length} items in ${endTime - startTime}ms`)
+    log.silly(`Processed actions batch #${batchNo} (${batch.length} items) in ${endTime - startTime}ms`)
   }
   log.debug(`Processed ${actionConfigCount} action configs`)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The actual value doesn't affect performance a lot.
Let's just keep batch size 100 to limit the object allocation rate in the runtime.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
