### PR TITLE
ci(build-dist): update Rust version to 1.83.0

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -287,9 +287,10 @@ commands:
             source "$HOME/.cargo/env"
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
 
-            # TODO: use the latest stable Rust version and apply the necessary fixes for the Windows build
-            # See the requirements change in https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html
-            RUST_VERSION="1.77.2"
+            # Install the latest stable Rust version
+            # We maintain it manually to avoid unexpected breaking changes like we faced in Rust 1.78 for Windows builds.
+            # See https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html for details.
+            RUST_VERSION="1.83.0"
             rustup install $RUST_VERSION
             rustup default $RUST_VERSION
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This fixes CI build errors like [this](https://app.circleci.com/pipelines/github/garden-io/garden/28054/workflows/a0b286db-6ad9-4426-a7cd-b04e4110f682).

The Rust version 1.77.2 (that we used before) is no longer compatible with some dependencies.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

A follow-up PR for #6000.