### PR TITLE
Show Pod logs from failed containers

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -23,7 +23,7 @@ import { KubeApi, KubernetesError } from "./api.js"
 import { getPodLogs, checkPodStatus } from "./status/pod.js"
 import type { KubernetesResource, KubernetesPod, KubernetesServerResource, SupportedRuntimeAction } from "./types.js"
 import type { ContainerEnvVars, ContainerResourcesSpec, ContainerVolumeSpec } from "../container/config.js"
-import { prepareEnvVars, makePodName, renderPodEvents, sanitizeVolumesForPodRunner } from "./util.js"
+import { prepareEnvVars, makePodName, renderWorkloadEvents, sanitizeVolumesForPodRunner } from "./util.js"
 import { dedent, deline, randomString } from "../../util/string.js"
 import type { ArtifactSpec } from "../../config/validation.js"
 import { prepareSecrets } from "./secrets.js"
@@ -808,14 +808,11 @@ class PodRunnerNotFoundError extends PodRunnerError {
 
     super({
       message: dedent`
-        Could not find Pod while waiting for it to complete. The Pod might have been evicted or deleted.
-
         There are several different possible causes for Pod disruptions.
 
         You can read more about the topic in the Kubernetes documentation:
-        https://kubernetes.io/docs/concepts/workloads/pods/disruptions/${
-          events?.length ? `\n\n${renderPodEvents(events)}` : ""
-        }
+        https://kubernetes.io/docs/concepts/workloads/pods/disruptions/\n\n
+        ${renderWorkloadEvents(events || [], "Pod", details.podName)}
       `,
       details,
     })
@@ -845,6 +842,7 @@ interface RunAndWaitResult {
 }
 
 export interface PodErrorDetails {
+  podName: string
   logs?: string
   // optional details
   exitCode?: number
@@ -1018,6 +1016,7 @@ export class PodRunner {
       }
       return {
         podEvents,
+        podName: this.podName,
       }
     }
 
@@ -1051,6 +1050,7 @@ export class PodRunner {
         exitCode,
         containerStatus: mainContainerStatus,
         podStatus: serverPod.status,
+        podName: this.podName,
       })
 
       // We've seen instances where Pods are OOMKilled but the exit code is 0 and the state that
@@ -1209,7 +1209,7 @@ export class PodRunner {
     const collectLogs = async () => result.allLogs || (await this.getMainContainerLogs())
 
     if (result.timedOut) {
-      const errorDetails: PodErrorDetails = { logs: await collectLogs(), result }
+      const errorDetails: PodErrorDetails = { logs: await collectLogs(), result, podName: this.podName }
       throw new PodRunnerTimeoutError({
         message: `Command timed out after ${timeoutSec} seconds.`,
         details: errorDetails,
@@ -1220,6 +1220,7 @@ export class PodRunner {
       const errorDetails: PodErrorDetails = {
         logs: await collectLogs(),
         exitCode: result.exitCode,
+        podName: this.podName,
         result,
       }
       throw new PodRunnerOutOfMemoryError({ message: "Pod container was OOMKilled.", details: errorDetails })
@@ -1233,6 +1234,7 @@ export class PodRunner {
       const errorDetails: PodErrorDetails = {
         logs: await collectLogs(),
         exitCode: result.exitCode,
+        podName: this.podName,
         result,
       }
       throw new PodRunnerWorkloadError({ message: `Failed with exit code ${result.exitCode}.`, details: errorDetails })
@@ -1272,7 +1274,7 @@ export class PodRunner {
     })
 
     if (some(events, (event) => event.reason === "Killing")) {
-      const details: PodErrorDetails = { podEvents: events }
+      const details: PodErrorDetails = { podEvents: events, podName: this.podName }
       throw new PodRunnerNotFoundError({ details })
     }
   }

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -91,19 +91,28 @@ export async function getPodLogs({
   timestamps?: boolean
   sinceSeconds?: number
 }) {
-  let podContainers = pod.spec!.containers.map((c) => c.name).filter((n) => !n.match(/garden-/))
+  let podContainers = [
+    // Include init containers
+    ...(pod.spec!.initContainers || []).map((c) => c.name).filter((n) => !n.match(/garden-/)),
+    ...pod.spec!.containers.map((c) => c.name).filter((n) => !n.match(/garden-/)),
+  ]
 
   if (containerNames) {
     podContainers = podContainers.filter((name) => containerNames.includes(name))
   }
+  const containerByOrder = podContainers.reduce<{ [key: string]: number }>((memo, name, index) => {
+    memo[name] = index
+    return memo
+  }, {})
 
-  return Promise.all(
+  const allLogs = await Promise.all(
     podContainers.map(async (container) => {
       const follow = false
       const insecureSkipTLSVerifyBackend = false
       const pretty = undefined
 
-      let log: any
+      let log: unknown
+      let retLog: string
       try {
         log = await api.core.readNamespacedPodLog({
           name: pod.metadata!.name!,
@@ -142,31 +151,50 @@ export async function getPodLogs({
               timestamps,
             })
           } catch (err) {
-            log = `[Could not retrieve previous logs for deleted pod ${pod.metadata!.name!}: ${
+            retLog = `[Could not retrieve previous logs for deleted pod ${pod.metadata!.name!}: ${
               err || "Unknown error occurred"
             }]`
           }
         } else if (error instanceof KubernetesError && error.message.includes("waiting to start")) {
-          log = ""
+          retLog = ""
         } else {
           throw error
         }
       }
 
-      if (typeof log === "object") {
-        log = stringify(log)
+      if (typeof log === "string") {
+        retLog = log
+      } else if (typeof log === "object") {
+        retLog = stringify(log)
+      } else if (!log) {
+        retLog = ""
+      } else {
+        retLog = "[Could not read Pod logs. Received unexpected output.]"
       }
 
       // the API returns undefined if no logs have been output, for some reason
-      return { containerName: container, log: log || "" }
+      return { containerName: container, log: retLog }
     })
   )
+
+  // The logs are grouped by container in the order that the logs promises are resolved so we sort
+  // them in the order the containers appear in the config.
+  const sortedLogs = allLogs.sort((a, b) => containerByOrder[a.containerName] - containerByOrder[b.containerName])
+
+  return sortedLogs
 }
 
 /**
  * Get a formatted list of log tails for each of the specified pods. Used for debugging and error logs.
  */
-export async function getFormattedPodLogs(api: KubeApi, namespace: string, pods: KubernetesPod[]): Promise<string> {
+export async function getFormattedPodLogs(
+  api: KubeApi,
+  namespace: string,
+  pods: KubernetesPod[],
+  filterFn?: (params: { log: string; containerName: string }) => boolean
+): Promise<string | null> {
+  const yesFilter = () => true
+  const logFilter = filterFn || yesFilter
   const allLogs = await Promise.all(
     pods.map(async (pod) => {
       return {
@@ -178,20 +206,32 @@ export async function getFormattedPodLogs(api: KubeApi, namespace: string, pods:
     })
   )
 
+  const hasLogs = !!allLogs.flatMap(({ containers }) => containers.map((c) => c.log)).join("")
+
+  if (!hasLogs) {
+    return null
+  }
+
   return allLogs
     .map(({ podName, containers }) => {
-      return (
-        styles.highlight(`\n****** ${podName} ******\n`) +
-        containers.map(({ containerName, log }) => {
-          return styles.primary(`------ ${containerName} ------`) + (log || "<no logs>")
+      const containerLogs = containers
+        .filter(logFilter)
+        // Format logs like so: <pod-name>/<container-name>: log message
+        .map(({ containerName, log }) => {
+          return log
+            .split("\n")
+            .map((line) => (line ? styles.primary(`${styles.section(podName + "/" + containerName)}: ${line}`) : ""))
+            .join("\n")
         })
-      )
+        .join("\n")
+
+      return containerLogs
     })
-    .join("\n\n")
+    .join("\n")
 }
 
 export function getExecExitCode(status: V1Status): number {
-  // Status csn be either "Success" or "Failure"
+  // Status can be either "Success" or "Failure"
   if (status.status === "Success") {
     return 0
   }

--- a/core/test/data/test-projects/kubernetes-type/action-simple/garden.yml
+++ b/core/test/data/test-projects/kubernetes-type/action-simple/garden.yml
@@ -1,0 +1,26 @@
+kind: Deploy
+type: kubernetes
+name: action-simple
+spec:
+  manifests:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: nginx
+        labels:
+          app: nginx
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: nginx
+        template:
+          metadata:
+            labels:
+              app: nginx
+          spec:
+            containers:
+              - name: nginx
+                image: nginx:1.14.2
+                ports:
+                  - containerPort: 80

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -163,7 +163,7 @@ describe("util", () => {
         })
         await garden.processTasks({ tasks: [deployTask], throwOnError: true })
 
-        const pods = await getWorkloadPods(api, "container", resource)
+        const pods = await getWorkloadPods({ api, namespace: "container", resource })
         const services = flatten(pods.map((pod) => pod.spec?.containers.map((container) => container.name)))
         expect(services).to.eql(["simple-service"])
       } finally {
@@ -201,7 +201,7 @@ describe("util", () => {
 
         const pod = allPods.items[0]
 
-        const pods = await getWorkloadPods(api, namespace, pod)
+        const pods = await getWorkloadPods({ api, namespace, resource: pod })
         expect(pods.length).to.equal(1)
         expect(pods[0].kind).to.equal("Pod")
         expect(pods[0].metadata.name).to.equal(pod.metadata.name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this commit, we'd show Pod logs from all _main_ containers for a
given K8s resource on failure but not from init containers.

This meant that:

a) If an init container would fail the user wouldn't see any logs
b) If a main container fails the user would see logs from all main
containers in all Pods, potentially drowning out the actual error
message.

With this change, we now only show logs from failed containers, and
include init containers as well.

**Which issue(s) this PR fixes**:

I bumped into this while working on #6563. This doesn't close that specific issue but it's basically the first in a trilogy of PRs meant to address that which I'm splitting up to make it easier to review. 

**Special notes for your reviewer**:

This is what it looked like before. Here an init container fails but we only show logs from the main container which are of course empty since it never ran 👇

<img width="1143" alt="Screenshot 2024-11-07 at 14 57 35" src="https://github.com/user-attachments/assets/c49e4f47-e821-4675-bd85-27b517f2022c">


This is what it looks like now when an init container fails 👇

<img width="1144" alt="Screenshot 2024-11-07 at 15 01 00" src="https://github.com/user-attachments/assets/3d99deaa-44c1-4d55-ac44-352fa0455a64">


And this is what it looks like when several main containers fail 👇

<img width="823" alt="Screenshot 2024-11-07 at 15 09 08" src="https://github.com/user-attachments/assets/07693e64-9238-4f4b-a6b2-302fa6e1c5c8">


