### PR TITLE
revert: "fix: correct deploy action validation in container plugin extension

### DIFF
--- a/core/src/plugins/kubernetes/container/extensions.ts
+++ b/core/src/plugins/kubernetes/container/extensions.ts
@@ -146,10 +146,7 @@ export const k8sContainerDeployExtension = (): DeployActionExtension<ContainerDe
     stopSync: k8sContainerStopSync,
     getSyncStatus: k8sContainerGetSyncStatus,
 
-    validate: async ({ ctx, action, base }) => {
-      if (base) {
-        await base({ action })
-      }
+    validate: async ({ ctx, action }) => {
       validateDeploySpec(action.name, <KubernetesProvider>ctx.provider, action.getSpec())
       return {}
     },

--- a/core/src/plugins/openshift/deploy.ts
+++ b/core/src/plugins/openshift/deploy.ts
@@ -42,10 +42,7 @@ export const openshiftContainerDeployExtension = (): DeployActionExtension<Conta
     stopSync: k8sContainerStopSync,
     getSyncStatus: k8sContainerGetSyncStatus,
 
-    validate: async ({ ctx, action, base }) => {
-      if (base) {
-        await base({ action })
-      }
+    validate: async ({ ctx, action }) => {
       validateDeploySpec(action.name, <KubernetesProvider>ctx.provider, action.getSpec())
       return {}
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts #6606 that introduced some regression on the container deploy action validation. This is necessary to unblock the upcoming release.

Let's revisit the module conversion and action validation flow later.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
