### PR TITLE
fix(core): emit namespaceStatus events during provider init

### DIFF
--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -155,6 +155,14 @@ export class PluginEventBroker extends EventEmitter<PluginEvents, PluginEventTyp
     this.garden.events.onKey("_exit", this.abortHandler, garden.sessionId)
     this.garden.events.onKey("_restart", this.abortHandler, garden.sessionId)
 
+    // Always pipe `namespaceStatus` events to the main event bus, since we need this to happen both during provider
+    // resolution (where `prepareEnvironment` is called, see `ResolveProviderTask`) and inside action handlers.
+    //
+    // Note: If any other plugin events without action-specific metadata are needed, they should be added here.
+    this.on("namespaceStatus", (status: NamespaceStatus) => {
+      this.garden.events.emit("namespaceStatus", status)
+    })
+
     this.on("abort", () => {
       this.aborted = true
     })

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -15,7 +15,7 @@ import type { KubernetesPluginContext, KubernetesProvider } from "../config.js"
 import { configureSyncMode, convertKubernetesModuleDevModeSpec } from "../sync.js"
 import { apply, deleteObjectsBySelector } from "../kubectl.js"
 import { streamK8sLogs } from "../logs.js"
-import { getActionNamespace, getActionNamespaceStatus } from "../namespace.js"
+import { deleteNamespaces, getActionNamespace, getActionNamespaceStatus } from "../namespace.js"
 import { getForwardablePorts, killPortForwards } from "../port-forward.js"
 import { getK8sIngresses } from "../status/ingress.js"
 import type { ResourceStatus } from "../status/status.js"
@@ -28,13 +28,7 @@ import {
 } from "../status/status.js"
 import type { BaseResource, KubernetesResource, KubernetesServerResource, SyncableResource } from "../types.js"
 import type { ManifestMetadata, ParsedMetadataManifestData } from "./common.js"
-import {
-  convertServiceResource,
-  gardenNamespaceAnnotationValue,
-  getManifests,
-  getMetadataManifest,
-  parseMetadataResource,
-} from "./common.js"
+import { convertServiceResource, getManifests, getMetadataManifest, parseMetadataResource } from "./common.js"
 import type { KubernetesModule } from "./module-config.js"
 import { configureKubernetesModule } from "./module-config.js"
 import { configureLocalMode, startServiceInLocalMode } from "../local-mode.js"
@@ -493,20 +487,7 @@ export const deleteKubernetesDeploy: DeployActionHandler<"delete", KubernetesDep
   const [namespaceManifests, otherManifests] = partition(manifests, (m) => m.kind === "Namespace")
 
   if (namespaceManifests.length > 0) {
-    await Promise.all(
-      namespaceManifests.map((ns) => {
-        const selector = `${gardenAnnotationKey("service")}=${gardenNamespaceAnnotationValue(ns.metadata.name)}`
-        return deleteObjectsBySelector({
-          log,
-          ctx,
-          provider,
-          namespace,
-          selector,
-          objectTypes: ["Namespace"],
-          includeUninitialized: false,
-        })
-      })
-    )
+    await deleteNamespaces({ namespaces: namespaceManifests.map((ns) => ns.metadata.name), api, ctx, log })
   }
   if (otherManifests.length > 0) {
     await deleteObjectsBySelector({

--- a/core/src/router/base.ts
+++ b/core/src/router/base.ts
@@ -39,7 +39,6 @@ import { getNames } from "../util/util.js"
 import { defaultProvider } from "../config/provider.js"
 import type { ConfigGraph } from "../graph/config-graph.js"
 import { ActionConfigContext, ActionSpecContext } from "../config/template-contexts/actions.js"
-import type { NamespaceStatus } from "../types/namespace.js"
 import { TemplatableConfigContext } from "../config/template-contexts/project.js"
 import type { ParamsBase } from "../plugin/handlers/base/base.js"
 import { Profile } from "../util/profiling.js"
@@ -74,11 +73,7 @@ export abstract class BaseRouter {
     events: PluginEventBroker | undefined
   ): Promise<PluginActionParamsBase> {
     const provider = await this.garden.resolveProvider({ log, name: handler.pluginName })
-
     const ctx = await this.garden.getPluginContext({ provider, templateContext, events })
-
-    // Forward plugin events that don't need any action-specific metadata (currently just `namespaceStatus` events).
-    ctx.events.on("namespaceStatus", (status: NamespaceStatus) => this.garden.events.emit("namespaceStatus", status))
 
     return {
       ctx,

--- a/core/test/integ/src/plugins/kubernetes/namespace.ts
+++ b/core/test/integ/src/plugins/kubernetes/namespace.ts
@@ -47,9 +47,9 @@ describe("Kubernetes Namespace helpers", () => {
   })
 
   describe("getNamespaceStatus", () => {
-    it("should return the namespace status and emit a namespace status event on the plugin event broker", async () => {
+    it("should return the namespace status and emit a namespace status event", async () => {
       let namespaceStatusFromEvent: NamespaceStatus | null = null
-      const expecteedNamespaceName = "container-default"
+      const expectedNamespaceName = "container-default"
       ctx.events.once("namespaceStatus", (s) => (namespaceStatusFromEvent = s))
       const status = await getNamespaceStatus({
         log,
@@ -58,14 +58,16 @@ describe("Kubernetes Namespace helpers", () => {
         skipCreate: true,
       })
       expect(namespaceStatusFromEvent).to.exist
-      expect(namespaceStatusFromEvent!.namespaceName).to.eql(expecteedNamespaceName)
+      expect(namespaceStatusFromEvent!.namespaceName).to.eql(expectedNamespaceName)
       expect(status).to.exist
-      expect(status.namespaceName).to.eql(expecteedNamespaceName)
+      expect(status.namespaceName).to.eql(expectedNamespaceName)
     })
   })
 
   describe("ensureNamespace", () => {
-    it("should create the namespace if it doesn't exist, with configured annotations and labels", async () => {
+    it("should create the namespace if it doesn't exist, with configured annotations and labels and emit a namespace status event", async () => {
+      let namespaceStatusFromEvent: NamespaceStatus | null = null
+      ctx.events.once("namespaceStatus", (s) => (namespaceStatusFromEvent = s))
       const namespace = {
         name: namespaceName,
         annotations: { foo: "bar" },
@@ -86,6 +88,9 @@ describe("Kubernetes Namespace helpers", () => {
 
       expect(result.created).to.be.true
       expect(result.patched).to.be.false
+
+      expect(namespaceStatusFromEvent).to.exist
+      expect(namespaceStatusFromEvent!.namespaceName).to.eql(namespaceName)
     })
 
     it("should add configured annotations if any are missing", async () => {


### PR DESCRIPTION
This was fixed by setting up the event forwarding during the initialization of the plugin event bus.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, `namespaceStatus` events weren't actually being emitted during provider resolution, since the event bus on the plugin context hadn't been set up to pipe `namespaceStatus` events to the main event bus (this happened later in the flow).

This is the probable cause for some users experiencing dangling namespaces that weren't being cleared up by Cloud's automatic environment cleanup when module/action resolution failed (since the namespace status events that would usually be emitted by the "get status" and "deploy" handlers for those actions weren't being emitted). This still needs to be verified, but most likely fixes the issue.