### PR TITLE
fix: resolve parts of template strings, even if another part cannot be resolved yet.

### DIFF
--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -139,6 +139,7 @@ export async function renderConfigTemplate({
     context: templateContext,
     contextOpts: {
       allowPartial: true,
+      legacyAllowPartial: true,
     },
     source: { yamlDoc, path: ["inputs"] },
   })
@@ -213,7 +214,7 @@ async function renderModules({
       const spec = resolveTemplateStrings({
         value: m,
         context,
-        contextOpts: { allowPartial: true },
+        contextOpts: { allowPartial: true, legacyAllowPartial: true },
         source: { yamlDoc, path: ["modules", i] },
       })
       const renderConfigPath = renderConfig.internal.configFilePath || renderConfig.internal.basePath
@@ -280,7 +281,7 @@ async function renderConfigs({
   const partiallyResolvedTemplateConfigs = resolveTemplateStrings({
     value: templateConfigs,
     context,
-    contextOpts: { allowPartial: true },
+    contextOpts: { allowPartial: true, legacyAllowPartial: true },
     source,
   })
 

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -380,6 +380,7 @@ export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
       context,
       contextOpts: {
         allowPartial: true,
+        legacyAllowPartial: true,
       },
       // TODO: Map inputs to their original YAML sources
       source: undefined,

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -747,7 +747,7 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
       },
       variables,
     }),
-    contextOpts: { allowPartial: true },
+    contextOpts: { allowPartial: true, legacyAllowPartial: true },
     // TODO: See about mapping this to the original variable sources
     source: undefined,
   })
@@ -765,7 +765,7 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
         },
         variables: resolvedVariables,
       }),
-      contextOpts: { allowPartial: true },
+      contextOpts: { allowPartial: true, legacyAllowPartial: true },
       // TODO: See about mapping this to the original inputs source
       source: undefined,
     })
@@ -844,6 +844,7 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
       context: builtinFieldContext,
       contextOpts: {
         allowPartial: true,
+        legacyAllowPartial: true,
       },
       source: { yamlDoc, path: [] },
     })

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -540,7 +540,7 @@ export class ModuleResolver {
     const resolvedDeps = resolveTemplateStrings({
       value: rawConfig.build.dependencies,
       context: configContext,
-      contextOpts: { allowPartial: true },
+      contextOpts: { allowPartial: true, legacyAllowPartial: true },
       // Note: We're not implementing the YAML source mapping for modules
       source: undefined,
     })
@@ -581,7 +581,7 @@ export class ModuleResolver {
     return resolveTemplateStrings({
       value: inputs,
       context: configContext,
-      contextOpts: { allowPartial: true },
+      contextOpts: { allowPartial: true, legacyAllowPartial: true },
       // Note: We're not implementing the YAML source mapping for modules
       source: undefined,
     })
@@ -643,6 +643,7 @@ export class ModuleResolver {
       context: new GenericContext({ inputs }),
       contextOpts: {
         allowPartial: true,
+        legacyAllowPartial: true,
       },
       // Note: We're not implementing the YAML source mapping for modules
       source: undefined,

--- a/core/test/data/test-projects/config-templates-partial/garden.yml
+++ b/core/test/data/test-projects/config-templates-partial/garden.yml
@@ -1,0 +1,36 @@
+apiVersion: garden.io/v1
+kind: Project
+name: config-templates
+environments:
+  - name: local
+providers:
+  - name: exec
+variables:
+  sync_targets:
+    test: ["foo", "bar"]
+
+---
+
+kind: RenderTemplate
+template: tpl
+name: foo
+inputs:
+  name: test
+
+---
+
+kind: ConfigTemplate
+name: tpl
+inputsSchemaPath: schema.json
+configs:
+  - kind: Build
+    type: exec
+    name: ${parent.name}-${inputs.name}-dt
+    include: []
+    variables:
+      myDir: "${var.sync_root || '../../../'}${inputs.name}"
+      syncTargets:
+      - $concat:
+          $forEach: ${var.sync_targets[inputs.name] || []}
+          $return:
+            source: "${var.sync_root || '../../../'}${item.value}"

--- a/core/test/data/test-projects/config-templates-partial/schema.json
+++ b/core/test/data/test-projects/config-templates-partial/schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where in certain cases we get errors like "`Could not find key item`" or "`Could not find key inputs`" since `0.13.46`, where the template parser has been rewritten.

Another PR is currently in progress, #6745, which will also fix this issue by capturing contexts instead of partially resolving templates. That PR won't get ready this week anymore though.

This fix is not complete, as the implementtion before 0.13.45 was not either – in certain situations partial resolution isn't cutting it, for example a template string like `${actions.build[input.name].outputs.log}`. Those cases will be solved by #6745
