### PR TITLE
fix(template): establish backwards bug-compatibility for kubernetes manifest files

### DIFF
--- a/core/src/config/template-contexts/base.ts
+++ b/core/src/config/template-contexts/base.ts
@@ -25,6 +25,10 @@ export type ContextKey = ContextKeySegment[]
 export interface ContextResolveOpts {
   // Allow templates to be partially resolved (used to defer runtime template resolution, for example)
   allowPartial?: boolean
+  // This is kept for backwards compatibility of rendering kubernetes manifests
+  // TODO(0.14): Do not allow the use of template strings in kubernetes manifest files
+  // TODO(0.14): Remove legacyAllowPartial
+  legacyAllowPartial?: boolean
   // Allow partial resolution for values that originate from a special context that always returns CONTEXT_RESOLVE_KEY_AVAILABLE_LATER.
   // This is used for module resolution and can be removed whenever we remove support for modules.
   allowPartialContext?: boolean

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -253,14 +253,14 @@ export async function makeTempDir({
 }: { git?: boolean; initialCommit?: boolean } = {}): Promise<TempDirectory> {
   const tmpDir = await tmp.dir({ unsafeCleanup: true })
   // Fully resolve path so that we don't get path mismatches in tests
-  const tmpPath = await realpath(tmpDir.path)
+  tmpDir.path = await realpath(tmpDir.path)
 
   if (git) {
-    await exec("git", ["init", "--initial-branch=main"], { cwd: tmpPath })
+    await exec("git", ["init", "--initial-branch=main"], { cwd: tmpDir.path })
     if (initialCommit) {
-      await writeFile(join(tmpPath, "foo"), "bar")
-      await exec("git", ["add", "."], { cwd: tmpPath })
-      await exec("git", ["commit", "-m", "first commit"], { cwd: tmpPath })
+      await writeFile(join(tmpDir.path, "foo"), "bar")
+      await exec("git", ["add", "."], { cwd: tmpDir.path })
+      await exec("git", ["commit", "-m", "first commit"], { cwd: tmpDir.path })
     }
   }
 

--- a/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/garden.yml
+++ b/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/garden.yml
@@ -1,0 +1,25 @@
+
+kind: Deploy
+type: kubernetes
+name: legacypartial-ifblock-doesnotexist
+spec:
+  files:
+   - ./k8s/ifblock-doesnotexist.yaml
+
+---
+
+kind: Deploy
+type: kubernetes
+name: legacypartial-ifblock-true
+spec:
+  files:
+   - ./k8s/ifblock-true.yaml
+
+---
+
+kind: Deploy
+type: kubernetes
+name: legacypartial-ifblock-false
+spec:
+  files:
+   - ./k8s/ifblock-false.yaml

--- a/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/k8s/ifblock-doesnotexist.yaml
+++ b/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/k8s/ifblock-doesnotexist.yaml
@@ -1,0 +1,15 @@
+${if var.doesNotExist}
+apiVersion: v1
+kind: Service
+metadata:
+  name: silly-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9090
+    targetPort: 9090
+    protocol: TCP
+    name: http
+  selector:
+    app: silly-demo
+${endif}

--- a/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/k8s/ifblock-false.yaml
+++ b/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/k8s/ifblock-false.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+${if false}
+  name: evaluated wrong branch
+${else}
+  name: it-${"partially"}-resolves-${var.doesNotExist}-and-$${unescapes}
+${endif}

--- a/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/k8s/ifblock-true.yaml
+++ b/core/test/data/test-projects/kubernetes-type/legacyAllowPartial/k8s/ifblock-true.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+${if true}
+  name: it-${"partially"}-resolves-${var.doesNotExist}-and-$${unescapes}
+${else}
+  name: evaluated wrong branch
+${endif}

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -44,6 +44,63 @@ describe("getManifests", () => {
   let api: KubeApi
   const defaultNamespace = "foobar"
 
+  context("legacyAllowPartial", () => {
+    let action: Resolved<KubernetesDeployAction>
+
+    before(async () => {
+      garden = await getKubernetesTestGarden()
+      const provider = (await garden.resolveProvider({
+        log: garden.log,
+        name: "local-kubernetes",
+      })) as KubernetesProvider
+      ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+      api = await KubeApi.factory(garden.log, ctx, provider)
+    })
+
+    beforeEach(async () => {
+      graph = await garden.getConfigGraph({
+        log: garden.log,
+        emit: false,
+      })
+    })
+
+    it("crashes with yaml syntax error if an if block references variable that does not exist", async () => {
+      action = await garden.resolveAction<KubernetesDeployAction>({
+        action: cloneDeep(graph.getDeploy("legacypartial-ifblock-doesnotexist")),
+        log: garden.log,
+        graph,
+      })
+
+      await expectError(() => getManifests({ ctx, api, action, log: garden.log, defaultNamespace }), {
+        contains: ["could not parse ifblock-doesnotexist.yaml in directory ", "as valid yaml"],
+      })
+    })
+
+    it("partially resolves the consequent branch of ${if true} block", async () => {
+      action = await garden.resolveAction<KubernetesDeployAction>({
+        action: cloneDeep(graph.getDeploy("legacypartial-ifblock-true")),
+        log: garden.log,
+        graph,
+      })
+
+      const result = await getManifests({ ctx, api, action, log: garden.log, defaultNamespace })
+      expect(result.length).to.eq(2) // due to metadata configmap
+      expect(result[0].metadata.name).to.eq("it-partially-resolves-${var.doesNotExist}-and-${unescapes}")
+    })
+
+    it("partially resolves the alternate branch of ${if false} block", async () => {
+      action = await garden.resolveAction<KubernetesDeployAction>({
+        action: cloneDeep(graph.getDeploy("legacypartial-ifblock-false")),
+        log: garden.log,
+        graph,
+      })
+
+      const result = await getManifests({ ctx, api, action, log: garden.log, defaultNamespace })
+      expect(result.length).to.eq(2) // due to metadata configmap
+      expect(result[0].metadata.name).to.eq("it-partially-resolves-${var.doesNotExist}-and-${unescapes}")
+    })
+  })
+
   context("duplicates", () => {
     let action: Resolved<KubernetesDeployAction>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Template strings in Kubernetes manifest files are partially resolved for legacy reasons. The partial resolve behaviour has been changed to improve sanity in https://github.com/garden-io/garden/pull/6685 but for kubernetes manifest files, we need to have a version of the old behaviour.

The expected legacy behaviour looks like this:
- If template strings reference variables that do not exist there is no error
- If a template string contains multiple template expressions, each expression can be partially resolved.
- Template expressions are evaluated before parsing yaml, which means that valid yaml with template expressions can be resolved to invalid yaml (e.g. if variable values contain special characters)

This legacy behaviour can lead to quite some surprises and UX problems, for example https://github.com/garden-io/garden/issues/5266

I would suggest that we remove this functionality in 0.14 in favor of the `patchManifests` feature

**Which issue(s) this PR fixes**:

Fixes #6711

**Special notes for your reviewer**:
