### PR TITLE
chore: exclude pulumi from workflow-runner images

### DIFF
--- a/plugins/pulumi/src/cli.ts
+++ b/plugins/pulumi/src/cli.ts
@@ -84,7 +84,7 @@ export const pulumiCliSpecs: PluginToolSpec[] = [
     name: getPulumiToolName(PULUMI_SEM_VER_3_122_0),
     description: getPulumiToolDescription(PULUMI_SEM_VER_3_122_0),
     type: "binary",
-    _includeInGardenImage: true,
+    _includeInGardenImage: false,
     builds: [
       {
         platform: "darwin",


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses GHSA-xr7q-jx4m-x55m - google.golang.org/grpc vulnerability.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
