### PR TITLE
fix: do not crash on missing `deploymentRegistry` for in-cluster builds

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -95,7 +95,8 @@ interface KubernetesStorage {
   builder: KubernetesStorageSpec
 }
 
-export type ContainerBuildMode = "local-docker" | "kaniko" | "cluster-buildkit"
+const containerBuildModes = ["local-docker", "kaniko", "cluster-buildkit"] as const
+export type ContainerBuildMode = (typeof containerBuildModes)[number]
 
 /**
  * To be removed in 0.14
@@ -418,11 +419,10 @@ export const utilImageRegistryDomainSpec = joi.string().default(defaultUtilImage
     Otherwise the utility images are pulled directly from Docker Hub by default.
   `)
 
-const validBuildModes = ["local-docker", "kaniko", "cluster-buildkit"] as const
 const buildModeSchema = () =>
   joi
     .string()
-    .valid(...validBuildModes)
+    .valid(...containerBuildModes)
     .default("local-docker")
     .description(
       dedent`

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -419,7 +419,6 @@ export const utilImageRegistryDomainSpec = joi.string().default(defaultUtilImage
   `)
 
 const validBuildModes = ["local-docker", "kaniko", "cluster-buildkit"] as const
-type ValidBuildMode = (typeof validBuildModes)[number]
 const buildModeSchema = () =>
   joi
     .string()
@@ -747,23 +746,7 @@ export const configSchema = () =>
     .keys({
       name: joiProviderName("kubernetes"),
       context: k8sContextSchema().required(),
-      deploymentRegistry: joi.alternatives().conditional("buildMode", {
-        switch: [
-          {
-            is: "kaniko" satisfies ValidBuildMode,
-            then: deploymentRegistrySchema().required(),
-          },
-          {
-            is: "cluster-buildkit" satisfies ValidBuildMode,
-            then: deploymentRegistrySchema().required(),
-          },
-          {
-            is: "local-docker" satisfies ValidBuildMode,
-            then: deploymentRegistrySchema(),
-            otherwise: deploymentRegistrySchema(),
-          },
-        ],
-      }),
+      deploymentRegistry: deploymentRegistrySchema(),
       ingressClass: joi.string().description(dedent`
         The ingress class or ingressClassName to use on configured Ingresses (via the \`kubernetes.io/ingress.class\` annotation or \`spec.ingressClassName\` field depending on the kubernetes version)
         when deploying \`container\` services. Use this if you have multiple ingress controllers in your cluster.

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -13,7 +13,7 @@ import type { KubernetesConfig, KubernetesPluginContext, KubernetesProvider } fr
 import { PodRunner, PodRunnerError, PodRunnerTimeoutError } from "../../run.js"
 import type { PluginContext } from "../../../../plugin-context.js"
 import { hashString, sleep } from "../../../../util/util.js"
-import { InternalError, RuntimeError } from "../../../../exceptions.js"
+import { ConfigurationError, RuntimeError } from "../../../../exceptions.js"
 import type { Log } from "../../../../logger/log-entry.js"
 import { prepareDockerAuth } from "../../init.js"
 import { prepareSecrets } from "../../secrets.js"
@@ -187,8 +187,8 @@ export async function skopeoBuildStatus({
   const deploymentRegistry = provider.config.deploymentRegistry
 
   if (!deploymentRegistry) {
-    // This is validated in the provider configure handler, so this is an internal error if it happens
-    throw new InternalError({
+    // TODO: try to use conditional joi validation instead
+    throw new ConfigurationError({
       message: `Expected configured deploymentRegistry for remote build`,
     })
   }

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -187,8 +187,9 @@ export async function skopeoBuildStatus({
   const deploymentRegistry = provider.config.deploymentRegistry
 
   if (!deploymentRegistry) {
-    // This is validated in the provider configure handler.
-    // Fallback to a configuration error instead of a crash if the validation is broken.
+    // This was supposed to be validated in the provider configure handler
+    // with conditional joi validation, but that caused some troubles with docs generation.
+    // Throw a configuration error here instead of a crash.
     throw new ConfigurationError({
       message: `The deploymentRegistry must be configured in provider for remote builds`,
     })

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -187,9 +187,10 @@ export async function skopeoBuildStatus({
   const deploymentRegistry = provider.config.deploymentRegistry
 
   if (!deploymentRegistry) {
-    // TODO: try to use conditional joi validation instead
+    // This is validated in the provider configure handler.
+    // Fallback to a configuration error instead of a crash if the validation is broken.
     throw new ConfigurationError({
-      message: `Expected configured deploymentRegistry for remote build`,
+      message: `The deploymentRegistry must be configured in provider for remote builds`,
     })
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A `ConfigurationError` is now thrown instead of `InternalError` if the `deploymentRegistry` is not configured on the provider-level when using in-cluster building.

So Garden do not crash and quits gracefully with informative error message.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

An attempt to use conditional validation for `deploymentRegistry` of the provider configuration was taken in 250b658cc9c40c4306f92a28bdef7e1b20c09a71.
It was reverted because of the of conditional validation support in the reference docs generation.
