### PR TITLE
docs: update docs about disabled modules

### DIFF
--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -214,7 +214,7 @@ export const baseModuleSpecKeys = memoize(() => ({
       dedent`
       Set this to \`true\` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. \`disabled: \${environment.name == "prod"}\`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-      Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+      Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
       If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
     `

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1513,9 +1513,8 @@ providers:
         # ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific
         # environments, e.g. only for development.
         #
-        # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It
-        # also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-        # module (in which case building this module is necessary for the dependant to be built).
+        # Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or
+        # run.
         #
         # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
         # will automatically ignore those dependency declarations. Note however that template strings referencing the
@@ -2466,9 +2465,7 @@ moduleConfigs:
     # "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for
     # development.
     #
-    # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-    # means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in
-    # which case building this module is necessary for the dependant to be built).
+    # Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
     #
     # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
     # will automatically ignore those dependency declarations. Note however that template strings referencing the
@@ -3040,9 +3037,7 @@ modules:
     # "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for
     # development.
     #
-    # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-    # means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in
-    # which case building this module is necessary for the dependant to be built).
+    # Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
     #
     # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
     # will automatically ignore those dependency declarations. Note however that template strings referencing the

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -90,9 +90,7 @@ modules:
     # "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for
     # development.
     #
-    # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-    # means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in
-    # which case building this module is necessary for the dependant to be built).
+    # Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
     #
     # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
     # will automatically ignore those dependency declarations. Note however that template strings referencing the
@@ -414,7 +412,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -74,9 +74,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -322,7 +320,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -77,9 +77,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -330,7 +328,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -82,9 +82,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -907,7 +905,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -86,9 +86,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -512,7 +510,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -80,9 +80,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -321,7 +319,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -76,9 +76,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -784,7 +782,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -150,9 +150,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -1122,7 +1120,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -78,9 +78,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -768,7 +766,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -74,9 +74,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -385,7 +383,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -76,9 +76,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -407,7 +405,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -80,9 +80,7 @@ description:
 # based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`).
 # This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
-# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
-# case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 #
 # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
 # automatically ignore those dependency declarations. Note however that template strings referencing the module's
@@ -347,7 +345,7 @@ A description of the module.
 
 Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: ${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be build, deployed or run.
 
 If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

While build dependencies had a special behavior in garden modules, in garden 0.13.x all modules are converted to actions and build dependencies between modules are not a thing anymore. This means that this special behavior in which the build in a disabled garden module will still run in case there is a build dependency on it does not exist any longer.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
