### PR TITLE
improvement: add better error handling when failing to archive test artifacts

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -582,7 +582,7 @@ async function runWithArtifacts({
         log,
         stdout,
         stderr,
-        // Anything above two minutes for this would be unusual
+        // Anything above 10 minutes for this would be unusual
         timeoutSec: 600,
         buffer: true,
       })

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -583,7 +583,7 @@ async function runWithArtifacts({
         stdout,
         stderr,
         // Anything above two minutes for this would be unusual
-        timeoutSec: 120,
+        timeoutSec: 600,
         buffer: true,
       })
     } catch (err) {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -587,7 +587,11 @@ async function runWithArtifacts({
         buffer: true,
       })
     } catch (err) {
-      // TODO: fall back to copying `arc` (https://github.com/mholt/archiver) or similar into the container and
+      if (!(err instanceof PodRunnerWorkloadError)) {
+        throw err
+      }
+
+      // TODO: fall back to copying `arc` (https://github.com/mholt/archiver) or similar into the container and
       // using that (tar is not statically compiled so we can't copy that directly). Keeping this snippet around
       // for that:
       // await runner.exec({
@@ -601,9 +605,10 @@ async function runWithArtifacts({
       // })
       throw new ConfigurationError({
         message: deline`
-        ${description} specifies artifacts to export, but the image doesn't
-        contain the tar binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need to
-        be installed in the image.`,
+      ${description} specifies artifacts to export, but the image doesn't
+      contain the tar binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need to
+      be installed in the image.`,
+        wrappedErrors: [err],
       })
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Improve error handling when trying to create the archive of artifacts. 
Additionally, increases the timeout for the `tar` command to 10 minutes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
