### PR TITLE
fix(k8s-exec): use containerName if specified for kubernetes-exec actions

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.ts
@@ -167,6 +167,7 @@ async function readAndExec({
     log,
     namespace,
     workload: target,
+    containerName: resource.containerName,
     command,
     interactive: false,
     streamLogs: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
In the kubernetes-exec actions we were not passing on the `action.spec.resource.containerName` resulting in always the first container to be picked e.g. for test actions.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
