### PR TITLE
Revert perf(git): use `sub-tree` scan mode for config files scan

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -286,7 +286,6 @@ export class Garden {
   public readonly localConfigStore: LocalConfigStore
   public globalConfigStore: GlobalConfigStore
   public readonly vcs: VcsHandler
-  private readonly configScanVcs: VcsHandler
   public events: EventBus
   private tools?: { [key: string]: PluginTool }
   public readonly configTemplates: { [name: string]: ConfigTemplateConfig }
@@ -387,19 +386,12 @@ export class Garden {
     const gitMode = params.projectConfig.scan?.git?.mode || gardenEnv.GARDEN_GIT_SCAN_MODE
     const handlerCls = gitMode === "repo" ? GitRepoHandler : GitSubTreeHandler
 
-    const vcsCache = new TreeCache()
     this.vcs = new handlerCls({
       garden: this,
       projectRoot: params.projectRoot,
       gardenDirPath: params.gardenDirPath,
       ignoreFile: params.dotIgnoreFile,
-      cache: vcsCache,
-    })
-    this.configScanVcs = new GitSubTreeHandler({
-      projectRoot: params.projectRoot,
-      gardenDirPath: params.gardenDirPath,
-      ignoreFile: params.dotIgnoreFile,
-      cache: vcsCache,
+      cache: new TreeCache(),
     })
 
     // Use the legacy build sync mode if
@@ -1380,7 +1372,7 @@ export class Garden {
     log.silly(() => `Scanning for configs in ${path}`)
 
     return findConfigPathsInPath({
-      vcs: this.configScanVcs,
+      vcs: this.vcs,
       dir: path,
       include: this.moduleIncludePatterns,
       exclude: this.moduleExcludePatterns,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This reverts commit 131663140f8f80c13305f22ceb67e8d0e4ab5e79 (from PR #6483)