### PR TITLE
chore(framework): mark `getEnvironmentStatus` handler as deprecated

### DIFF
--- a/core/src/plugin/handlers/Provider/getEnvironmentStatus.ts
+++ b/core/src/plugin/handlers/Provider/getEnvironmentStatus.ts
@@ -31,13 +31,18 @@ export interface EnvironmentStatusMap {
   [providerName: string]: EnvironmentStatus
 }
 
+/**
+ * Deprecated: Will be removed in 0.14
+ */
 export const getEnvironmentStatus = () => ({
   description: dedent`
-    Check if the current environment is ready for use by this plugin. Only called
+    [DEPRECATED] Check if the current environment is ready for use by this plugin. Only called
     with commands that set \`statusOnly: true\`.
 
     This handler MUST NOT have side effects and should only return the status of the
     environment.
+
+    NOTE: This handler is deprecated and will be removed in Garden 0.14.
   `,
   paramsSchema: projectActionParamsSchema(),
   resultSchema: environmentStatusSchema(),

--- a/core/src/plugin/providers.ts
+++ b/core/src/plugin/providers.ts
@@ -47,6 +47,7 @@ export interface ProviderActionOutputs<C extends BaseProviderConfig = any, O ext
   configureProvider: ConfigureProviderResult<C>
   augmentGraph: AugmentGraphResult
 
+  // Deprecated: Will be removed in 0.14
   getEnvironmentStatus: EnvironmentStatus<O>
   prepareEnvironment: PrepareEnvironmentResult<O>
   cleanupEnvironment: CleanupEnvironmentResult
@@ -67,6 +68,7 @@ export function getProviderActionDescriptions(): ResolvedActionHandlerDescriptio
     configureProvider,
     augmentGraph,
 
+    // Deprecated: Will be removed in 0.14
     getEnvironmentStatus,
     prepareEnvironment,
     cleanupEnvironment,

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -411,6 +411,9 @@ export class ResolveProviderTask extends BaseTask<Provider> {
       return cachedStatus
     }
 
+    // TODO: Remove this condition in 0.14 since we no longer check provider statuses when
+    // before preparing environments. Instead we should simply set provider statuses to `"unknown"` (or similar)
+    // in commands like `garden get status` since returning actual provider statuses doesn't really serve any purpose.
     if (statusOnly) {
       // TODO: avoid calling the handler manually (currently doing it to override the plugin context)
       const getStatusHandler = await actions.provider["getPluginHandler"]({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

In a previous commit we changed the behaviour such that the `getEnvironmentStatus` handler isn't called before preparing an environment and instead the `prepareEnvironment` handler is always called.

This leaves the `getEnvironmentStatus` pretty useless and it's currently only called with `statusOnly` commands like `garden get status`.

In these cases we might as well set the environment status to `unknown` and remove these handlers altogether and that's why we're deprecating it now.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
