### PR TITLE
chore: remove old mutagen sync method coda paths

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -105,7 +105,6 @@ export const gardenEnv = {
     .required(false)
     .default("https://get.garden.io/releases")
     .asUrlString(),
-  GARDEN_ENABLE_NEW_SYNC: env.get("GARDEN_ENABLE_NEW_SYNC").required(false).default("true").asBool(),
   // GARDEN_CLOUD_BUILDER will always override the config; That's why it doesn't have a default.
   // FIXME: If the environment variable is not set, asBool returns undefined, unlike the type suggests. That's why we cast to `boolean | undefined`.
   GARDEN_CLOUD_BUILDER: env.get("GARDEN_CLOUD_BUILDER").required(false).asBool() as boolean | undefined,

--- a/core/src/graph/config-graph.ts
+++ b/core/src/graph/config-graph.ts
@@ -449,6 +449,7 @@ export abstract class BaseConfigGraph<
       }
     }
 
+    // @ts-ignore
     const sortedNodeKeys = toposort(simpleEdges)
 
     const edgeSortIndex = (e: ConfigGraphEdge) => {

--- a/core/src/graph/config-graph.ts
+++ b/core/src/graph/config-graph.ts
@@ -449,7 +449,6 @@ export abstract class BaseConfigGraph<
       }
     }
 
-    // @ts-ignore
     const sortedNodeKeys = toposort(simpleEdges)
 
     const edgeSortIndex = (e: ConfigGraphEdge) => {

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -16,7 +16,7 @@ import pRetry, { type FailedAttemptError } from "p-retry"
 import { join } from "path"
 import respawn from "respawn"
 import split2 from "split2"
-import { GARDEN_GLOBAL_PATH, gardenEnv, MUTAGEN_DIR_NAME } from "./constants.js"
+import { GARDEN_GLOBAL_PATH, MUTAGEN_DIR_NAME } from "./constants.js"
 import { ChildProcessError, GardenError } from "./exceptions.js"
 import pMemoize from "./lib/p-memoize.js"
 import type { Log } from "./logger/log-entry.js"
@@ -31,7 +31,6 @@ import { styles } from "./logger/styles.js"
 import { dirname } from "node:path"
 import { makeDocsLinkStyled } from "./docs/common.js"
 import { syncGuideRelPath } from "./plugins/kubernetes/constants.js"
-import { emitNonRepeatableWarning } from "./warnings.js"
 
 const { mkdirp, pathExists } = fsExtra
 
@@ -325,8 +324,8 @@ class _MutagenMonitor extends TypedEventEmitter<MonitorEvents> {
 }
 
 function logMutagenDaemonWarning(log: Log) {
-  const daemonStopCommand = `GARDEN_ENABLE_NEW_SYNC=${!gardenEnv.GARDEN_ENABLE_NEW_SYNC} garden util mutagen daemon stop`
-  const redeploySyncCommand = `GARDEN_ENABLE_NEW_SYNC=${gardenEnv.GARDEN_ENABLE_NEW_SYNC} garden deploy --sync`
+  const daemonStopCommand = `garden util mutagen daemon stop`
+  const redeploySyncCommand = `garden deploy --sync`
 
   log.warn(
     deline`
@@ -368,17 +367,6 @@ export class Mutagen {
     this.dataDir = getMutagenDataDir(params)
     this.activeSyncs = {}
     this.monitoring = false
-
-    emitNonRepeatableWarning(
-      this.log,
-      deline`
-    Warning!\n
-
-    Starting from 0.13.34, Garden uses the new sync daemon.
-    Thus, the default value of the \`GARDEN_ENABLE_NEW_SYNC\` environment variable is \`true\` now.\n
-
-    Please make sure you have tested the new sync daemon. See the troubleshooting docs for more details: ${makeDocsLinkStyled("guides/code-synchronization", "#restarting-sync-daemon")}\n`
-    )
 
     // TODO: This is a little noisy atm. We could be a bit smarter and filter some superfluous messages out.
     this.monitorHandler = (session) => {
@@ -940,85 +928,20 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
   return parsed
 }
 
-const mutagenVersionLegacy = "0.15.0"
-const mutagenVersionNative = "0.17.6"
+export const mutagenVersion = "0.17.6"
 
-export const mutagenVersion = gardenEnv.GARDEN_ENABLE_NEW_SYNC ? mutagenVersionNative : mutagenVersionLegacy
-
-export function mutagenCliSpecLegacy(): PluginToolSpec {
+export function mutagenCliSpec(): PluginToolSpec {
   return {
     name: "mutagen",
-    version: mutagenVersionLegacy,
-    description: `The mutagen synchronization tool, v${mutagenVersionLegacy}`,
+    version: mutagenVersion,
+    description: `The mutagen synchronization tool, v${mutagenVersion}`,
     type: "binary",
     _includeInGardenImage: false,
     builds: [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_darwin_amd64_v${mutagenVersionLegacy}.tar.gz`,
-        sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
-      },
-      {
-        platform: "darwin",
-        architecture: "arm64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_darwin_arm64_v${mutagenVersionLegacy}.tar.gz`,
-        sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_linux_amd64_v${mutagenVersionLegacy}.tar.gz`,
-        sha256: "e8c0708258ddd6d574f1b8f514fb214f9ab5d82aed38dd8db49ec10956e5063a",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "arm64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_linux_arm64_v${mutagenVersionLegacy}.tar.gz`,
-        sha256: "80f108fc316223d8c3d1a48def18192e666b33a334b75aa3ebcc95938b774e64",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: `https://github.com/garden-io/mutagen/releases/download/v${mutagenVersionLegacy}-garden-1/mutagen_windows_amd64_v${mutagenVersionLegacy}.zip`,
-        sha256: "fdae26b43cc418b2525a937a1613bba36e74ea3dde4dbec3512a9abd004def95",
-        extract: {
-          format: "zip",
-          targetPath: "mutagen.exe",
-        },
-      },
-    ],
-  }
-}
-
-export function mutagenCliSpecNative(): PluginToolSpec {
-  return {
-    name: "mutagen",
-    version: mutagenVersionNative,
-    description: `The mutagen synchronization tool, v${mutagenVersionNative}`,
-    type: "binary",
-    _includeInGardenImage: false,
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_darwin_amd64_v${mutagenVersionNative}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
         sha256: "f082eef2ae405a6bf5effdbcd000bb5fe2bc7b0968f86b2b54d9d3260c48c739",
         extract: {
           format: "tar",
@@ -1028,7 +951,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "darwin",
         architecture: "arm64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_darwin_arm64_v${mutagenVersionNative}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
         sha256: "b6c35942ca9cbbbf726bfa249da554d829a8a28cad620a55e02d098d692121d1",
         extract: {
           format: "tar",
@@ -1038,7 +961,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "linux",
         architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_linux_amd64_v${mutagenVersionNative}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
         sha256: "1b826e121be59506e133d90dc2b8a0c820b92f480d9b2b230d8b389d6178a6cf",
         extract: {
           format: "tar",
@@ -1048,7 +971,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "linux",
         architecture: "arm64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_linux_arm64_v${mutagenVersionNative}.tar.gz`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
         sha256: "2a383cb572a1bdad83f7c4be3cc4a541a58e6c9e11e326ee4cc2d0e14f9d003a",
         extract: {
           format: "tar",
@@ -1058,7 +981,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
       {
         platform: "windows",
         architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersionNative}/mutagen_windows_amd64_v${mutagenVersionNative}.zip`,
+        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
         sha256: "3019ccb556afb39cf2213adcacab97576c4419f8d08d3a55d063a5c773ec6d35",
         extract: {
           format: "zip",
@@ -1069,9 +992,7 @@ export function mutagenCliSpecNative(): PluginToolSpec {
   }
 }
 
-export const mutagenCliSpec = gardenEnv.GARDEN_ENABLE_NEW_SYNC ? mutagenCliSpecNative() : mutagenCliSpecLegacy()
-
-export const mutagenCli = new PluginTool(mutagenCliSpec)
+export const mutagenCli = new PluginTool(mutagenCliSpec())
 
 const mutagenFauxSshVersion = "v0.0.1"
 const mutagenFauxSshReleaseBaseUrl = "https://github.com/garden-io/mutagen-faux-ssh/releases/download/"
@@ -1139,14 +1060,9 @@ export const mutagenFauxSshSpec: PluginToolSpec = {
 export const mutagenFauxSsh = new PluginTool(mutagenFauxSshSpec)
 
 /**
- * Returns the path to the location of the faux SSH Mutagen transport if the original Mutagen is used
- * (i.e. if {@code GARDEN_ENABLE_NEW_SYNC=true}) or {@code undefined} otherwise.
+ * Returns the path to the location of the faux SSH Mutagen transport
  */
 async function getMutagenSshPath(log: Log): Promise<string | undefined> {
-  if (!gardenEnv.GARDEN_ENABLE_NEW_SYNC) {
-    return undefined
-  }
-
   const fauxSshToolPath = await mutagenFauxSsh.ensurePath(log)
   // This must be the dir containing the faux SSH binary,
   // not the full path that includes the binary name.

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -930,69 +930,67 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
 
 export const mutagenVersion = "0.17.6"
 
-export function mutagenCliSpec(): PluginToolSpec {
-  return {
-    name: "mutagen",
-    version: mutagenVersion,
-    description: `The mutagen synchronization tool, v${mutagenVersion}`,
-    type: "binary",
-    _includeInGardenImage: false,
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
-        sha256: "f082eef2ae405a6bf5effdbcd000bb5fe2bc7b0968f86b2b54d9d3260c48c739",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
+export const mutagenCliSpec: PluginToolSpec = {
+  name: "mutagen",
+  version: mutagenVersion,
+  description: `The mutagen synchronization tool, v${mutagenVersion}`,
+  type: "binary",
+  _includeInGardenImage: false,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_amd64_v${mutagenVersion}.tar.gz`,
+      sha256: "f082eef2ae405a6bf5effdbcd000bb5fe2bc7b0968f86b2b54d9d3260c48c739",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
       },
-      {
-        platform: "darwin",
-        architecture: "arm64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
-        sha256: "b6c35942ca9cbbbf726bfa249da554d829a8a28cad620a55e02d098d692121d1",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
+    },
+    {
+      platform: "darwin",
+      architecture: "arm64",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_darwin_arm64_v${mutagenVersion}.tar.gz`,
+      sha256: "b6c35942ca9cbbbf726bfa249da554d829a8a28cad620a55e02d098d692121d1",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
       },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
-        sha256: "1b826e121be59506e133d90dc2b8a0c820b92f480d9b2b230d8b389d6178a6cf",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_amd64_v${mutagenVersion}.tar.gz`,
+      sha256: "1b826e121be59506e133d90dc2b8a0c820b92f480d9b2b230d8b389d6178a6cf",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
       },
-      {
-        platform: "linux",
-        architecture: "arm64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
-        sha256: "2a383cb572a1bdad83f7c4be3cc4a541a58e6c9e11e326ee4cc2d0e14f9d003a",
-        extract: {
-          format: "tar",
-          targetPath: "mutagen",
-        },
+    },
+    {
+      platform: "linux",
+      architecture: "arm64",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_linux_arm64_v${mutagenVersion}.tar.gz`,
+      sha256: "2a383cb572a1bdad83f7c4be3cc4a541a58e6c9e11e326ee4cc2d0e14f9d003a",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
       },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
-        sha256: "3019ccb556afb39cf2213adcacab97576c4419f8d08d3a55d063a5c773ec6d35",
-        extract: {
-          format: "zip",
-          targetPath: "mutagen.exe",
-        },
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `https://github.com/mutagen-io/mutagen/releases/download/v${mutagenVersion}/mutagen_windows_amd64_v${mutagenVersion}.zip`,
+      sha256: "3019ccb556afb39cf2213adcacab97576c4419f8d08d3a55d063a5c773ec6d35",
+      extract: {
+        format: "zip",
+        targetPath: "mutagen.exe",
       },
-    ],
-  }
+    },
+  ],
 }
 
-export const mutagenCli = new PluginTool(mutagenCliSpec())
+export const mutagenCli = new PluginTool(mutagenCliSpec)
 
 const mutagenFauxSshVersion = "v0.0.1"
 const mutagenFauxSshReleaseBaseUrl = "https://github.com/garden-io/mutagen-faux-ssh/releases/download/"

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -7,7 +7,6 @@
  */
 
 import type { DockerImageWithDigest } from "../../util/string.js"
-import { gardenEnv } from "../../constants.js"
 import { makeDocsLinkPlain } from "../../docs/common.js"
 
 export const MAX_CONFIGMAP_DATA_SIZE = 1024 * 1024 // max ConfigMap data size is 1MB
@@ -48,25 +47,17 @@ function makeImagePath({
 }
 
 export function getK8sUtilImagePath(registryDomain: string): DockerImageWithDigest {
-  const k8sUtilImageNameLegacy: DockerImageWithDigest =
-    "gardendev/k8s-util:0.5.7@sha256:522da245a5e6ae7c711aa94f84fc83f82a8fdffbf6d8bc48f4d80fee0e0e631b"
   const k8sUtilImageName: DockerImageWithDigest =
     "gardendev/k8s-util:0.6.2@sha256:f51e7ce040e2e23bc0eaa7216e4d976f13786d96773ef7b8c8f349e7a63d74e9"
 
-  return gardenEnv.GARDEN_ENABLE_NEW_SYNC
-    ? makeImagePath({ imageName: k8sUtilImageName, registryDomain })
-    : makeImagePath({ imageName: k8sUtilImageNameLegacy, registryDomain })
+  return makeImagePath({ imageName: k8sUtilImageName, registryDomain })
 }
 
 export function getK8sSyncUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sSyncUtilImageName: DockerImageWithDigest =
     "gardendev/k8s-sync:0.2.2@sha256:9ebcd84df4a3a55ae0ba95051cab521d249a4d2d7a15d04da7301c888c02347b"
-  const k8sSyncUtilImageNameLegacy: DockerImageWithDigest =
-    "gardendev/k8s-sync:0.1.5@sha256:28263cee5ac41acebb8c08f852c4496b15e18c0c94797d7a949a4453b5f91578"
 
-  return gardenEnv.GARDEN_ENABLE_NEW_SYNC
-    ? makeImagePath({ imageName: k8sSyncUtilImageName, registryDomain })
-    : makeImagePath({ imageName: k8sSyncUtilImageNameLegacy, registryDomain })
+  return makeImagePath({ imageName: k8sSyncUtilImageName, registryDomain })
 }
 
 export function getK8sReverseProxyImagePath(registryDomain: string): DockerImageWithDigest {

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -334,7 +334,7 @@ export async function configureSyncMode({
           Override configuration:
           ${(override.command?.length ?? 0) > 0 ? `Command: ${override.command?.join(" ")}` : ""}
           ${(override.args?.length ?? 0) > 0 ? `Args: ${override.args?.join(" ")}` : ""}
-          ${override.image?.length ?? 0 ? `Image: ${override.image}` : ""}
+          ${(override.image?.length ?? 0) ? `Image: ${override.image}` : ""}
         `,
       })
     }
@@ -984,7 +984,7 @@ export function makeSyncConfig({
   }
 }
 
-async function getKubectlExecDestination({
+export async function getKubectlExecDestination({
   ctx,
   log,
   namespace,

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -68,7 +68,6 @@ import { convertServiceResource } from "./kubernetes-type/common.js"
 import { prepareConnectionOpts } from "./kubectl.js"
 import type { GetSyncStatusResult, SyncState, SyncStatus } from "../../plugin/handlers/Deploy/get-sync-status.js"
 import { ConfigurationError } from "../../exceptions.js"
-import { gardenEnv } from "../../constants.js"
 import { styles } from "../../logger/styles.js"
 import { commandListToShellScript } from "../../util/escape.js"
 import { toClearText } from "../../util/secrets.js"
@@ -335,7 +334,7 @@ export async function configureSyncMode({
           Override configuration:
           ${(override.command?.length ?? 0) > 0 ? `Command: ${override.command?.join(" ")}` : ""}
           ${(override.args?.length ?? 0) > 0 ? `Args: ${override.args?.join(" ")}` : ""}
-          ${(override.image?.length ?? 0) ? `Image: ${override.image}` : ""}
+          ${override.image?.length ?? 0 ? `Image: ${override.image}` : ""}
         `,
       })
     }
@@ -985,48 +984,7 @@ export function makeSyncConfig({
   }
 }
 
-async function getKubectlExecDestinationLegacy({
-  ctx,
-  log,
-  namespace,
-  containerName,
-  resourceName,
-  targetPath,
-}: {
-  ctx: KubernetesPluginContext
-  log: Log
-  namespace: string
-  containerName: string
-  resourceName: string
-  targetPath: string
-}) {
-  const kubectl = ctx.tools["kubernetes.kubectl"]
-  const kubectlPath = await kubectl.ensurePath(log)
-
-  const connectionOpts = prepareConnectionOpts({
-    provider: ctx.provider,
-    namespace,
-  })
-
-  const command = [
-    kubectlPath,
-    "exec",
-    "-i",
-    ...connectionOpts,
-    "--container",
-    containerName,
-    resourceName,
-    "--",
-    mutagenAgentPath,
-    "synchronizer",
-  ]
-
-  log.debug("Using legacy Mutagen (Garden fork)")
-
-  return `exec:'${command.join(" ")}':${targetPath}`
-}
-
-async function getKubectlExecDestinationNative({
+async function getKubectlExecDestination({
   ctx,
   log,
   namespace,
@@ -1073,9 +1031,5 @@ async function getKubectlExecDestinationNative({
 
   return `${hostname}:${targetPath}`
 }
-
-export const getKubectlExecDestination = gardenEnv.GARDEN_ENABLE_NEW_SYNC
-  ? getKubectlExecDestinationNative
-  : getKubectlExecDestinationLegacy
 
 const isReverseMode = (mode: string) => mode === "one-way-reverse" || mode === "one-way-replica-reverse"

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { mutagenCliSpecLegacy, mutagenCliSpecNative, mutagenFauxSshSpec } from "../../../src/mutagen.js"
+import { mutagenCliSpecLegacy, mutagenCliSpec, mutagenFauxSshSpec } from "../../../src/mutagen.js"
 import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
 import { kustomize4Spec, kustomize5Spec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helmSpec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
@@ -22,7 +22,7 @@ describe("regctlCLI binaries", () => {
 })
 
 describe("Mutagen binaries", () => {
-  downloadBinariesAndVerifyHashes([mutagenCliSpecNative(), mutagenCliSpecLegacy()])
+  downloadBinariesAndVerifyHashes([mutagenCliSpec(), mutagenCliSpecLegacy()])
 })
 
 describe("Mutagen faux SSH binaries", () => {

--- a/core/test/unit/src/verify-ext-tool-binary-hashes.ts
+++ b/core/test/unit/src/verify-ext-tool-binary-hashes.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { mutagenCliSpecLegacy, mutagenCliSpec, mutagenFauxSshSpec } from "../../../src/mutagen.js"
+import { mutagenCliSpec, mutagenFauxSshSpec } from "../../../src/mutagen.js"
 import { kubectlSpec } from "../../../src/plugins/kubernetes/kubectl.js"
 import { kustomize4Spec, kustomize5Spec } from "../../../src/plugins/kubernetes/kubernetes-type/kustomize.js"
 import { helmSpec } from "../../../src/plugins/kubernetes/helm/helm-cli.js"
@@ -22,7 +22,7 @@ describe("regctlCLI binaries", () => {
 })
 
 describe("Mutagen binaries", () => {
-  downloadBinariesAndVerifyHashes([mutagenCliSpec(), mutagenCliSpecLegacy()])
+  downloadBinariesAndVerifyHashes([mutagenCliSpec])
 })
 
 describe("Mutagen faux SSH binaries", () => {

--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -360,7 +360,7 @@ garden util mutagen daemon stop
 garden self-update <your-preferred-version>
 garden deploy --sync
 
-# If you are downgrading to Garden >= 0.13.22 and <=0.13.32 and want to use the old sync machinery
+# If you are downgrading to Garden >= 0.13.26 and <=0.13.32 and want to use the old sync machinery
 garden util mutagen daemon stop
 garden self-update <your-preferred-version>
 GARDEN_ENABLE_NEW_SYNC=false garden deploy --sync

--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -322,30 +322,61 @@ garden util mutagen sync list
 ### Restarting sync daemon
 
 Starting from the version `0.13.26`, Garden offers a new file synchronization machinery.
-It is available via the environment variable `GARDEN_ENABLE_NEW_SYNC` and it disabled by default.
+It is available via the environment variable `GARDEN_ENABLE_NEW_SYNC` and it disabled by default up until version `0.13.32`.
 
-Starting from the version `0.13.33`, the new synchronization machinery has been used by default.
+Starting from the version `0.13.33`, the new synchronization machinery is enabled by default.
+
+From version `0.13.44` the old synchronization machinery is completely removed together with the `GARDEN_ENABLE_NEW_SYNC` variable.
 
 It is important to stop all syncs and the sync daemon before changing the value of `GARDEN_ENABLE_NEW_SYNC`,
 or upgrading to the version `0.13.33` or higher, or downgrading from `0.13.33+` to a lower version.
 Otherwise, the code synchronization won't work and Garden will fail with an error.
 
-#### Switching from the old sync machinery to the new one
+#### Switching from the old sync machinery to the new one (Garden `>=0.13.26` and `<=0.13.33`)
 
-To stop the old sync daemon and to deploy with new sync mode, you need to run the following commands from the project
-root directory:
+To stop the old sync daemon and to deploy with new sync mode, you need to run the following commands from the project root directory:
 
 ```
 GARDEN_ENABLE_NEW_SYNC=false garden util mutagen daemon stop
 GARDEN_ENABLE_NEW_SYNC=true garden deploy --sync
 ```
 
-#### Switching from the new sync machinery to the old one
+#### Switching from the new sync machinery to the old one (Garden `>=0.13.26` and `<=0.13.33`)
 
-To stop the new sync daemon and to deploy with old sync mode, you need to run the following commands from the project
-root directory:
+To stop the new sync daemon and to deploy with old sync mode, you need to run the following commands from the project root directory:
 
 ```
 GARDEN_ENABLE_NEW_SYNC=true garden util mutagen daemon stop
 GARDEN_ENABLE_NEW_SYNC=false garden deploy --sync
+```
+
+#### Switching from the new sync machinery to the old one when downgrading from Garden `>=0.13.44`
+
+When downgrading, to stop the new sync daemon and to deploy with old sync mode, you need to run the following commands from the project root directory:
+
+```sh
+# If you are downgrading to Garden >= 0.13.33
+garden util mutagen daemon stop
+garden self-update <your-preferred-version>
+garden deploy --sync
+
+# If you are downgrading to Garden >= 0.13.22 and <=0.13.32 and want to use the old sync machinery
+garden util mutagen daemon stop
+garden self-update <your-preferred-version>
+GARDEN_ENABLE_NEW_SYNC=false garden deploy --sync
+
+```
+
+#### Manually stopping lingering mutagen processes
+
+If experience any lingering Mutagen processes, you can use the following command to find and kill them:
+
+```sh
+ps -ef | grep mutagen
+```
+
+If any Mutagen processes are found, you can terminate them using the `kill` command:
+
+```sh
+kill -9 <process-uid>
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR removes any reference to the old `mutagen` sync mode and removes the `GARDEN_ENABLE_NEW_SYNC` environment variable.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
