### PR TITLE
feat: allow overriding `source.path` in remote actions (when using `source.repository`)

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -87,18 +87,20 @@ const actionSourceSpecSchema = createSchema({
   description: dedent`
     By default, the directory where the action is defined is used as the source for the build context.
 
-    You can override this by setting either \`source.path\` to another (POSIX-style) path relative to the action source directory, or \`source.repository\` to get the source from an external repository.
+    You can override the directory that is used for the build context by setting \`source.path\`.
 
-    If using \`source.path\`, you must make sure the target path is in a git repository.
-
-    For \`source.repository\` behavior, please refer to the [Remote Sources guide](${DOCS_BASE_URL}/advanced/using-remote-sources).
-  `,
+    You can use \`source.repository\` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](${DOCS_BASE_URL}/advanced/using-remote-sources).`,
   keys: () => ({
     path: joi
       .posixPath()
       .relativeOnly()
       .description(
-        `A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!`
+        dedent`
+          A relative POSIX-style path to the source directory for this action.
+
+          If specified together with \`source.repository\`, the path will be relative to the repository root.
+
+          Otherwise, the path will be relative to the directory containing the Garden configuration file.`
       ),
     repository: joi
       .object()
@@ -109,7 +111,6 @@ const actionSourceSpecSchema = createSchema({
         `When set, Garden will import the action source from this repository, but use this action configuration (and not scan for configs in the separate repository).`
       ),
   }),
-  oxor: [["path", "repository"]],
   meta: { name: "action-source", advanced: true, templateContext: ActionConfigContext },
 })
 

--- a/core/test/data/test-project-remote-action/garden.yml
+++ b/core/test/data/test-project-remote-action/garden.yml
@@ -1,0 +1,5 @@
+apiVersion: garden.io/v1
+kind: Project
+name: test-project-remote-action
+environments:
+  - name: local

--- a/core/test/data/test-project-remote-action/remote-action-a/garden.yml
+++ b/core/test/data/test-project-remote-action/remote-action-a/garden.yml
@@ -1,0 +1,10 @@
+kind: Build
+name: remote-action-a
+type: exec
+spec:
+  # This command tests presence of Docker
+  # and in turn, if the action is running in the right subdirectory (remote repository root)
+  command: [ls, Dockerfile]
+source:
+  repository:
+    url: https://github.com/garden-io/garden-example-remote-module-jworker.git#8f6da155581a567ffa28c410174d43d74eb4cb9b

--- a/core/test/data/test-project-remote-action/remote-action-b/garden.yml
+++ b/core/test/data/test-project-remote-action/remote-action-b/garden.yml
@@ -1,0 +1,11 @@
+kind: Build
+name: remote-action-b
+type: exec
+spec:
+  # This command tests presence of Worker.java
+  # and in turn, if the action is running in the right subdirectory (src/main/java/worker)
+  command: [ls, Worker.java]
+source:
+  path: src/main/java/worker
+  repository:
+    url: https://github.com/garden-io/garden-example-remote-module-jworker.git#8f6da155581a567ffa28c410174d43d74eb4cb9b

--- a/core/test/unit/src/actions/remote-actions.ts
+++ b/core/test/unit/src/actions/remote-actions.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+
+import type { Garden } from "../../../../src/garden.js"
+import { gardenPlugin } from "../../../../src/plugins/exec/exec.js"
+import type { ActionLog } from "../../../../src/logger/log-entry.js"
+import { createActionLog } from "../../../../src/logger/log-entry.js"
+import { getDataDir } from "../../../helpers.js"
+import { makeTestGarden } from "../../../helpers.js"
+import type { ConfigGraph } from "../../../../src/graph/config-graph.js"
+
+import { ACTION_RUNTIME_LOCAL } from "../../../../src/plugin/base.js"
+import { BuildTask } from "../../../../src/tasks/build.js"
+
+describe("remote actions", () => {
+  context("test-project based tests", () => {
+    const testProjectRoot = getDataDir("test-project-remote-action")
+    const plugin = gardenPlugin
+
+    let garden: Garden
+    // let execProvider: ExecProvider
+    let graph: ConfigGraph
+    let log: ActionLog
+
+    beforeEach(async () => {
+      garden = await makeTestGarden(testProjectRoot, { plugins: [plugin] })
+      graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      // execProvider = await garden.resolveProvider({ log: garden.log, name: "exec" })
+      // const ctx = await garden.getPluginContext({ provider: execProvider, templateContext: undefined, events: undefined })
+      log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
+      await garden.clearBuilds()
+    })
+
+    it("remote action source path should default to repository root", async () => {
+      const action = graph.getBuild("remote-action-a")
+      const resolvedAction = await garden.resolveAction({ action, log, graph })
+
+      const task = new BuildTask({
+        garden,
+        action: resolvedAction,
+        graph,
+        log,
+        force: true,
+      })
+
+      const results = await garden.processTasks({ tasks: [task], throwOnError: true })
+
+      expect(results.results.getResult(task)?.result?.detail).to.eql({
+        buildLog: "Dockerfile",
+        fresh: true,
+        runtime: ACTION_RUNTIME_LOCAL,
+      })
+    })
+
+    it("if remote action specifies source path, it should be relative from remote repository", async () => {
+      const action = graph.getBuild("remote-action-b")
+      const resolvedAction = await garden.resolveAction({ action, log, graph })
+
+      const task = new BuildTask({
+        garden,
+        action: resolvedAction,
+        graph,
+        log,
+        force: true,
+      })
+
+      const results = await garden.processTasks({ tasks: [task], throwOnError: true })
+
+      expect(results.results.getResult(task)?.result?.detail).to.eql({
+        buildLog: "Worker.java",
+        fresh: true,
+        runtime: ACTION_RUNTIME_LOCAL,
+      })
+    })
+  })
+})

--- a/docs/advanced/using-remote-sources.md
+++ b/docs/advanced/using-remote-sources.md
@@ -96,6 +96,8 @@ source:
 ...
 ```
 
+You can use the `source.path` option together with the `source.repository` option to override the directory inside the git repository.
+
 As with remote sources, the URL must point to a specific branch or tag.
 
 Use this when you want to configure the action within your main project but import the source from another repository.

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -44,11 +44,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -58,7 +56,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -44,11 +44,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -58,7 +56,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -56,11 +56,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -70,7 +68,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -44,11 +44,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -58,7 +56,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -48,11 +48,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -62,7 +60,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -50,11 +50,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -64,7 +62,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -48,11 +48,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -62,7 +60,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -52,11 +52,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -66,7 +64,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -44,11 +44,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -58,7 +56,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -50,11 +50,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -64,7 +62,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -48,11 +48,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -62,7 +60,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -44,11 +44,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -58,7 +56,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -50,11 +50,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -64,7 +62,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -46,11 +46,9 @@ A description of the action.
 
 By default, the directory where the action is defined is used as the source for the build context.
 
-You can override this by setting either `source.path` to another (POSIX-style) path relative to the action source directory, or `source.repository` to get the source from an external repository.
+You can override the directory that is used for the build context by setting `source.path`.
 
-If using `source.path`, you must make sure the target path is in a git repository.
-
-For `source.repository` behavior, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -60,7 +58,11 @@ For `source.repository` behavior, please refer to the [Remote Sources guide](htt
 
 [source](#source) > path
 
-A relative POSIX-style path to the source directory for this action. You must make sure this path exists and is in a git repository!
+A relative POSIX-style path to the source directory for this action.
+
+If specified together with `source.repository`, the path will be relative to the repository root.
+
+Otherwise, the path will be relative to the directory containing the Garden configuration file.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1780,16 +1780,16 @@ actionConfigs:
 
       # By default, the directory where the action is defined is used as the source for the build context.
       #
-      # You can override this by setting either `source.path` to another (POSIX-style) path relative to the action
-      # source directory, or `source.repository` to get the source from an external repository.
+      # You can override the directory that is used for the build context by setting `source.path`.
       #
-      # If using `source.path`, you must make sure the target path is in a git repository.
-      #
-      # For `source.repository` behavior, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/advanced/using-remote-sources).
+      # You can use `source.repository` to get the source from an external repository. For more information on remote
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
-        # A relative POSIX-style path to the source directory for this action. You must make sure this path exists and
-        # is in a git repository!
+        # A relative POSIX-style path to the source directory for this action.
+        #
+        # If specified together with `source.repository`, the path will be relative to the repository root.
+        #
+        # Otherwise, the path will be relative to the directory containing the Garden configuration file.
         path:
 
         # When set, Garden will import the action source from this repository, but use this action configuration (and
@@ -1965,16 +1965,16 @@ actionConfigs:
 
       # By default, the directory where the action is defined is used as the source for the build context.
       #
-      # You can override this by setting either `source.path` to another (POSIX-style) path relative to the action
-      # source directory, or `source.repository` to get the source from an external repository.
+      # You can override the directory that is used for the build context by setting `source.path`.
       #
-      # If using `source.path`, you must make sure the target path is in a git repository.
-      #
-      # For `source.repository` behavior, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/advanced/using-remote-sources).
+      # You can use `source.repository` to get the source from an external repository. For more information on remote
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
-        # A relative POSIX-style path to the source directory for this action. You must make sure this path exists and
-        # is in a git repository!
+        # A relative POSIX-style path to the source directory for this action.
+        #
+        # If specified together with `source.repository`, the path will be relative to the repository root.
+        #
+        # Otherwise, the path will be relative to the directory containing the Garden configuration file.
         path:
 
         # When set, Garden will import the action source from this repository, but use this action configuration (and
@@ -2120,16 +2120,16 @@ actionConfigs:
 
       # By default, the directory where the action is defined is used as the source for the build context.
       #
-      # You can override this by setting either `source.path` to another (POSIX-style) path relative to the action
-      # source directory, or `source.repository` to get the source from an external repository.
+      # You can override the directory that is used for the build context by setting `source.path`.
       #
-      # If using `source.path`, you must make sure the target path is in a git repository.
-      #
-      # For `source.repository` behavior, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/advanced/using-remote-sources).
+      # You can use `source.repository` to get the source from an external repository. For more information on remote
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
-        # A relative POSIX-style path to the source directory for this action. You must make sure this path exists and
-        # is in a git repository!
+        # A relative POSIX-style path to the source directory for this action.
+        #
+        # If specified together with `source.repository`, the path will be relative to the repository root.
+        #
+        # Otherwise, the path will be relative to the directory containing the Garden configuration file.
         path:
 
         # When set, Garden will import the action source from this repository, but use this action configuration (and
@@ -2275,16 +2275,16 @@ actionConfigs:
 
       # By default, the directory where the action is defined is used as the source for the build context.
       #
-      # You can override this by setting either `source.path` to another (POSIX-style) path relative to the action
-      # source directory, or `source.repository` to get the source from an external repository.
+      # You can override the directory that is used for the build context by setting `source.path`.
       #
-      # If using `source.path`, you must make sure the target path is in a git repository.
-      #
-      # For `source.repository` behavior, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/advanced/using-remote-sources).
+      # You can use `source.repository` to get the source from an external repository. For more information on remote
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
-        # A relative POSIX-style path to the source directory for this action. You must make sure this path exists and
-        # is in a git repository!
+        # A relative POSIX-style path to the source directory for this action.
+        #
+        # If specified together with `source.repository`, the path will be relative to the repository root.
+        #
+        # Otherwise, the path will be relative to the directory containing the Garden configuration file.
         path:
 
         # When set, Garden will import the action source from this repository, but use this action configuration (and


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow overriding `source.path` in remote actions (when using `source.repository`).

This is useful when an action source path needs to be a subdirectory in a remote repository.

**Special notes for your reviewer**:
This feature already was working, I just lifted the limitation in the validation code and added a test, and updated docs.

See also Discord thread: https://discord.com/channels/817392104711651328/1320775997880144005/1320775997880144005