### PR TITLE
fix: correct deploy action validation in container plugin extension

### DIFF
--- a/core/src/plugins/kubernetes/container/extensions.ts
+++ b/core/src/plugins/kubernetes/container/extensions.ts
@@ -146,7 +146,10 @@ export const k8sContainerDeployExtension = (): DeployActionExtension<ContainerDe
     stopSync: k8sContainerStopSync,
     getSyncStatus: k8sContainerGetSyncStatus,
 
-    validate: async ({ ctx, action }) => {
+    validate: async ({ ctx, action, base }) => {
+      if (base) {
+        await base({ action })
+      }
       validateDeploySpec(action.name, <KubernetesProvider>ctx.provider, action.getSpec())
       return {}
     },

--- a/core/src/plugins/openshift/deploy.ts
+++ b/core/src/plugins/openshift/deploy.ts
@@ -42,7 +42,10 @@ export const openshiftContainerDeployExtension = (): DeployActionExtension<Conta
     stopSync: k8sContainerStopSync,
     getSyncStatus: k8sContainerGetSyncStatus,
 
-    validate: async ({ ctx, action }) => {
+    validate: async ({ ctx, action, base }) => {
+      if (base) {
+        await base({ action })
+      }
       validateDeploySpec(action.name, <KubernetesProvider>ctx.provider, action.getSpec())
       return {}
     },


### PR DESCRIPTION
Call base handler from original container plugin before doing extra validation.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This fixes the behaviour discrepancy between `Deploy` and `Run/Test` actions validation in container plugin.

**Reproducible example:**

<details>
<summary>Click to see the configuration</summary>

```yml
kind: Build
name: my-build
type: container

---
kind: Deploy
description: Desc
name: my-deploy
type: container
dependencies:
  - build.my-build
spec:
  image: ${actions.build.my-build.outputs.deploymentImageId}
  volumes:
    - name: "my-volume"
      containerPath: "my-container-path"
      action: deploy.config # <-- reference to an action that is not listed in the dependencies list

---
kind: Run
description: Desc
name: my-run
type: container
dependencies:
  - build.my-build
spec:
  args: [ "echo", "foo" ]
  image: ${actions.build.my-build.outputs.deploymentImageId}
  volumes:
    - name: "my-volume"
      containerPath: "my-container-path"
      action: deploy.config # <-- reference to an action that is not listed in the dependencies list
```

</details>

Validate each action with the `--resolve` flag:

```console
garden validate --resolve=my-run
garden validate --resolve=my-deploy
```

**Expected result.**

Both actions should fail with the same error:

<details>
<summary>Click to see Run action validation outputs</summary>

```console
✖ run.my-run                → Failed processing resolve Run type=container name=my-run (took 0.01 sec). This is what happened:

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Run type=container name=my-run references action deploy.config under `spec.volumes` but does not declare a dependency on it. Please add an explicit dependency on the volume action.
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Failed to resolve Run type=container name=my-run: Error: resolve Run type=container name=my-run failed: Error: Run type=container name=my-run references action deploy.config under `spec.volumes` but does not declare a dependency on it. Please add an explicit dependency on the volume action.
```

</details>

<details>
<summary>Click to see Deploy action validation outputs</summary>

```console
✖ deploy.my-deploy          → Failed processing resolve Deploy type=container name=my-deploy (took 0.01 sec). This is what happened:

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Deploy type=container name=my-deploy references action [object Object] under `spec.volumes` but does not declare a dependency on it. Please add an explicit dependency on the volume action.
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Failed to resolve Deploy type=container name=my-deploy: Error: resolve Deploy type=container name=my-deploy failed: Error: Deploy type=container name=my-deploy references action [object Object] under `spec.volumes` but does not declare a dependency on it. Please add an explicit dependency on the volume action.
```


</details>

**Actual result.**

Without this fix, command `garden validate --resolve=my-deploy` passes without errors.

**Special notes for your reviewer**:
