### PR TITLE
ci: bump minikube kubernetes from 1.28 to 1.31

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1353,22 +1353,18 @@ workflows:
           <<: *only-internal-prs
           name: test-remote
           requires: [build]
-          kubernetesVersion: "v1.28.3"
-          minikubeVersion: "v1.32.0"
+          kubernetesVersion: "v1.31.0"
+          minikubeVersion: "v1.34.0"
           skipTests: "local-only"
           remoteCluster: true
 
       ### VM TESTS ###
 
       # Note: The below is a not-quite-random mix of local k8s variants and k8s versions. Doing a full matrix of every
-      # variant and k8s version would be quite expensive, so we try and make sure each of the latest 6-7 k8s versions is
-      # tested, and that the most recent versions are broadly tested. The kind tests are the cheapest to run so we use many
-      # of those, but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
-      - test-minikube:
-          name: vm-1.28-minikube
-          requires: [ build ]
-          kubernetesVersion: "v1.28.3"
-          minikubeVersion: "v1.32.0"
+      # variant and k8s version would be quite expensive, so we try and make sure each of the officially maintained
+      # k8s versions is tested, and that the most recent versions are broadly tested.
+      # The kind tests are the cheapest to run so we use many of those,
+      # but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
       - test-kind:
           name: vm-1.29-kind
           requires: [build]
@@ -1381,6 +1377,11 @@ workflows:
           name: vm-1.31-k3s
           requires: [build]
           k3sVersion: v1.31.1+k3s1
+      - test-minikube:
+          name: vm-1.31-minikube
+          requires: [ build ]
+          kubernetesVersion: "v1.31.0"
+          minikubeVersion: "v1.34.0"
 
       - test-plugins:
           <<: *only-internal-prs


### PR DESCRIPTION
**What this PR does / why we need it**:

The maintenance support of 1.28 was ended 2 days ago.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
