### PR TITLE
fix: improve error message if filter expression in foreach cannot be resolved

### DIFF
--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -449,7 +449,12 @@ function handleForEachObject({
       const filterResult = resolveTemplateStrings({
         value: value[arrayForEachFilterKey],
         context: loopContext,
-        contextOpts,
+        contextOpts: {
+          ...contextOpts,
+          // filter expression must be completely resolvable
+          // TODO: In a future iteration of this code, we should leave the entire $forEach expression unresolved if filter cannot be resolved yet and allowPartial=true.
+          allowPartial: false,
+        },
         source: {
           ...source,
           path: source.path && [...source.path, arrayForEachFilterKey],
@@ -460,7 +465,7 @@ function handleForEachObject({
         continue
       } else if (filterResult !== true) {
         throw new TemplateError({
-          message: `${arrayForEachFilterKey} clause in ${arrayForEachKey} loop must resolve to a boolean value (got ${typeof resolvedInput})`,
+          message: `${arrayForEachFilterKey} clause in ${arrayForEachKey} loop must resolve to a boolean value (got ${typeof filterResult})`,
           path: source.path && [...source.path, arrayForEachFilterKey],
           value,
           resolved: undefined,

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -2141,7 +2141,32 @@ describe("resolveTemplateStrings", () => {
       void expectError(
         () => resolveTemplateStrings({ source: undefined, value: obj, context: new GenericContext({}) }),
         {
-          contains: "$filter clause in $forEach loop must resolve to a boolean value (got object)",
+          contains: "$filter clause in $forEach loop must resolve to a boolean value (got string)",
+        }
+      )
+    })
+
+    // TODO: In a future iteration of this code, we should leave the entire $forEach expression unresolved if filter cannot be resolved yet and allowPartial=true.
+    it("throws if $filter can't be resolved, even if allowPartial=true", () => {
+      const obj = {
+        foo: {
+          $forEach: ["a", "b", "c"],
+          $filter: "${var.doesNotExist}",
+          $return: "${item.value}",
+        },
+      }
+
+      void expectError(
+        () =>
+          resolveTemplateStrings({
+            source: undefined,
+            value: obj,
+            context: new GenericContext({ var: { fruit: "banana" } }),
+            contextOpts: { allowPartial: true },
+          }),
+        {
+          contains:
+            "invalid template string (${var.doesnotexist}) at path foo.$filter: could not find key doesnotexist under var. available keys: fruit.",
         }
       )
     })


### PR DESCRIPTION
Old error due to bug:

```
$filter clause in $forEach loop must resolve to a boolean value (got object)
```

New error:

```
Invalid template string (${var.volume-mount-set == item.key}) at path MY_VOLUMES.$concat.$filter: Could not find key volume-mount-set under var. Available keys: $merge, MY_VOLUMES and volumes.
```