### PR TITLE
chore: improve mutagen version changed error message

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -325,20 +325,28 @@ class _MutagenMonitor extends TypedEventEmitter<MonitorEvents> {
 
 function logMutagenDaemonWarning(log: Log) {
   const daemonStopCommand = `garden util mutagen daemon stop`
+  const deleteEnvironmentCommand = `garden delete environment`
   const redeploySyncCommand = `garden deploy --sync`
+  const killProcessesCommand = `kill -9 $(pgrep mutagen)`
 
   log.warn(
     deline`
     It looks like the sync daemon might have been changed to a different version.\n
 
-    Therefore the sync daemon needs to be restarted, and the affected deploys must be redeployed.\n
+    Therefore the sync daemon needs to be restarted, current mutagen processes stopped and the affected deploys must be redeployed.\n
     Please, stop this command and follow the instructions below.\n
 
     1. Stop the active sync daemon by running this command ${styles.accent(styles.bold("from the project root directory"))}:\n
 
     ${styles.command(daemonStopCommand)}\n
 
-    2. Redeploy the affected deploys by running this command (specify the action names if necessary):\n
+    2. Kill all mutagen processes on your machine by running this command\n
+
+    ${styles.command(killProcessesCommand)}\n
+
+    3. Redeploy the affected deploys by running the following commands (specify the action names if necessary):\n
+
+    ${styles.command(deleteEnvironmentCommand)}\n
 
     ${styles.command(redeploySyncCommand)}\n
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
When the mutagen version changes, all local mutagen processes need to be cleaned up. Additionally the resources with sync enabled need to be redeployed in kubernetes. This is because the`k8s-sync` init container needs to ship the same mutagen version as the local version. The error message so far recommended this, but because the `k8s-sync` init container does not affect the version hash the deploy command would not really redeploy the pods with an updated init-container with the update image version. Therefore an environment needs to be deleted before redeployed.

Many thanks to @kevinthenet  for the detailed workaround instructions.

**Which issue(s) this PR fixes**:

Fixes #6662

**Special notes for your reviewer**:
