### PR TITLE
fix(cluster-buildkit): assume image needs rebuild if skopeo command fails and print a warning

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -13,7 +13,7 @@ import type { KubernetesConfig, KubernetesPluginContext, KubernetesProvider } fr
 import { PodRunner, PodRunnerError, PodRunnerTimeoutError } from "../../run.js"
 import type { PluginContext } from "../../../../plugin-context.js"
 import { hashString, sleep } from "../../../../util/util.js"
-import { ConfigurationError, RuntimeError } from "../../../../exceptions.js"
+import { ConfigurationError } from "../../../../exceptions.js"
 import type { Log } from "../../../../logger/log-entry.js"
 import { prepareDockerAuth } from "../../init.js"
 import { prepareSecrets } from "../../secrets.js"
@@ -285,9 +285,11 @@ export async function skopeoBuildStatus({
         return { state: "not-ready", outputs, detail: { runtime } }
       }
 
-      log.warn(`Failed to check if the image has already been built: Command "${skopeoCommand.join(
+      log.warn(
+        `Failed to check if the image has already been built: Command "${skopeoCommand.join(
           " "
-        )}" failed: ${err.message}`)
+        )}" failed: ${err.message}`
+      )
       log.debug(() => `Error details: ${err}`)
 
       // If we fail to check the image status, we assume we need to rebuild it.

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -288,7 +288,7 @@ export async function skopeoBuildStatus({
       log.warn(`Failed to check if the image has already been built: Command "${skopeoCommand.join(
           " "
         )}" failed: ${err.message}`)
-      log.debug(err)
+      log.debug({ err })
 
       // If we fail to check the image status, we assume we need to rebuild it.
       return { state: "not-ready", outputs, detail: { runtime } }

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -290,7 +290,9 @@ export async function skopeoBuildStatus({
           " "
         )}" failed: ${err.message}`
       )
-      log.debug(() => `Error details: ${err}`)
+      log.debug({
+        error: err,
+      })
 
       // If we fail to check the image status, we assume we need to rebuild it.
       return { state: "not-ready", outputs, detail: { runtime } }
@@ -735,7 +737,7 @@ const baseUtilService: KubernetesResource<V1Service> = {
         name: "rsync",
         protocol: "TCP",
         port: utilRsyncPort,
-        targetPort: <any>utilRsyncPort,
+        targetPort: utilRsyncPort,
       },
     ],
     selector: {

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -288,7 +288,7 @@ export async function skopeoBuildStatus({
       log.warn(`Failed to check if the image has already been built: Command "${skopeoCommand.join(
           " "
         )}" failed: ${err.message}`)
-      log.debug({ err })
+      log.debug(() => `Error details: ${err}`)
 
       // If we fail to check the image status, we assume we need to rebuild it.
       return { state: "not-ready", outputs, detail: { runtime } }

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -285,12 +285,13 @@ export async function skopeoBuildStatus({
         return { state: "not-ready", outputs, detail: { runtime } }
       }
 
-      throw new RuntimeError({
-        message: `Unable to query registry for image status: Command "${skopeoCommand.join(
+      log.warn(`Failed to check if the image has already been built: Command "${skopeoCommand.join(
           " "
-        )}" failed: ${err.message}`,
-        wrappedErrors: [err],
-      })
+        )}" failed: ${err.message}`)
+      log.debug(err)
+
+      // If we fail to check the image status, we assume we need to rebuild it.
+      return { state: "not-ready", outputs, detail: { runtime } }
     }
 
     throw err


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Instead of failing completely, assume image needs to be rebuilt and print a warning. 

This is meant as a pain relieve for the issue encountered in this Discord thread: https://discord.com/channels/817392104711651328/1313997959121211463/1313997959121211463

This is not a full solution for the problem encountered in the thread.

**Special notes for your reviewer**:
