### PR TITLE
feat(k8s): show Helm events and logs

### DIFF
--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -42,6 +42,7 @@ interface HelmChartSpec {
 
 interface HelmDeployActionSpec {
   atomic: boolean
+  waitForUnhealthyResources: boolean
   chart?: HelmChartSpec
   defaultTarget?: KubernetesTargetResourceSpec
   sync?: KubernetesDeploySyncSpec
@@ -166,7 +167,13 @@ const helmChartSpecSchema = () =>
     )
 
 export const defaultHelmAtomicFlag = false
-export const defaultHelmAtomicFlagDesc = `Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure.`
+export const defaultHelmAtomicFlagDesc = dedent`
+  Whether to set the \`--atomic\` flag during installs and upgrades. Set to \`true\` if you'd like the changes applied
+  to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually
+  roll back, instead of having Helm do it automatically on failure.
+
+  Note that setting \`atomic\` to \`true\` implies \`wait\`.
+`
 
 export const helmDeploySchema = () =>
   joi
@@ -174,6 +181,17 @@ export const helmDeploySchema = () =>
     .keys({
       ...helmCommonSchemaKeys(),
       atomic: joi.boolean().default(defaultHelmAtomicFlag).description(defaultHelmAtomicFlagDesc),
+      waitForUnhealthyResources: joi.boolean().default(false).description(dedent`
+        Whether to wait for the Helm command to complete before throwing an error if one of the resources being installed/upgraded is unhealthy.
+
+        By default, Garden will monitor the resources being created by Helm and throw an error as soon as one of them is unhealthy. This allows Garden to fail fast if there's an issue with one of the resources. If no issue is detected, Garden waits for the Helm command to complete.
+
+        If however \`waitForUnhealthyResources\` is set to \`true\` and some resources are unhealthy, then Garden will wait for Helm itself to throw an error which typically happens when it times out in the case of unhealthy resources (e.g. due to \`ImagePullBackOff\` or \`CrashLoopBackOff\` errors).
+
+        Waiting for the timeout can take awhile so using the default value here is recommended unless you'd like to completely mimic Helm's behaviour and not rely on Garden's resource monitoring.
+
+        Note that setting \`atomic\` to \`true\` implies \`waitForUnhealthyResources\`.
+      `),
       chart: helmChartSpecSchema(),
       defaultTarget: defaultTargetSchema(),
       sync: kubernetesDeploySyncSchema(),

--- a/core/src/plugins/kubernetes/helm/handlers.ts
+++ b/core/src/plugins/kubernetes/helm/handlers.ts
@@ -187,6 +187,8 @@ function prepareDeployAction({
 
     spec: {
       atomic: module.spec.atomicInstall,
+      // This option is not available on Modules so we default to false when converting from modules
+      waitForUnhealthyResources: false,
       portForwards: module.spec.portForwards,
       namespace: module.spec.namespace,
       releaseName: module.spec.releaseName || module.name,

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -117,7 +117,9 @@ export async function helm({
   }
 
   const outputStream = split2()
-  outputStream.on("error", () => {})
+  outputStream.on("error", () => {
+    // Do nothing
+  })
   outputStream.on("data", (line: Buffer) => {
     if (emitLogEvents) {
       ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -430,7 +430,6 @@ export const kubernetesDeploy: DeployActionHandler<"deploy", KubernetesDeployAct
       waitForJobs: spec.waitForJobs,
     })
   }
-
   const status = await getKubernetesDeployStatus(<any>params)
 
   // Make sure port forwards work after redeployment

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -268,6 +268,9 @@ interface WaitParams {
 
 /**
  * Wait until the rollout is complete for each of the given Kubernetes objects
+ *
+ * @throws {DeploymentResourceStatusError} as soon as resource with state="unhealthy" is found
+ * @throws {DeploymentError} if it times out waiting for resource
  */
 export async function waitForResources({
   namespace,

--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -113,17 +113,15 @@ export async function checkWorkloadStatus({ api, namespace, resource }: StatusHa
       podLogs = null
     }
 
-    logs += styles.accent(
-      `\n\n━━━ Latest logs from failed containers in each Pod in ${workload.kind} ${workload.metadata.name} ━━━\n`
-    )
     if (podLogs) {
+      logs += styles.accent(
+        `\n\n━━━ Latest logs from failed containers in each Pod in ${workload.kind} ${workload.metadata.name} ━━━\n`
+      )
       logs += podLogs
       logs += styles.primary(dedent`
         \n💡 Garden hint: For complete Pod logs for this ${workload.kind}, run the following command:
         ${styles.command(`kubectl -n ${namespace} --context=${api.context} logs ${workload.kind.toLowerCase()}/${workload.metadata.name} --all-containers`)}
       `)
-    } else {
-      logs += "<No Pod logs found>"
     }
 
     return <ResourceStatus>{

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -463,8 +463,8 @@ export async function upsertConfigMap({
  * becomes
  * `[{ metadata: { name: a }}, { metadata: { name: b }}, { metadata: { name: b }}]`
  */
-export function flattenResources(resources: KubernetesResource[]) {
-  return flatten(resources.map((r: any) => (r.apiVersion === "v1" && r.kind === "List" ? r.items : [r])))
+export function flattenResources(resources: KubernetesResource[]): KubernetesResource[] {
+  return flatten(resources.map((r: KubernetesResource) => (r.apiVersion === "v1" && r.kind === "List" ? r.items : [r])))
 }
 
 /**

--- a/core/test/data/test-projects/helm/api/garden.yml
+++ b/core/test/data/test-projects/helm/api/garden.yml
@@ -13,6 +13,7 @@ spec:
     kind: Deployment
     name: api-release
   values:
+    args: [python, app.py]
     image:
       repository: api-image
       tag: ${actions.build.api-image.version}
@@ -20,9 +21,7 @@ spec:
       enabled: true
       paths: [/]
       hosts: [api.local.demo.garden]
-
 ---
-
 kind: Module
 description: The API backend for the voting UI
 type: helm
@@ -30,8 +29,8 @@ name: api-module
 releaseName: api-module-release
 devMode:
   sync:
-  - target: /app
-    mode: two-way
+    - target: /app
+      mode: two-way
 serviceResource:
   kind: Deployment
   containerModule: api-image

--- a/core/test/data/test-projects/helm/api/templates/deployment.yaml
+++ b/core/test/data/test-projects/helm/api/templates/deployment.yaml
@@ -24,7 +24,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: [python, app.py]
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
           ports:
             - name: http
               containerPort: 80

--- a/core/test/data/test-projects/helm/api/values.yaml
+++ b/core/test/data/test-projects/helm/api/values.yaml
@@ -29,6 +29,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+args: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/core/test/data/test-projects/kubernetes-type/with-build-action/with-build.garden.yml
+++ b/core/test/data/test-projects/kubernetes-type/with-build-action/with-build.garden.yml
@@ -3,4 +3,4 @@ type: kubernetes
 name: with-build-action
 build: exec-build
 spec:
-  files: [ "*.yaml" ]
+  files: ["*.yaml"]

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -389,7 +389,29 @@ this action config's directory.
 
 [spec](#spec) > atomic
 
-Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure.
+Whether to set the `--atomic` flag during installs and upgrades. Set to `true` if you'd like the changes applied
+to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually
+roll back, instead of having Helm do it automatically on failure.
+
+Note that setting `atomic` to `true` implies `wait`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
+### `spec.waitForUnhealthyResources`
+
+[spec](#spec) > waitForUnhealthyResources
+
+Whether to wait for the Helm command to complete before throwing an error if one of the resources being installed/upgraded is unhealthy.
+
+By default, Garden will monitor the resources being created by Helm and throw an error as soon as one of them is unhealthy. This allows Garden to fail fast if there's an issue with one of the resources. If no issue is detected, Garden waits for the Helm command to complete.
+
+If however `waitForUnhealthyResources` is set to `true` and some resources are unhealthy, then Garden will wait for Helm itself to throw an error which typically happens when it times out in the case of unhealthy resources (e.g. due to `ImagePullBackOff` or `CrashLoopBackOff` errors).
+
+Waiting for the timeout can take awhile so using the default value here is recommended unless you'd like to completely mimic Helm's behaviour and not rely on Garden's resource monitoring.
+
+Note that setting `atomic` to `true` implies `waitForUnhealthyResources`.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -219,9 +219,11 @@ values: {}
 # this action config's directory.
 valueFiles: []
 
-# Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be
-# reverted on failure. Set to false if e.g. you want to see more information about failures and then manually roll
-# back, instead of having Helm do it automatically on failure.
+# Whether to set the `--atomic` flag during installs and upgrades. Set to `true` if you'd like the changes applied
+# to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually
+# roll back, instead of having Helm do it automatically on failure.
+#
+# Note that setting `atomic` to `true` implies `wait`.
 atomicInstall: false
 
 # The name of another `helm` module to use as a base for this one. Use this to re-use a Helm chart across multiple
@@ -1044,7 +1046,11 @@ this action config's directory.
 
 ### `atomicInstall`
 
-Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure.
+Whether to set the `--atomic` flag during installs and upgrades. Set to `true` if you'd like the changes applied
+to be reverted on failure. Set to false if e.g. you want to see more information about failures and then manually
+roll back, instead of having Helm do it automatically on failure.
+
+Note that setting `atomic` to `true` implies `wait`.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/examples/vote-helm/api.garden.yml
+++ b/examples/vote-helm/api.garden.yml
@@ -3,6 +3,7 @@ description: The API backend for the voting UI
 type: helm
 name: api
 dependencies:
+  - build.api-image
   - deploy.redis
 variables:
   repository: ${actions.build.api-image.outputs.deployment-image-name}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously we would use Garden's own resource monitoring to monitor the
health of a Helm install/upgrade and fail fast if one of the resources
was unhealthy as well as show K8s events and Pod logs.

In commit https://github.com/garden-io/garden/commit/7a68373a175b1e757b67f391030c643d0fde55d4 we replaced that with Helm's own `--wait` flag.

The reason for that change was because a user reported issues with
Garden returning early from the Helm command in the success case
(see https://github.com/garden-io/garden/pull/6078 and https://github.com/garden-io/garden/issues/6053 for more details).

The problem with that change is that since we weren't using our own
resource monitoring we stopped showing events and logs when Helm
installs/upgrades fail. Another problem is that Garden would now wait
for the Helm command to complete which in the case of unhealthy
resources means Helm will timeout, with a default of 300 seconds.

This commit fixes that and we try to go for the best of both worlds:

- We always use the `--wait` flag but also monitor resources at the same time
- If the resources are healthy we wait for the Helm command to
  complete (this was the intent with https://github.com/garden-io/garden/commit/7a68373a175b1e757b67f391030c643d0fde55d4)
- If we detect unhealthy resources we fail fast (as we did before on the
  same major version)
- We add a flag to overwrite the fail fast behaviour in case a user
  might prefer that

**Which issue(s) this PR fixes**:

Fixes #6563 

**Special notes for your reviewer**:
