### PR TITLE
docs(install): clarify windows OS requirements

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -81,9 +81,9 @@ for further information. For remote clusters, take a look at the [Remote Kuberne
 
 ## Windows
 
-You can run Garden on Windows 10 Home, Pro or Enterprise editions.
+You can run Garden on Windows 10 or later.
 
-_Note: The Home edition doesn't support virtualization, but you can still use Garden if you're working with [remote Kubernetes](../k8s-plugins/remote-k8s/README.md) and [in-cluster building](../k8s-plugins/guides/in-cluster-building.md)._
+_Note: Building docker images generally requires installing Docker Desktop. Please refer to [the Docker Desktop documentation for its requirements](https://docs.docker.com/desktop/setup/install/windows-install/)._
 
 To install the Garden CLI and its dependencies, please use our installation script. To run the script, open PowerShell as an administrator and run:
 


### PR DESCRIPTION
Garden requires Windows 10 or later and does not care about the edition. Docker Desktop on the other hand has more specific requirements.
