### PR TITLE
chore(plugins): deprecate conftest, hadolint and octant plugins

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,6 +22,7 @@ import { waitForOutputFlush } from "@garden-io/core/build/src/process.js"
 
 // These plugins are always registered
 export const getBundledPlugins = (): GardenPluginReference[] => [
+  // TODO(0.14): remove confest plugins from the list of the bundled plugins
   {
     name: "conftest",
     callback: async () => {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -2057,23 +2057,23 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       vcsInfo,
     } = partialResolved
 
-    let { config, namespace } = partialResolved
+    let { config: projectConfig, namespace } = partialResolved
 
     await ensureDir(gardenDirPath)
     await ensureDir(artifactsPath)
 
-    const projectApiVersion = config.apiVersion
+    const projectApiVersion = projectConfig.apiVersion
     const sessionId = opts.sessionId || uuidv4()
     const cloudApiFactory = getCloudApiFactory(opts)
     const skipCloudConnect = opts.skipCloudConnect || false
 
-    const cloudDomain = getCloudDomain(config.domain)
+    const cloudDomain = getCloudDomain(projectConfig.domain)
     const cloudApi = await initCloudApi({
       cloudApiFactory,
       cloudDomain,
       globalConfigStore,
       log,
-      projectConfig: config,
+      projectConfig,
       skipCloudConnect,
     })
     const loggedIn = !!cloudApi
@@ -2083,7 +2083,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
 
     const { secrets, cloudProject } = await initCloudProject({
       cloudApi,
-      config,
+      config: projectConfig,
       log,
       projectRoot,
       projectName,
@@ -2099,22 +2099,22 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       vcsInfo,
       username: _username,
       loggedIn,
-      enterpriseDomain: config.domain,
+      enterpriseDomain: projectConfig.domain,
       secrets,
       commandInfo,
     })
 
-    config = resolveProjectConfig({
+    projectConfig = resolveProjectConfig({
       log,
       defaultEnvironmentName: configDefaultEnvironment,
-      config,
+      config: projectConfig,
       context: projectContext,
     })
 
     const variableOverrides = opts.variableOverrides || {}
 
     const pickedEnv = await pickEnvironment({
-      projectConfig: config,
+      projectConfig,
       variableOverrides,
       envString: environmentStr,
       artifactsPath,
@@ -2122,7 +2122,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       vcsInfo,
       username: _username,
       loggedIn,
-      enterpriseDomain: config.domain,
+      enterpriseDomain: projectConfig.domain,
       secrets,
       commandInfo,
     })
@@ -2143,7 +2143,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     const gardenDirExcludePattern = `${relative(projectRoot, gardenDirPath)}/**/*`
 
     const moduleExcludePatterns = [
-      ...((config.scan || {}).exclude || []),
+      ...((projectConfig.scan || {}).exclude || []),
       gardenDirExcludePattern,
       ...fixedProjectExcludes,
     ]
@@ -2152,8 +2152,8 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     let proxyHostname: string
     if (gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS) {
       proxyHostname = gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS
-    } else if (config.proxy?.hostname) {
-      proxyHostname = config.proxy.hostname
+    } else if (projectConfig.proxy?.hostname) {
+      proxyHostname = projectConfig.proxy.hostname
     } else {
       proxyHostname = defaultLocalAddress
     }
@@ -2171,8 +2171,8 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       // If the user is logged in and a cloud project exists we use that ID
       // but fallback to the one set in the config (even if the user isn't logged in).
       // Same applies for domains.
-      projectId: cloudProject?.id || config.id,
-      projectConfig: config,
+      projectId: cloudProject?.id || projectConfig.id,
+      projectConfig,
       projectRoot,
       projectName,
       environmentName,
@@ -2181,22 +2181,22 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       variables,
       variableOverrides,
       secrets,
-      projectSources: config.sources,
+      projectSources: projectConfig.sources,
       production,
       gardenDirPath,
       localConfigStore,
       globalConfigStore,
       opts,
-      outputs: config.outputs || [],
+      outputs: projectConfig.outputs || [],
       plugins: opts.plugins || [],
       providerConfigs: providers,
       moduleExcludePatterns,
       workingCopyId,
-      dotIgnoreFile: config.dotIgnoreFile,
+      dotIgnoreFile: projectConfig.dotIgnoreFile,
       proxy,
       log,
       gardenInitLog: opts.gardenInitLog,
-      moduleIncludePatterns: (config.scan || {}).include,
+      moduleIncludePatterns: (projectConfig.scan || {}).include,
       username: _username,
       forceRefresh: opts.forceRefresh,
       cache: treeCache,

--- a/core/src/plugin/sdk.ts
+++ b/core/src/plugin/sdk.ts
@@ -56,7 +56,7 @@ export type BuildStatus = _BuildStatus
 
 export class GardenSdkPlugin {
   public readonly name: string
-  private spec: GardenPluginSpec
+  private readonly spec: GardenPluginSpec
 
   constructor(spec: GardenSdkPluginSpec) {
     this.name = spec.name

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -8,7 +8,6 @@
 
 import { join, resolve } from "path"
 import fsExtra from "fs-extra"
-const { pathExists, readFile } = fsExtra
 import { joi } from "../../config/common.js"
 import { dedent, splitLines, naturalList } from "../../util/string.js"
 import { STATIC_DIR } from "../../constants.js"
@@ -23,6 +22,8 @@ import type { BaseAction } from "../../actions/base.js"
 import type { BuildAction } from "../../actions/build.js"
 import { sdk } from "../../plugin/sdk.js"
 import { styles } from "../../logger/styles.js"
+
+const { pathExists, readFile } = fsExtra
 
 const defaultConfigPath = join(STATIC_DIR, "hadolint", "default.hadolint.yaml")
 const configFilename = ".hadolint.yaml"

--- a/core/src/plugins/plugins.ts
+++ b/core/src/plugins/plugins.ts
@@ -6,7 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-// These plugins are always registered and the providers documented
+import { GardenApiVersion } from "../constants.js"
+import { isDeprecatedPlugin } from "../util/deprecations.js"
+
+/**
+ * These plugins are always registered and the providers documented.
+ */
 export const getSupportedPlugins = () => [
   {
     name: "container",
@@ -75,13 +80,20 @@ export const getSupportedPlugins = () => [
 ]
 
 // These plugins are always registered
-export const getBuiltinPlugins = () =>
-  getSupportedPlugins().concat([
-    {
-      name: "templated",
-      callback: async () => {
-        const plugin = await import("./templated.js")
-        return plugin.gardenPlugin()
+export const getBuiltinPlugins = (projectApiVersion: GardenApiVersion) =>
+  getSupportedPlugins()
+    .filter((p) => {
+      if (projectApiVersion === GardenApiVersion.v2) {
+        return !isDeprecatedPlugin(p.name)
+      }
+      return true
+    })
+    .concat([
+      {
+        name: "templated",
+        callback: async () => {
+          const plugin = await import("./templated.js")
+          return plugin.gardenPlugin()
+        },
       },
-    },
-  ])
+    ])

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -51,3 +51,9 @@ For more information, please refer to the [`scan` reference documentation](../re
 <h3 id="kubernetesClusterInitCommand">The Kubernetes plugin command `cluster-init`</h3>
 
 Do not use this command. It has no effect.
+
+## Garden Plugins
+
+<h3 id="hadolintPlugin">The `Hadolint` plugin</h3>
+
+Do not use this plugin.


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pr deprecated some old plugins. It used the new deprecation machinery introduced in #6820.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
