### PR TITLE
fix(k8s): respect pod selector in kubernetes-exec action type

### DIFF
--- a/core/test/data/test-projects/kubernetes-type/module-simple/garden.yml
+++ b/core/test/data/test-projects/kubernetes-type/module-simple/garden.yml
@@ -55,6 +55,18 @@ spec:
   command: [echo, ok]
 
 ---
+kind: Run
+name: echo-run-exec-pod-selector
+type: kubernetes-exec
+dependencies:
+  - deploy.module-simple
+spec:
+  resource:
+    podSelector:
+      app: busybox
+  command: [echo, ok]
+
+---
 kind: Test
 name: echo-test-exec
 type: kubernetes-exec


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to this fix, the `kubernetes-exec` action type was not able to consider a specified `podSelector` as a valid resource query.

**Reproducible example.**

<details>

<summary>Click to expand</summary>

```yml
apiVersion: garden.io/v1
kind: Project
name: vote
environments:
  - name: local
providers:
  - name: local-kubernetes
    environments: [ local ]

---

kind: Run
name: test-run
type: kubernetes-exec
spec:
  command: [ "echo", "foo" ]
  resource:
    podSelector:
      name: "my-pod"

```

</details>

**Which issue(s) this PR fixes**:

Without this fix, the example above will crash with the following error:

```console
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Encountered an unexpected Garden error. This is likely a bug 🍂

You can help by reporting this on GitHub: https://github.com/garden-io/garden/issues/new?labels=bug,crash&template=CRASH.md&title=Crash%3A%20Must%20specify%20name%20in%20resource%2Ftarget%20query

Please attach the following information to the bug report after making sure that the error message does not contain sensitive information:

Failed processing Run type=kubernetes-exec name=test-run (took 0.07 sec). This is what happened:
Error: Must specify name in resource/target query
    at readTargetResource (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/plugins/kubernetes/util.js:521:15)
    at readAndExec (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.js:94:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.run (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.js:52:28)
    at async Object.assign.handlerType.handlerType (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/router/base.js:215:28)
    at async Router.callHandler (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/router/base.js:186:24)
    at async run (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/router/run.js:46:28)
    at async RunTask.process (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/tasks/run.js:69:28)
    at async descriptor.value (file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/tasks/base.js:382:29)
    at async file:///Users/vladimirvagaytsev/Repositories/garden/core/build/src/util/open-telemetry/decorators.js:44:30
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
1 requested run action(s) failed!
```

**Special notes for your reviewer**:
