### PR TITLE
fix(publish): copy image from registry if it has been pushed directly after build

### DIFF
--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -23,10 +23,15 @@ export const k8sPublishContainerBuild: BuildActionHandler<"publish", ContainerBu
   const localImageId = action.getOutput("localImageId")
   const deploymentRegistryImageId = action.getOutput("deploymentImageId")
   const remoteImageId = containerHelpers.getPublicImageId(action, tagOverride)
+  const dockerBuildExtraFlags = action.getSpec("extraFlags")
 
   // For in-cluster building or cloud builder, use regctl to copy the image.
   // This does not require to pull the image locally.
-  if (provider.config.buildMode !== "local-docker" || cloudBuilderConfigured) {
+  if (
+    provider.config.buildMode !== "local-docker" ||
+    cloudBuilderConfigured ||
+    dockerBuildExtraFlags?.includes("--push")
+  ) {
     const regctlCopyCommand = ["image", "copy", deploymentRegistryImageId, remoteImageId]
     log.info({ msg: `Publishing image ${remoteImageId}` })
     await containerHelpers.regctlCli({ cwd: action.getBuildPath(), args: regctlCopyCommand, log, ctx })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Allows using the regctl publish method which copies an image from one registry to another if the `--push` `extraArgs` are set in the build action spec. This behavior was already used for the container provider but is with this PR also usable when using the kubernetes provider.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
