### PR TITLE
fix: default image registry namespace

### DIFF
--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -267,7 +267,8 @@ const helpers = {
     const name = parsed.tag ? `${parsed.repository}:${parsed.tag}` : parsed.repository
 
     if (parsed.host) {
-      return `${parsed.host}/${parsed.namespace || defaultImageNamespace}/${name}`
+      const namespace = parsed.namespace || defaultImageNamespace
+      return namespace != "_" ? `${parsed.host}/${namespace}/${name}` : `${parsed.host}/${name}`
     } else if (parsed.namespace) {
       return `${parsed.namespace}/${name}`
     } else {


### PR DESCRIPTION


**What this PR does / why we need it**:
The PR is to fix the issue, make sure the default `_` don't appear in image name which cause to error.


**Which issue(s) this PR fixes**:
https://github.com/garden-io/garden/issues/6635

**Special notes for your reviewer**:
Garden.io is a great project, thanks for creating it.