### PR TITLE
fix: when using create project, the project name is undefined

### DIFF
--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -137,7 +137,7 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
         default: name,
       })
 
-      name = answer.name
+      name = answer
 
       log.info("")
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Found this little bug which was causing the `garden create project` command to render a `project.garden.yaml` file with an `undefined` project name.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
