### PR TITLE
feat: allow cross-referencing variables in the same scope

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -773,6 +773,11 @@ export abstract class ResolvedRuntimeAction<
     this.executedDependencies = params.executedDependencies
     this.resolvedDependencies = params.resolvedDependencies
     this._staticOutputs = params.staticOutputs
+    this._config = {
+      ...this._config,
+      // makes sure the variables show up in the `garden get config` command
+      variables: params.resolvedVariables,
+    }
     this._config.spec = params.spec
     this._config.internal.inputs = params.inputs
   }

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -458,7 +458,7 @@ export function prepareProjectResource(log: Log, spec: any): ProjectConfig {
 }
 
 export function prepareModuleResource(spec: any, configPath: string, projectRoot: string): ModuleConfig {
-  spec.build = evaluate(spec.build, { context: new GenericContext({}), opts: {} }).resolved
+  spec.build = evaluate(spec.build, { context: new GenericContext("empty", {}), opts: {} }).resolved
 
   const dependencies: BuildDependencyConfig[] = spec.build?.dependencies || []
 

--- a/core/src/config/provider.ts
+++ b/core/src/config/provider.ts
@@ -185,7 +185,8 @@ export function getProviderTemplateReferences(config: UnresolvedProviderConfig, 
     visitAll({
       value: config.unresolvedConfig,
     }),
-    context
+    context,
+    {}
   )
   for (const finding of generator) {
     const keyPath = finding.keyPath

--- a/core/src/config/references.ts
+++ b/core/src/config/references.ts
@@ -168,7 +168,8 @@ export function* getActionTemplateReferences(
     visitAll({
       value: config as ObjectWithName,
     }),
-    context
+    context,
+    {}
   )
 
   for (const finding of generator) {
@@ -190,7 +191,8 @@ export function getModuleTemplateReferences(config: ModuleConfig, context: Modul
     visitAll({
       value: config as ObjectWithName,
     }),
-    context
+    context,
+    {}
   )
 
   for (const finding of generator) {

--- a/core/src/config/secrets.ts
+++ b/core/src/config/secrets.ts
@@ -86,7 +86,8 @@ export function detectMissingSecretKeys(
     visitAll({
       value: obj,
     }),
-    context
+    context,
+    {}
   )
   for (const finding of generator) {
     const keyPath = finding.keyPath

--- a/core/src/config/template-contexts/base.ts
+++ b/core/src/config/template-contexts/base.ts
@@ -325,7 +325,16 @@ export class LayeredContext extends ConfigContext {
 
   constructor(description: string, ...layers: ConfigContext[]) {
     super(description)
-    this.layers = layers
+    if (layers.length === 0) {
+      this.layers = [new GenericContext({})]
+    } else {
+      this.layers = layers
+    }
+  }
+
+  public addLayer(layer: ConfigContext) {
+    this.layers.push(layer)
+    this.clearCache()
   }
 
   override resolveImpl(args: ContextResolveParams): ContextResolveOutput {

--- a/core/src/config/template-contexts/base.ts
+++ b/core/src/config/template-contexts/base.ts
@@ -41,6 +41,30 @@ export interface ContextResolveOpts {
    */
   keepEscapingInTemplateStrings?: boolean
 
+  /**
+   * If true, the given context is final and contains everything needed to fully resolve the given templates.
+   *
+   * If false, this flag enables special behaviour of for some template values, like `ObjectSpreadLazyValue`,
+   * where we basically ignore unresolvable templates and resolve to whatever is available at the moment.
+   *
+   * This is currently used in the `VariableContext`, to allow for using some of the variables early during action processing,
+   * before we built the actual graph.
+   *
+   * @example
+   *  kind: Build
+   *  name: xy
+   *  dependencies: ${var.dependencies} // <-- if false, we can resolve 'var.dependencies' despite the fact that 'actions' context is missing
+   *  variables:
+   *    $merge: ${actions.build.foo.vars} // <-- if true, the $merge operation fails if 'actions' context is missing
+   *    dependencies: ["bar"]
+   *
+   * @warning If set to false, templates can lose information; Be careful when persisting the resolved values, because
+   * we may have lost some information even if evaluate returned `partial: false`.
+   *
+   * @default true
+   */
+  isFinalContext?: boolean
+
   // for detecting circular references
   stack?: string[]
 }

--- a/core/src/config/template-contexts/input.ts
+++ b/core/src/config/template-contexts/input.ts
@@ -55,11 +55,11 @@ export class InputContext extends LayeredContext {
     if (template) {
       super(
         "unresolved inputs (with best-effort schema defaults)",
-        new GenericContext(template.inputsSchemaDefaults),
-        new GenericContext(inputs || {})
+        new GenericContext("best-effort schema defaults", template.inputsSchemaDefaults),
+        new GenericContext("unresolved inputs", inputs || {})
       )
     } else {
-      super("fully resolved inputs", new GenericContext(inputs || {}))
+      super("fully resolved inputs", new GenericContext("fully resolved inputs", inputs || {}))
     }
   }
 }

--- a/core/src/config/template-contexts/variables.ts
+++ b/core/src/config/template-contexts/variables.ts
@@ -55,12 +55,15 @@ export class VariablesContext extends LayeredContext {
 
     for (const [i, layer] of entries) {
       const parent = layers[i]
-      layers.push(
-        new GenericContext(
-          // this ensures that a variable in any given context can refer to variables in the parent scope
-          capture(layer || {}, makeVariableRootContext(parent))
-        )
-      )
+
+      // this ensures that a variable in any given context can refer to variables in the parent scope
+      let captured = capture(layer || {}, makeVariableRootContext(parent))
+
+      // allow variables cross-referencing each other in the same scope, e.g. to reuse values across multiple variables
+      captured = capture(captured, makeVariableRootContext(new GenericContext(captured)))
+
+      // add this layer of variables
+      layers.push(new GenericContext(captured))
     }
 
     super(description, ...layers)

--- a/core/src/outputs.ts
+++ b/core/src/outputs.ts
@@ -41,7 +41,8 @@ export async function resolveProjectOutputs(garden: Garden, log: Log): Promise<O
       resolvedProviders: {},
       variables: garden.variables,
       modules: [],
-    })
+    }),
+    {}
   )
   for (const finding of generator) {
     const keyPath = finding.keyPath

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -1241,6 +1241,7 @@ function partiallyEvaluateModule<Input extends ParsedTemplate>(config: Input, co
       someReferences({
         value,
         context,
+        opts: {},
         onlyEssential: true,
         matcher: (ref) => ref.keyPath[0] === "runtime",
       })

--- a/core/src/template/templated-collections.ts
+++ b/core/src/template/templated-collections.ts
@@ -374,7 +374,7 @@ export class ForEachLazyValue extends StructuralTemplateOperator {
 
     for (const i of Object.keys(collectionValue)) {
       // put the TemplateValue in the context, not the primitive value, so we have input tracking
-      const contextForIndex = new GenericContext({
+      const contextForIndex = new GenericContext("item ($forEach)", {
         item: { key: i, value: collectionValue[i] },
       })
       const loopContext = new LayeredContext("item ($forEach)", args.context, contextForIndex)

--- a/core/src/template/templated-collections.ts
+++ b/core/src/template/templated-collections.ts
@@ -31,7 +31,7 @@ import { evaluate } from "./evaluate.js"
 import { LayeredContext } from "../config/template-contexts/base.js"
 import { parseTemplateString } from "./templated-strings.js"
 import { TemplateError } from "./errors.js"
-import { visitAll, type TemplateExpressionGenerator } from "./analysis.js"
+import { canEvaluateSuccessfully, visitAll, type TemplateExpressionGenerator } from "./analysis.js"
 import { capture } from "./capture.js"
 
 export function pushYamlPath(part: ObjectPath[0], configSource: ConfigSource): ConfigSource {
@@ -442,6 +442,18 @@ export class ObjectSpreadLazyValue extends StructuralTemplateOperator {
       }
 
       k satisfies typeof objectSpreadKey
+
+      const { isFinalContext = true } = args.opts
+      if (!isFinalContext && v instanceof UnresolvedTemplateValue) {
+        if (!canEvaluateSuccessfully({ value: v, ...args, onlyEssential: true })) {
+          /**
+           * if this is not the final context, and calling `evaluate` would fail, then
+           * skip evaluating the $merge operation.
+           * @see ContextResolveOpts.isFinalContext
+           */
+          continue
+        }
+      }
 
       const { resolved } = evaluate(v, args)
 

--- a/core/test/data/test-projects/variable-crossreferences/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/garden.yml
@@ -1,0 +1,16 @@
+apiVersion: garden.io/v1
+kind: Project
+name: duplicate-module
+environments:
+  - name: local
+    variables:
+      environmentLevel:
+        suffix: "world"
+        hello: hello ${var.environmentLevel.suffix}
+
+providers:
+  - name: test-plugin
+variables:
+  projectLevel:
+    suffix: "world"
+    hello: hello ${var.projectLevel.suffix}

--- a/core/test/data/test-projects/variable-crossreferences/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/garden.yml
@@ -1,6 +1,7 @@
 apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
+
 environments:
   - name: local
     variables:
@@ -10,7 +11,43 @@ environments:
 
 providers:
   - name: test-plugin
+
 variables:
   projectLevel:
     suffix: "world"
     hello: hello ${var.projectLevel.suffix}
+
+---
+
+kind: RenderTemplate
+template: tpl
+name: render
+inputs:
+  dt: test-1
+
+---
+
+kind: ConfigTemplate
+name: tpl
+configs:
+  - kind: Build
+    type: exec
+    name: ${inputs.dt}-dummy
+    variables:
+      foo0: bar0
+      composeImageName: "busybox"
+      env:
+        DT: ${inputs.dt}
+        FOO0: ${var.foo0}
+
+  - kind: Deploy
+    type: container
+    name: ${inputs.dt}-container
+    variables:
+      $merge: ${actions.build["${inputs.dt}-dummy"].var}
+    spec:
+      env:
+        FOO0: ${var.foo0}
+      image: "${ var.composeImageName }"
+      command:
+        - echo ${!(var contains "web")}

--- a/core/test/data/test-projects/variable-crossreferences/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/garden.yml
@@ -43,11 +43,33 @@ configs:
   - kind: Deploy
     type: container
     name: ${inputs.dt}-container
+    # It must be possible to use var.dependencies despite the $merge in variables
+    dependencies: ${var.dependencies}
     variables:
       $merge: ${actions.build["${inputs.dt}-dummy"].var}
+      dependencies:
+        - build.${inputs.dt}-dummy
     spec:
       env:
         FOO0: ${var.foo0}
       image: "${ var.composeImageName }"
       command:
         - echo ${!(var contains "web")}
+
+---
+
+kind: Deploy
+type: container
+name: standalone-container
+# It must be possible to use var.dependencies despite the $merge in variables
+dependencies: ${var.dependencies}
+variables:
+  $merge: ${actions.build.test-1-dummy.var}
+  dependencies:
+   - build.test-1-dummy
+spec:
+  env:
+    FOO0: ${var.foo0}
+  image: "${ var.composeImageName }"
+  command:
+    - echo ${!(var contains "web")}

--- a/core/test/data/test-projects/variable-crossreferences/module-a/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/module-a/garden.yml
@@ -1,3 +1,0 @@
-kind: Module
-name: module-a
-type: test

--- a/core/test/data/test-projects/variable-crossreferences/module-a/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/module-a/garden.yml
@@ -1,0 +1,3 @@
+kind: Module
+name: module-a
+type: test

--- a/core/test/data/test-projects/variable-crossreferences/module-b/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/module-b/garden.yml
@@ -1,3 +1,0 @@
-kind: Module
-name: module-a
-type: test

--- a/core/test/data/test-projects/variable-crossreferences/module-b/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/module-b/garden.yml
@@ -1,0 +1,3 @@
+kind: Module
+name: module-a
+type: test

--- a/core/test/unit/src/commands/workflow.ts
+++ b/core/test/unit/src/commands/workflow.ts
@@ -84,7 +84,7 @@ describe("RunWorkflowCommand", () => {
 
     garden.setRawWorkflowConfigs(parsedWorkflowConfigs)
 
-    garden.variables = VariablesContext.forTest(garden, { foo: null })
+    garden.variables = VariablesContext.forTest({ garden, variablePrecedence: [{ foo: null }] })
 
     const result = await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
 

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -31,6 +31,7 @@ import { omit } from "lodash-es"
 import { serialiseUnresolvedTemplates } from "../../../../src/template/types.js"
 import type { DeepPrimitiveMap } from "@garden-io/platform-api-types"
 import { ProjectConfigContext } from "../../../../src/config/template-contexts/project.js"
+import { TestContext } from "./template-contexts/base.js"
 
 const { realpath, writeFile } = fsExtra
 
@@ -636,7 +637,7 @@ describe("pickEnvironment", () => {
     expect(variables).to.eql({})
 
     const resolvedProviders = env.providers.map((p) =>
-      deepEvaluate(p.unresolvedConfig, { context: new GenericContext({}), opts: {} })
+      deepEvaluate(p.unresolvedConfig, { context: new TestContext({}), opts: {} })
     )
     expect(resolvedProviders).to.eql([
       { name: "exec" },

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { platform } from "os"
 import { expect } from "chai"
 import tmp from "tmp-promise"
 import type { ProjectConfig } from "../../../../src/config/project.js"
@@ -26,7 +25,7 @@ import { dedent } from "../../../../src/util/string.js"
 import { resolve, join } from "path"
 import { getRootLogger } from "../../../../src/logger/logger.js"
 import { deepEvaluate } from "../../../../src/template/evaluate.js"
-import { deepResolveContext, GenericContext } from "../../../../src/config/template-contexts/base.js"
+import { deepResolveContext } from "../../../../src/config/template-contexts/base.js"
 import { omit } from "lodash-es"
 import { serialiseUnresolvedTemplates } from "../../../../src/template/types.js"
 import type { DeepPrimitiveMap } from "@garden-io/platform-api-types"
@@ -87,7 +86,7 @@ describe("resolveProjectConfig", () => {
     })
   })
 
-  it("should resolve template strings on fields other than environments, providers and remote sources", async () => {
+  it("should resolve template strings on fields other than environments, providers and remote sources and variables", async () => {
     const repositoryUrl = "git://github.com/foo/bar.git#boo"
 
     const config: ProjectConfig = createProjectConfig({
@@ -161,10 +160,10 @@ describe("resolveProjectConfig", () => {
       ],
       varfile: defaultProjectVarfilePath,
       variables: {
-        platform: platform(),
-        secret: "banana",
-        projectPath: config.path,
-        envVar: "foo",
+        platform: "${local.platform}",
+        secret: "${secrets.foo}",
+        projectPath: "${local.projectPath}",
+        envVar: "${local.env.TEST_ENV_VAR}",
       },
     })
 

--- a/core/test/unit/src/config/provider.ts
+++ b/core/test/unit/src/config/provider.ts
@@ -10,10 +10,10 @@ import { expect } from "chai"
 import { getAllProviderDependencyNames } from "../../../../src/config/provider.js"
 import { expectError } from "../../../helpers.js"
 import { createGardenPlugin } from "../../../../src/plugin/plugin.js"
-import { GenericContext } from "../../../../src/config/template-contexts/base.js"
 import { UnresolvedProviderConfig } from "../../../../src/config/project.js"
 import type { ObjectWithName } from "../../../../src/util/util.js"
 import { parseTemplateCollection } from "../../../../src/template/templated-collections.js"
+import { TestContext } from "./template-contexts/base.js"
 
 describe("getProviderDependencies", () => {
   const plugin = createGardenPlugin({
@@ -26,7 +26,7 @@ describe("getProviderDependencies", () => {
       someKey: "${providers.other-provider.foo}",
       anotherKey: "foo-${providers.another-provider.bar}",
     })
-    expect(getAllProviderDependencyNames(plugin, config, new GenericContext({}))).to.eql([
+    expect(getAllProviderDependencyNames(plugin, config, new TestContext({}))).to.eql([
       "another-provider",
       "other-provider",
     ])
@@ -38,7 +38,7 @@ describe("getProviderDependencies", () => {
       someKey: "${providers.other-provider.foo}",
       anotherKey: "foo-${some.other.ref}",
     })
-    expect(getAllProviderDependencyNames(plugin, config, new GenericContext({}))).to.eql(["other-provider"])
+    expect(getAllProviderDependencyNames(plugin, config, new TestContext({}))).to.eql(["other-provider"])
   })
 
   it("should throw on provider-scoped template strings without a provider name", async () => {
@@ -47,7 +47,7 @@ describe("getProviderDependencies", () => {
       someKey: "${providers}",
     })
 
-    await expectError(() => getAllProviderDependencyNames(plugin, config, new GenericContext({})), {
+    await expectError(() => getAllProviderDependencyNames(plugin, config, new TestContext({})), {
       contains:
         "Invalid template key 'providers' in configuration for provider 'my-provider'. You must specify a provider name as well (e.g. \\${providers.my-provider}).",
     })

--- a/core/test/unit/src/config/render-template.ts
+++ b/core/test/unit/src/config/render-template.ts
@@ -458,8 +458,13 @@ describe("config templates", () => {
 
       const config: RenderTemplateConfig = cloneDeep(defaults)
       config.inputs = parseTemplateCollection({ value: { name: "${var.test}" }, source: { path: [] } })
-      garden.variables = VariablesContext.forTest(garden, {
-        test: "test-value",
+      garden.variables = VariablesContext.forTest({
+        garden,
+        variablePrecedence: [
+          {
+            test: "test-value",
+          },
+        ],
       })
 
       const resolved = await renderConfigTemplate({ garden, log, config, templates: _templates })

--- a/core/test/unit/src/config/template-contexts/base.ts
+++ b/core/test/unit/src/config/template-contexts/base.ts
@@ -28,29 +28,42 @@ import { deepEvaluate } from "../../../../../src/template/evaluate.js"
 import { isPlainObject } from "../../../../../src/util/objects.js"
 import { InternalError } from "../../../../../src/exceptions.js"
 import { parseTemplateCollection } from "../../../../../src/template/templated-collections.js"
+import type { ResolvedTemplate } from "../../../../../src/template/types.js"
 
 type TestValue = string | ConfigContext | TestValues
 
 interface TestValues {
   [key: string]: TestValue
 }
-
-describe("ConfigContext", () => {
-  class TestContext extends GenericContext {
-    constructor(obj: TestValues) {
-      super(obj)
-    }
-
-    addValues(obj: TestValues) {
-      if (!isPlainObject(this.data)) {
-        throw new InternalError({
-          message: "TestContext expects data to be a plain object",
-        })
-      }
-      Object.assign(this.data, obj)
-    }
+export class TestContext extends GenericContext {
+  constructor(obj: TestValues) {
+    super(obj)
   }
 
+  /**
+   * Helper to test contexts with fewer lines of code.
+   */
+  eval(rawTemplateString: string): ResolvedTemplate {
+    const parsed = parseTemplateString({
+      rawTemplateString,
+      source: {
+        path: [],
+      },
+    })
+    return deepEvaluate(parsed, { context: this, opts: {} })
+  }
+
+  addValues(obj: TestValues) {
+    if (!isPlainObject(this.data)) {
+      throw new InternalError({
+        message: "TestContext expects data to be a plain object",
+      })
+    }
+    Object.assign(this.data, obj)
+  }
+}
+
+describe("ConfigContext", () => {
   describe("resolve", () => {
     // just a shorthand to aid in testing
     function resolveKey(c: ConfigContext, key: ContextKey, opts = {}) {

--- a/core/test/unit/src/config/template-contexts/variables.ts
+++ b/core/test/unit/src/config/template-contexts/variables.ts
@@ -12,6 +12,7 @@ import type { TestGarden } from "../../../../helpers.js"
 import { getDataDir, makeTestGarden } from "../../../../helpers.js"
 import { TestContext } from "./base.js"
 import { deepResolveContext } from "../../../../../src/config/template-contexts/base.js"
+import { resolveAction } from "../../../../../src/graph/actions.js"
 
 /*
  * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
@@ -38,6 +39,56 @@ describe("VariablesContext", () => {
           hello: "hello world",
           suffix: "world",
         },
+        projectLevel: {
+          hello: "hello world",
+          suffix: "world",
+        },
+      })
+    })
+
+    it("resolves the test action variables correctly", async () => {
+      const graph = await garden.getResolvedConfigGraph({ log: garden.log, emit: false })
+
+      const dummy = await resolveAction({
+        garden,
+        graph,
+        action: graph.getActionByRef("build.test-1-dummy"),
+        log: garden.log,
+      })
+      expect(dummy.getResolvedVariables()).to.eql({
+        composeImageName: "busybox",
+        env: {
+          DT: "test-1",
+          FOO0: "bar0",
+        },
+        environmentLevel: {
+          hello: "hello world",
+          suffix: "world",
+        },
+        foo0: "bar0",
+        projectLevel: {
+          hello: "hello world",
+          suffix: "world",
+        },
+      })
+
+      const container = await resolveAction({
+        garden,
+        graph,
+        action: graph.getActionByRef("deploy.test-1-container"),
+        log: garden.log,
+      })
+      expect(container.getResolvedVariables()).to.eql({
+        composeImageName: "busybox",
+        env: {
+          DT: "test-1",
+          FOO0: "bar0",
+        },
+        environmentLevel: {
+          hello: "hello world",
+          suffix: "world",
+        },
+        foo0: "bar0",
         projectLevel: {
           hello: "hello world",
           suffix: "world",

--- a/core/test/unit/src/config/template-contexts/variables.ts
+++ b/core/test/unit/src/config/template-contexts/variables.ts
@@ -32,6 +32,188 @@ describe("VariablesContext", () => {
     garden.close()
   })
 
+  describe("General overview", () => {
+    it("enforces variable precedence", () => {
+      const config = {
+        variables: {
+          hello: "lowest precedence",
+        },
+      }
+
+      const varfile = {
+        hello: "elevated precedence",
+      }
+
+      garden.variableOverrides["hello"] = "most precedence"
+
+      const context = new TestContext({
+        var: VariablesContext.forTest({ garden, variablePrecedence: [config.variables, varfile] }),
+      })
+
+      expect(context.eval("${var.hello}")).to.eql("most precedence")
+    })
+
+    it("allows for variables to reference variables from lower precedence level", () => {
+      const project = parseTemplateCollection({
+        value: {
+          variables: {
+            foo: "bar",
+            fruit: "banana",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const environment = parseTemplateCollection({
+        value: {
+          variables: {
+            foo: "${var.foo}",
+            favouriteFood: "${var.fruit}",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const context = new TestContext({
+        var: VariablesContext.forTest({ garden, variablePrecedence: [project.variables, environment.variables] }),
+      })
+
+      expect(context.eval("${var}")).to.eql({
+        foo: "bar",
+        favouriteFood: "banana",
+        fruit: "banana",
+      })
+    })
+
+    it("allows for variables to reference each other in the same precedence level", () => {
+      const config = parseTemplateCollection({
+        value: {
+          variables: {
+            suffix: "world",
+            hello: "hello ${var.suffix}",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const context = new TestContext({
+        var: VariablesContext.forTest({ garden, variablePrecedence: [config.variables] }),
+      })
+
+      expect(context.eval("${var.hello}")).to.eql("hello world")
+    })
+
+    it("for backwards-compatibility with 0.13, variables in parent context have precedence over cross-referenced variables", () => {
+      const project = parseTemplateCollection({
+        value: {
+          variables: {
+            suffix: "project",
+          },
+        },
+        source: { path: [] },
+      })
+      const action = parseTemplateCollection({
+        value: {
+          variables: {
+            suffix: "action", // <-- takes lower precedence than "project.variables.suffix" when cross-referencing in the same scope
+            hello: "hello ${var.suffix}",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const context = new TestContext({
+        var: VariablesContext.forTest({ garden, variablePrecedence: [project.variables, action.variables] }),
+      })
+
+      expect(context.eval("${var.hello}")).to.eql("hello project")
+    })
+
+    /**
+     * @see ContextResolveOpts.isFinalContext
+     */
+    describe("ContextResolveOpts.isFinalContext", () => {
+      describe("variables.$merge is unresolvable", () => {
+        const action = parseTemplateCollection({
+          value: {
+            variables: {
+              $merge: "${actions.build.foobar.var}",
+              hello: "world, I am here!",
+            },
+          },
+          source: { path: [] },
+        })
+
+        let finalContext: TestContext
+        let incompleteContext: TestContext
+
+        beforeEach(() => {
+          finalContext = new TestContext({
+            var: VariablesContext.forTest({ garden, variablePrecedence: [action.variables] }), // <-- isFinalContext defaults to true
+          })
+
+          incompleteContext = new TestContext({
+            var: VariablesContext.forTest({ garden, variablePrecedence: [action.variables], isFinalContext: false }), // <-- we indicate partial context
+          })
+        })
+
+        it("given a final context, a $merge operation in variables causes lookup to fail", () => {
+          expect(() => finalContext.eval("${var.hello}")).to.throw("Could not find key") // <-- resolving hello fails
+        })
+
+        it("given an incomplete context, we ignore unresolvable $merge operators", () => {
+          expect(incompleteContext.eval("${var.hello}")).to.eql("world, I am here!") // <-- resolving works in incompleteContext
+          expect(() => finalContext.eval("${var.doesNotExist}")).to.throw("Could not find key") // <-- will fail on non-existent keys
+        })
+
+        it("does not ignore resolvable $merge operations", () => {
+          expect(incompleteContext.eval("${var.hello}")).to.eql("world, I am here!") // <-- resolving works in incompleteContext
+        })
+      })
+
+      describe("variables.$merge is resolvable but contains unresolvable keys", () => {
+        const action = parseTemplateCollection({
+          value: {
+            variables: {
+              $merge: {
+                resolvable: "yes, I can be resolved.",
+                unresolvable: "${actions.build.foobar.outputs}",
+              },
+              hello: "world, I am here!",
+            },
+          },
+          source: { path: [] },
+        })
+
+        let finalContext: TestContext
+        let incompleteContext: TestContext
+
+        beforeEach(() => {
+          finalContext = new TestContext({
+            var: VariablesContext.forTest({ garden, variablePrecedence: [action.variables] }), // <-- isFinalContext defaults to true
+          })
+
+          incompleteContext = new TestContext({
+            var: VariablesContext.forTest({ garden, variablePrecedence: [action.variables], isFinalContext: false }), // <-- we indicate partial context
+          })
+        })
+
+        it("will not fail when variables.$merge merely contains unresolvable keys, but all keys are known", () => {
+          expect(finalContext.eval("${var.hello}")).to.eql("world, I am here!")
+          expect(incompleteContext.eval("${var.hello}")).to.eql("world, I am here!")
+
+          expect(finalContext.eval("${var.resolvable}")).to.eql("yes, I can be resolved.")
+          expect(incompleteContext.eval("${var.resolvable}")).to.eql("yes, I can be resolved.")
+        })
+
+        it("should fail to resolve var.unresolvable even in the incompleteContext", () => {
+          expect(() => finalContext.eval("${var.unresolvable}")).to.throw("Could not find key")
+          expect(() => incompleteContext.eval("${var.unresolvable}")).to.throw("Could not find key")
+        })
+      })
+    })
+  })
+
   describe("Project-level crossreferences", () => {
     it("resolves the test project config correctly", () => {
       expect(deepResolveContext("project + environment variables", garden.variables)).to.eql({
@@ -45,7 +227,9 @@ describe("VariablesContext", () => {
         },
       })
     })
+  })
 
+  describe("Action-level crossreferences", () => {
     it("resolves the test action variables correctly", async () => {
       const graph = await garden.getResolvedConfigGraph({ log: garden.log, emit: false })
 
@@ -78,7 +262,9 @@ describe("VariablesContext", () => {
         action: graph.getActionByRef("deploy.test-1-container"),
         log: garden.log,
       })
+      expect(container.getConfig().dependencies).to.eql([{ kind: "Build", name: "test-1-dummy" }])
       expect(container.getResolvedVariables()).to.eql({
+        dependencies: ["build.test-1-dummy"],
         composeImageName: "busybox",
         env: {
           DT: "test-1",
@@ -94,104 +280,31 @@ describe("VariablesContext", () => {
           suffix: "world",
         },
       })
-    })
-  })
 
-  describe("it encapsulates the way variables should behave across all configs", () => {
-    it("enforces variable precedence", () => {
-      const config = {
-        variables: {
-          hello: "lowest precedence",
+      const standalone = await resolveAction({
+        garden,
+        graph,
+        action: graph.getActionByRef("deploy.standalone-container"),
+        log: garden.log,
+      })
+      expect(standalone.getConfig().dependencies).to.eql([{ kind: "Build", name: "test-1-dummy" }])
+      expect(standalone.getResolvedVariables()).to.eql({
+        dependencies: ["build.test-1-dummy"],
+        composeImageName: "busybox",
+        env: {
+          DT: "test-1",
+          FOO0: "bar0",
         },
-      }
-
-      const varfile = {
-        hello: "elevated precedence",
-      }
-
-      garden.variableOverrides["hello"] = "most precedence"
-
-      const context = new TestContext({
-        var: VariablesContext.forTest(garden, config.variables, varfile),
-      })
-
-      expect(context.eval("${var.hello}")).to.eql("most precedence")
-    })
-
-    it("allows for variables to reference variables from lower precedence level", () => {
-      const project = parseTemplateCollection({
-        value: {
-          variables: {
-            foo: "bar",
-            fruit: "banana",
-          },
+        environmentLevel: {
+          hello: "hello world",
+          suffix: "world",
         },
-        source: { path: [] },
-      })
-
-      const environment = parseTemplateCollection({
-        value: {
-          variables: {
-            foo: "${var.foo}",
-            favouriteFood: "${var.fruit}",
-          },
+        foo0: "bar0",
+        projectLevel: {
+          hello: "hello world",
+          suffix: "world",
         },
-        source: { path: [] },
       })
-
-      const context = new TestContext({
-        var: VariablesContext.forTest(garden, project.variables, environment.variables),
-      })
-
-      expect(context.eval("${var}")).to.eql({
-        foo: "bar",
-        favouriteFood: "banana",
-        fruit: "banana",
-      })
-    })
-
-    it("allows for variables to reference each other in the same precedence level", () => {
-      const config = parseTemplateCollection({
-        value: {
-          variables: {
-            suffix: "world",
-            hello: "hello ${var.suffix}",
-          },
-        },
-        source: { path: [] },
-      })
-
-      const context = new TestContext({
-        var: VariablesContext.forTest(garden, config.variables),
-      })
-
-      expect(context.eval("${var.hello}")).to.eql("hello world")
-    })
-
-    it("for backwards-compatibility with 0.13, variables in parent context have precedence over cross-referenced variables", () => {
-      const project = parseTemplateCollection({
-        value: {
-          variables: {
-            suffix: "project",
-          },
-        },
-        source: { path: [] },
-      })
-      const action = parseTemplateCollection({
-        value: {
-          variables: {
-            suffix: "action", // <-- takes lower precedence than "project.variables.suffix" when cross-referencing in the same scope
-            hello: "hello ${var.suffix}",
-          },
-        },
-        source: { path: [] },
-      })
-
-      const context = new TestContext({
-        var: VariablesContext.forTest(garden, project.variables, action.variables),
-      })
-
-      expect(context.eval("${var.hello}")).to.eql("hello project")
     })
   })
 })

--- a/core/test/unit/src/config/template-contexts/variables.ts
+++ b/core/test/unit/src/config/template-contexts/variables.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { expect } from "chai"
+import { VariablesContext } from "../../../../../src/config/template-contexts/variables.js"
+import { parseTemplateCollection } from "../../../../../src/template/templated-collections.js"
+import type { TestGarden } from "../../../../helpers.js"
+import { getDataDir, makeTestGarden } from "../../../../helpers.js"
+import { TestContext } from "./base.js"
+import { deepResolveContext } from "../../../../../src/config/template-contexts/base.js"
+
+/*
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+describe("VariablesContext", () => {
+  let garden: TestGarden
+
+  beforeEach(async () => {
+    garden = await makeTestGarden(getDataDir("test-projects", "variable-crossreferences"))
+  })
+
+  afterEach(() => {
+    garden.close()
+  })
+
+  describe("Project-level crossreferences", () => {
+    it("resolves the test project config correctly", () => {
+      expect(deepResolveContext("project + environment variables", garden.variables)).to.eql({
+        environmentLevel: {
+          hello: "hello world",
+          suffix: "world",
+        },
+        projectLevel: {
+          hello: "hello world",
+          suffix: "world",
+        },
+      })
+    })
+  })
+
+  describe("it encapsulates the way variables should behave across all configs", () => {
+    it("enforces variable precedence", () => {
+      const config = {
+        variables: {
+          hello: "lowest precedence",
+        },
+      }
+
+      const varfile = {
+        hello: "elevated precedence",
+      }
+
+      garden.variableOverrides["hello"] = "most precedence"
+
+      const context = new TestContext({
+        var: VariablesContext.forTest(garden, config.variables, varfile),
+      })
+
+      expect(context.eval("${var.hello}")).to.eql("most precedence")
+    })
+
+    it("allows for variables to reference variables from lower precedence level", () => {
+      const project = parseTemplateCollection({
+        value: {
+          variables: {
+            foo: "bar",
+            fruit: "banana",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const environment = parseTemplateCollection({
+        value: {
+          variables: {
+            foo: "${var.foo}",
+            favouriteFood: "${var.fruit}",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const context = new TestContext({
+        var: VariablesContext.forTest(garden, project.variables, environment.variables),
+      })
+
+      expect(context.eval("${var}")).to.eql({
+        foo: "bar",
+        favouriteFood: "banana",
+        fruit: "banana",
+      })
+    })
+
+    it("allows for variables to reference each other in the same precedence level", () => {
+      const config = parseTemplateCollection({
+        value: {
+          variables: {
+            suffix: "world",
+            hello: "hello ${var.suffix}",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const context = new TestContext({
+        var: VariablesContext.forTest(garden, config.variables),
+      })
+
+      expect(context.eval("${var.hello}")).to.eql("hello world")
+    })
+
+    it("for backwards-compatibility with 0.13, variables in parent context have precedence over cross-referenced variables", () => {
+      const project = parseTemplateCollection({
+        value: {
+          variables: {
+            suffix: "project",
+          },
+        },
+        source: { path: [] },
+      })
+      const action = parseTemplateCollection({
+        value: {
+          variables: {
+            suffix: "action", // <-- takes lower precedence than "project.variables.suffix" when cross-referencing in the same scope
+            hello: "hello ${var.suffix}",
+          },
+        },
+        source: { path: [] },
+      })
+
+      const context = new TestContext({
+        var: VariablesContext.forTest(garden, project.variables, action.variables),
+      })
+
+      expect(context.eval("${var.hello}")).to.eql("hello project")
+    })
+  })
+})

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -51,7 +51,7 @@ describe("resolveWorkflowConfig", () => {
   before(async () => {
     garden = await makeTestGardenA()
     garden.secrets = { foo: "bar", bar: "baz", baz: "banana" }
-    garden.variables = VariablesContext.forTest(garden, { foo: "baz", skip: false })
+    garden.variables = VariablesContext.forTest({ garden, variablePrecedence: [{ foo: "baz", skip: false }] })
   })
 
   it("should pass through a canonical workflow config", async () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2924,7 +2924,7 @@ describe("Garden", () => {
         await exec("git", ["add", "."], { cwd: repoPath })
         await exec("git", ["commit", "-m", "foo"], { cwd: repoPath })
 
-        garden.variables = VariablesContext.forTest(garden, { sourceBranch: "main" })
+        garden.variables = VariablesContext.forTest({ garden, variablePrecedence: [{ sourceBranch: "main" }] })
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const _garden = garden as any

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -2630,7 +2630,8 @@ describe("getContextLookupReferences", () => {
         visitAll({
           value: obj,
         }),
-        new TestContext({})
+        new TestContext({}),
+        {}
       )
     )
     const expected: Partial<ContextLookupReferenceFinding>[] = [
@@ -2691,7 +2692,8 @@ describe("getContextLookupReferences", () => {
         visitAll({
           value: obj,
         }),
-        new TestContext({})
+        new TestContext({}),
+        {}
       )
     )
 

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -274,7 +274,10 @@ describe("getModuleVersionString", () => {
     templateGarden["cacheKey"] = "" // Disable caching of the config graph
     const before = await templateGarden.resolveModule("module-a")
 
-    templateGarden.variables = VariablesContext.forTest(templateGarden, { "echo-string": "something-else" })
+    templateGarden.variables = VariablesContext.forTest({
+      garden: templateGarden,
+      variablePrecedence: [{ "echo-string": "something-else" }],
+    })
 
     const after = await templateGarden.resolveModule("module-a")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows cross-referencing variables in the same scope.

**Which issue(s) this PR fixes**:

Fixes #2730 (and some regressions of variable lookup behaviour introduced in #6745, there is no need to mention them in the release notes because we have not released it so far)

**Special notes for your reviewer**:
There are some caveats that are covered in the test cases, to maintain backwards-compatibility with older versions of 0.13.