### PR TITLE
chore: remove too noisy silly-log message

### DIFF
--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -177,7 +177,6 @@ export class GitRepoHandler extends AbstractGitHandler {
 
     const filtered = this.filterPaths({
       files: filesAtPath,
-      log,
       path,
       augmentedIncludes,
       augmentedExcludes,
@@ -191,14 +190,12 @@ export class GitRepoHandler extends AbstractGitHandler {
   }
 
   private filterPaths({
-    log,
     files,
     path,
     augmentedIncludes,
     augmentedExcludes,
     filter,
   }: {
-    log: GetFilesParams["log"]
     files: VcsFile[]
     path: string
     augmentedIncludes: string[]
@@ -214,7 +211,6 @@ export class GitRepoHandler extends AbstractGitHandler {
       // Previously we prepended the module path to the globs
       // but that caused issues with the glob matching on windows due to backslashes
       const relativePath = p.replace(`${path}${sep}`, "")
-      log.silly(() => `Checking if ${relativePath} matches include/exclude globs`)
       return matchPath(relativePath, augmentedIncludes, augmentedExcludes)
     })
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

That log statement can produce tens of megabytes of logs that do not help in debugging.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
