### PR TITLE
refactor(cloud): encapsulate backend-specific configs

### DIFF
--- a/core/src/cloud/backend.ts
+++ b/core/src/cloud/backend.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { AuthRedirectServerConfig } from "./auth.js"
+import { isArray } from "lodash-es"
+
+function getFirstValue(v: string | string[]) {
+  return isArray(v) ? v[0] : v
+}
+
+export type GardenBackendConfig = { readonly cloudDomain: string }
+export type AuthRedirectConfig = Pick<AuthRedirectServerConfig, "getLoginUrl" | "successUrl" | "extractAuthToken">
+
+export abstract class AbstractGardenBackend {
+  constructor(protected readonly config: GardenBackendConfig) {}
+
+  abstract getAuthRedirectConfig(): AuthRedirectConfig
+}
+
+export class GardenCloudBackend extends AbstractGardenBackend {
+  override getAuthRedirectConfig(): AuthRedirectConfig {
+    return {
+      getLoginUrl: (port) => new URL(`/clilogin/${port}`, this.config.cloudDomain).href,
+      successUrl: new URL("/clilogin/success", this.config.cloudDomain).href,
+      extractAuthToken: (query) => {
+        const { jwt, rt, jwtval } = query
+        // TODO: validate properly
+        return {
+          token: getFirstValue(jwt!),
+          refreshToken: getFirstValue(rt!),
+          tokenValidity: parseInt(getFirstValue(jwtval!), 10),
+        }
+      },
+    }
+  }
+}

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -6,23 +6,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { CommandParams, CommandResult } from "./base.js";
-import { Command } from "./base.js";
-import { printHeader } from "../logger/util.js";
-import dedent from "dedent";
-import { GardenCloudApi } from "../cloud/api.js";
-import type { Log } from "../logger/log-entry.js";
-import { CloudApiError, ConfigurationError, InternalError, TimeoutError } from "../exceptions.js";
-import type { AuthToken } from "../cloud/auth.js";
-import { AuthRedirectServer, saveAuthToken } from "../cloud/auth.js";
-import type { EventBus } from "../events/events.js";
-import type { ProjectConfig } from "../config/project.js";
-import { findProjectConfig } from "../config/base.js";
-import { BooleanParameter } from "../cli/params.js";
-import { deline } from "../util/string.js";
-import { gardenEnv } from "../constants.js";
-import { getCloudDistributionName, getGardenCloudDomain } from "../cloud/util.js";
-import { GardenCloudBackend } from "../cloud/backend.js";
+import type { CommandParams, CommandResult } from "./base.js"
+import { Command } from "./base.js"
+import { printHeader } from "../logger/util.js"
+import dedent from "dedent"
+import { GardenCloudApi } from "../cloud/api.js"
+import type { Log } from "../logger/log-entry.js"
+import { CloudApiError, ConfigurationError, InternalError, TimeoutError } from "../exceptions.js"
+import type { AuthToken } from "../cloud/auth.js"
+import { AuthRedirectServer, saveAuthToken } from "../cloud/auth.js"
+import type { EventBus } from "../events/events.js"
+import type { ProjectConfig } from "../config/project.js"
+import { findProjectConfig } from "../config/base.js"
+import { BooleanParameter } from "../cli/params.js"
+import { deline } from "../util/string.js"
+import { gardenEnv } from "../constants.js"
+import { getCloudDistributionName, getGardenCloudDomain } from "../cloud/util.js"
+import { GardenCloudBackend } from "../cloud/backend.js"
 
 const loginTimeoutSec = 60
 

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -6,23 +6,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { CommandParams, CommandResult } from "./base.js"
-import { Command } from "./base.js"
-import { printHeader } from "../logger/util.js"
-import dedent from "dedent"
-import { GardenCloudApi } from "../cloud/api.js"
-import type { Log } from "../logger/log-entry.js"
-import { CloudApiError, ConfigurationError, InternalError, TimeoutError } from "../exceptions.js"
-import type { AuthRedirectServerConfig, AuthToken } from "../cloud/auth.js"
-import { AuthRedirectServer, saveAuthToken } from "../cloud/auth.js"
-import type { EventBus } from "../events/events.js"
-import type { ProjectConfig } from "../config/project.js"
-import { findProjectConfig } from "../config/base.js"
-import { BooleanParameter } from "../cli/params.js"
-import { deline } from "../util/string.js"
-import { gardenEnv } from "../constants.js"
-import { getCloudDistributionName, getGardenCloudDomain } from "../cloud/util.js"
-import { isArray } from "lodash-es"
+import type { CommandParams, CommandResult } from "./base.js";
+import { Command } from "./base.js";
+import { printHeader } from "../logger/util.js";
+import dedent from "dedent";
+import { GardenCloudApi } from "../cloud/api.js";
+import type { Log } from "../logger/log-entry.js";
+import { CloudApiError, ConfigurationError, InternalError, TimeoutError } from "../exceptions.js";
+import type { AuthToken } from "../cloud/auth.js";
+import { AuthRedirectServer, saveAuthToken } from "../cloud/auth.js";
+import type { EventBus } from "../events/events.js";
+import type { ProjectConfig } from "../config/project.js";
+import { findProjectConfig } from "../config/base.js";
+import { BooleanParameter } from "../cli/params.js";
+import { deline } from "../util/string.js";
+import { gardenEnv } from "../constants.js";
+import { getCloudDistributionName, getGardenCloudDomain } from "../cloud/util.js";
+import { GardenCloudBackend } from "../cloud/backend.js";
 
 const loginTimeoutSec = 60
 
@@ -108,38 +108,6 @@ export class LoginCommand extends Command<{}, Opts> {
     log.success({ msg: `Successfully logged in to ${cloudDomain}.`, showDuration: false })
 
     return {}
-  }
-}
-
-function getFirstValue(v: string | string[]) {
-  return isArray(v) ? v[0] : v
-}
-
-export type GardenBackendConfig = { readonly cloudDomain: string }
-
-type AuthRedirectConfig = Pick<AuthRedirectServerConfig, "getLoginUrl" | "successUrl" | "extractAuthToken">
-
-export abstract class AbstractGardenBackend {
-  constructor(protected readonly config: GardenBackendConfig) {}
-
-  abstract getAuthRedirectConfig(): AuthRedirectConfig
-}
-
-export class GardenCloudBackend extends AbstractGardenBackend {
-  override getAuthRedirectConfig(): AuthRedirectConfig {
-    return {
-      getLoginUrl: (port) => new URL(`/clilogin/${port}`, this.config.cloudDomain).href,
-      successUrl: new URL("/clilogin/success", this.config.cloudDomain).href,
-      extractAuthToken: (query) => {
-        const { jwt, rt, jwtval } = query
-        // TODO: validate properly
-        return {
-          token: getFirstValue(jwt!),
-          refreshToken: getFirstValue(rt!),
-          tokenValidity: parseInt(getFirstValue(jwtval!), 10),
-        }
-      },
-    }
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `AuthRedirectServer` backend-agnostic.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
