### PR TITLE
improvement(terraform): support dynamic backends

### DIFF
--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -79,6 +79,15 @@ export function isExecaError(err: any): err is ExecaError {
   return err.exitCode !== undefined && err.exitCode !== null
 }
 
+export function isErrorWithMessage(error: unknown): error is { message: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  )
+}
+
 export type StackTraceMetadata = {
   functionName: string
   relativeFileName?: string

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -354,6 +354,32 @@ Use the specified Terraform workspace.
 | -------- | -------- |
 | `string` | No       |
 
+### `spec.backendConfig`
+
+[spec](#spec) > backendConfig
+
+Configure the Terraform backend.
+
+The key-value pairs defined here are set as the `-backend-config` options when Garden
+runs `terraform init`.
+
+This can be used to dynamically set a Terraform backend depending on the environment.
+
+If Garden sees that the backend has changes, it'll re-initialize Terraform and set the new values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+spec:
+  ...
+  backendConfig:
+      "bucket: ${environment.name\\}-bucket\nkey: tf-state/${local.username\\}/terraform.tfstate"
+```
+
 
 ## Outputs
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -199,6 +199,16 @@ version:
 
 # Use the specified Terraform workspace.
 workspace:
+
+# Configure the Terraform backend.
+#
+# The key-value pairs defined here are set as the `-backend-config` options when Garden
+# runs `terraform init`.
+#
+# This can be used to dynamically set a Terraform backend depending on the environment.
+#
+# If Garden sees that the backend has changes, it'll re-initialize Terraform and set the new values.
+backendConfig:
 ```
 
 ## Configuration Keys
@@ -561,6 +571,28 @@ Use the specified Terraform workspace.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `backendConfig`
+
+Configure the Terraform backend.
+
+The key-value pairs defined here are set as the `-backend-config` options when Garden
+runs `terraform init`.
+
+This can be used to dynamically set a Terraform backend depending on the environment.
+
+If Garden sees that the backend has changes, it'll re-initialize Terraform and set the new values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+backendConfig:
+    "bucket: ${environment.name\\}-bucket\nkey: tf-state/${local.username\\}/terraform.tfstate"
+```
 
 
 ## Outputs

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -54,8 +54,15 @@ providers:
     # Use the specified Terraform workspace.
     workspace:
 
-    # Set to `true` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to `false`
-    streamLogsToCloud: false
+    # Configure the Terraform backend.
+    #
+    # The key-value pairs defined here are set as the `-backend-config` options when Garden
+    # runs `terraform init`.
+    #
+    # This can be used to dynamically set a Terraform backend depending on the environment.
+    #
+    # If Garden sees that the backend has changes, it'll re-initialize Terraform and set the new values.
+    backendConfig:
 ```
 ## Configuration Keys
 
@@ -184,13 +191,28 @@ Use the specified Terraform workspace.
 | -------- | -------- |
 | `string` | No       |
 
-### `providers[].streamLogsToCloud`
+### `providers[].backendConfig`
 
-[providers](#providers) > streamLogsToCloud
+[providers](#providers) > backendConfig
 
-Set to `true` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to `false`
+Configure the Terraform backend.
 
-| Type      | Default | Required |
-| --------- | ------- | -------- |
-| `boolean` | `false` | No       |
+The key-value pairs defined here are set as the `-backend-config` options when Garden
+runs `terraform init`.
+
+This can be used to dynamically set a Terraform backend depending on the environment.
+
+If Garden sees that the backend has changes, it'll re-initialize Terraform and set the new values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - backendConfig:
+        "bucket: ${environment.name\\}-bucket\nkey: tf-state/${local.username\\}/terraform.tfstate"
+```
 

--- a/docs/terraform-plugin/about.md
+++ b/docs/terraform-plugin/about.md
@@ -44,49 +44,21 @@ Each command automatically applies any variables configured on the provider or a
 garden --env=<env-name> plugins terraform apply-root -- -auto-approve
 ```
 
-## Injecting Environment Variables Into Backend Manifests
+## Setting the backend dynamically
 
-[Terraform does not interpolate named values in backend manifests](https://developer.hashicorp.com/terraform/language/backend). Below is a solution using an `exec` provider.
+[Terraform does not interpolate named values in backend manifests](https://developer.hashicorp.com/terraform/language/backend) but with Garden you can achieve this via the `backendConfig` field on either the `terraform` provider or action configuration. This enables you to dynamically set the backend when applying your Terraform stack in different environments.
 
-### Exec Provider
+For example, running `garden deploy --env dev` and `garden deploy --env ci` will pick the appropriate backend for the environment.
 
-One way to inject variables into new terraform manifests is to add an [exec provider](../reference/providers/exec.md) that calls an [initScript](../reference/providers/exec.md#providers-.initscript) in the project.garden.yaml file. Exec providers allow us to run scripts while initiating other providers. An `initScript` runs in the project root when initializing those providers.
+If you'd like to apply the stack when starting Garden (e.g. because you're provisioning a Kubernetes cluster and need to pass the outputs to other Garden providers), checkout [the Terraform provider docs for configuring dynamic backends](./configure-provider.md#setting-the-backend-dynamically).
 
-In this sample `terraform/backend.tf` manifest, we need to replace the `key` based on which environment we are building.
-
-```
-terraform {
-  backend "s3" {
-    bucket  = "state-bucket"
-    key     = "projects/my-project/terraform.tfstate"
-    region  = "us-west-2"
-  }
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
-```
-
-In the `project.garden.yaml` file for this sample, the `exec` provider calls an `initScript` that replaces in-place the pre-existing state file with a copy that substitutes the s3 bucket name with the environment name in the `backend.tf` file.
-
-```yaml
-providers:
-  - name: exec
-    initScript: rm -rf terraform/.terraform* && sed -i .bak 's;key *= *"projects/[a-zA-Z0-9]*/terraform.tfstate";key = "projects/${environment.name}/terraform.tfstate";g' terraform/backend.tf
-  - name: terraform
-    initRoot: "./terraform"
-    variables:
-      project: ${environment.name}
-    dependencies: [exec]
-```
-
-Now when you deploy a new Terraformed environment, the new backend statefile will know where to go.
+If instead you configure your Terraform stack via actions (e.g. because you have
+multiple AWS labmdas that should each have their own stack), checkout [the Terraform
+action docs for configuring dynamic
+backends](./actions.md#setting-the-backend-dynamically).
 
 ## Next steps
 
-Check out the [terraform-gke example](https://github.com/garden-io/garden/tree/0.13.53/examples/terraform-gke) project. Also take a look at the [Terraform provider reference](../reference/providers/terraform.md) and the [Terraform Deploy action type reference](../reference/action-types/Deploy/terraform.md) for details on all the configuration parameters.
+Check out how to configure the Terraform provider and/or actions in the following pages.
+You'll find some [Terraform examples here](https://github.com/garden-io/garden/tree/main/examples).
 
-If you're having issues with Terraform itself, please refer to the [official docs](https://developer.hashicorp.com/terraform/docs).

--- a/docs/terraform-plugin/about.md
+++ b/docs/terraform-plugin/about.md
@@ -50,12 +50,10 @@ garden --env=<env-name> plugins terraform apply-root -- -auto-approve
 
 For example, running `garden deploy --env dev` and `garden deploy --env ci` will pick the appropriate backend for the environment.
 
-If you'd like to apply the stack when starting Garden (e.g. because you're provisioning a Kubernetes cluster and need to pass the outputs to other Garden providers), checkout [the Terraform provider docs for configuring dynamic backends](./configure-provider.md#setting-the-backend-dynamically).
+If you'd like to apply the stack when starting Garden (e.g. because you're provisioning a Kubernetes cluster and need to pass the outputs to other Garden providers), check out [the Terraform provider docs for configuring dynamic backends](./configure-provider.md#setting-the-backend-dynamically).
 
 If instead you configure your Terraform stack via actions (e.g. because you have
-multiple AWS labmdas that should each have their own stack), checkout [the Terraform
-action docs for configuring dynamic
-backends](./actions.md#setting-the-backend-dynamically).
+multiple AWS labmdas that should each have their own stack), check out [the Terraform action docs for configuring dynamic backends](./actions.md#setting-the-backend-dynamically).
 
 ## Next steps
 

--- a/docs/terraform-plugin/actions.md
+++ b/docs/terraform-plugin/actions.md
@@ -52,10 +52,10 @@ defaultEnvironment: dev
 environments:
   - name: dev
     variables:
-      tfNamespace: ${kebabCase(local.username)} # <--- Each user has their lambda
+      tfNamespace: ${kebabCase(local.username)} # <--- Each user has their own set of lambdas
   - name: ci
     variables:
-      tfNamespace: ${slice(git.commitHash, 0, 7) || '<detached>'} # <--- Each CI run has their lambda
+      tfNamespace: ${slice(git.commitHash, 0, 7) || '<detached>'} # <--- Each CI run has its own set of lambdas
 
 ---
 kind: Deploy

--- a/docs/terraform-plugin/actions.md
+++ b/docs/terraform-plugin/actions.md
@@ -28,4 +28,75 @@ spec:
 
 Here we imagine a Terraform stack that has a `my-database-uri` output, that we then supply to `my-service` via the `DATABASE_URI` environment variable.
 
-Much like other Deploy actions, you can also reference Terraform definitions in other repositories using the `repositoryUrl` key. See the [Remote Sources](../advanced/using-remote-sources.md) guide for details.
+Much like other Deploy actions, you can also reference Terraform definitions in other repositories using the `repositoryUrl` key. See the [Remote Sources](../advanced/custom-commands.md
+
+## Setting the backend dynamically
+
+[Terraform does not interpolate named values in backend manifests](https://developer.hashicorp.com/terraform/language/backend) but with Garden you can achieve this via the `backendConfig` field on the `terraform` Deploy action. This enables you to dynamically set the backend when applying your Terraform stack in different environments.
+
+### Example - Isolated namespaces for Labmda functions
+
+In the example below we can imagine a project with multiple AWS Lambda functions and a Terraform stack per function. Splitting the functions into individual stacks is useful for leveraging Garden's graph and cache capabilities. For example, you can granularly deploy or test individual lambdas instead of having everything bundled together in big stack.
+
+Here we namespace the Lambdas such that each developer and CI run gets its own isolated namespace which can be cleaned up after the run.
+
+We achieve this via the `backendConfig` field on the `terraform` Deploy action spec which can make use of Garden's powerful templating system.
+
+```yaml
+# In project.garden.yml file
+apiVersion: "garden.io/v1"
+kind: Project
+name: terraform-lambda-example
+defaultEnvironment: dev
+
+environments:
+  - name: dev
+    variables:
+      tfNamespace: ${kebabCase(local.username)} # <--- Each user has their lambda
+  - name: ci
+    variables:
+      tfNamespace: ${slice(git.commitHash, 0, 7) || '<detached>'} # <--- Each CI run has their lambda
+
+---
+kind: Deploy
+name: function-a
+type: terraform
+spec:
+  root: ./tf/function-a
+  variables:
+    function_name_prefix: ${var.tfNamespace} # <--- This would get passed to Terraform to ensure the function names are unique
+  backendConfig:
+    bucket: my-${environment.name}-bucket
+    key: tf-state/${var.tfNamespace}/terraform.tfstate
+---
+kind: Deploy
+name: function-b
+type: terraform
+spec:
+  root: ./tf/function-b
+  variables:
+    function_name_prefix: ${var.tfNamespace}
+  backendConfig:
+    bucket: my-${environment.name}-bucket
+    key: tf-state/${var.tfNamespace}/terraform.tfstate
+```
+
+The corresponding Terraform `main.tf` files would look something like this:
+
+```hcl
+# For example in ./tf/function-a/main.tf
+terraform {
+  required_version = ">= 0.12"
+  backend "s3" {
+    bucket = ""
+    key    = ""
+    region = "<my-aws-region>"
+  }
+}
+# ...
+```
+
+Note that this same pattern of course applies to other cloud providers and/or resources
+as well.
+
+You can use the `garden cleanup` function to cleanup namespaces. It's also useful to have a lifecycle policy for cleaning up S3 buckets in non-prod environments.

--- a/docs/terraform-plugin/configure-provider.md
+++ b/docs/terraform-plugin/configure-provider.md
@@ -42,3 +42,53 @@ providers:
 The `initRoot` parameter tells Garden that there is a Terraform working directory at the specified path. If you don't specify this, Garden doesn't attempt to apply a stack when initializing the provider.
 
 Notice also that we're providing an output value from the stack to the `kubernetes` provider. This can be very powerful, and allows you to fully codify your full project setup, not just the services running in your environment. Any Garden action can also reference the provider outputs in the exact same way, so you can easily provide your services with any information they need to operate.
+
+## Setting the backend dynamically
+
+
+[Terraform does not interpolate named values in backend manifests](https://developer.hashicorp.com/terraform/language/backend) but with Garden you can achieve this via the `backendConfig` field on the Terraform provider. This enables you to dynamically set the backend when applying your Terraform stack in different environments.
+
+### Example - Provision a K8s cluster per environment
+
+In the example below we can imagine a Terraform stack that provisions a Kubernetes cluster when Garden starts and passes the output to other providers (similar to the example above) and picks a backend dynamically depending on the environment.
+
+We achieve this via the `backendConfig` field on the `terraform` provider spec which can make use of Garden's powerful templating system.
+
+This means you can run `garden deploy` (for the dev env) and it'll use the corresponding backend. From the same host you could then run `garden deploy --env` without needing to update your config and manually re-intialize Terraform and it'll again pick the correct backend.
+
+```yaml
+# In project.garden.yml file
+apiVersion: "garden.io/v1"
+kind: Project
+name: terraform-lambda-example
+defaultEnvironment: dev
+
+environments:
+  - dev
+  - ci
+
+providers:
+  - name: terraform
+    initRoot: "."
+    # Pick the right S3 bucket and key for the environment
+    backendConfig:
+      bucket: my-${environment.name}-bucket
+      key: tf-state/${environment.name}/terraform.tfstate
+  - name: kubernetes
+    kubeconfig: ${providers.terraform.outputs.kubeconfig_path}
+# ...
+```
+
+A corresponding Terraform `main.tf` file would look like this:
+
+```hcl
+terraform {
+  required_version = ">= 0.12"
+  backend "s3" {
+    bucket = ""
+    key    = ""
+    region = "<my-aws-region>"
+  }
+}
+# ...
+```

--- a/docs/terraform-plugin/configure-provider.md
+++ b/docs/terraform-plugin/configure-provider.md
@@ -54,7 +54,7 @@ In the example below we can imagine a Terraform stack that provisions a Kubernet
 
 We achieve this via the `backendConfig` field on the `terraform` provider spec which can make use of Garden's powerful templating system.
 
-This means you can run `garden deploy` (for the dev env) and it'll use the corresponding backend. From the same host you could then run `garden deploy --env` without needing to update your config and manually re-intialize Terraform and it'll again pick the correct backend.
+This means you can run `garden deploy` (for the dev env) and it will use the corresponding backend. From the same host you could then run `garden deploy --env` without needing to update your config and manually re-intialize Terraform, and it will again pick the correct backend.
 
 ```yaml
 # In project.garden.yml file

--- a/examples/terraform-dynamic-backend/README.md
+++ b/examples/terraform-dynamic-backend/README.md
@@ -1,0 +1,64 @@
+# Dynamic Terraform backend example project
+
+This example project demonstrates how to use dynamic Terraform backends with Garden.
+
+Terraform itself doesn't allow variables in the backend configuration but with Garden you can enable this behaviour and create unique, on-demand environments for your Terraform stack.
+
+> [!TIP]
+> If using S3 or similar as your Terraform backend, set a lifecycle policy on your bucket so that old folders get cleaned up in non-production environments. They'll anyway get re-created if needed.
+
+## Using this project
+
+This project is for demonstrating how to configure dynamic backends and won't run without access to an S3 bucket (with the corresponding values in the `project.garden.yml` file correctly set).
+
+Assuming everything's wired up, running Garden in different environments will dynamically set the backend and re-initialize Terraform if needed.
+
+E.g. running `garden deploy` would use the default `dev` environment and store the state in the `dev-bucket` under a folder named `tf-state/<your-username>` .
+
+Similarly, running `garden deploy --env ci` would store the state in the `ci-bucket` under a folder named `tf-state/<short-git-commit-hash>`
+
+## How it's set up
+
+The `main.tf` file includes the `backend` configuration:
+
+```terraform
+terraform {
+  required_version = ">= 0.12"
+  backend "s3" {
+    # Set in Garden config
+    bucket = ""
+    key = ""
+    region = ""
+  }
+}
+```
+
+You'll notice that the actual values are empty because they're set dynamically by Garden (you could also have default values here).
+
+In the Garden config in the `project.garden.yml` file we dynmically set the backend values based on the environment:
+
+```yaml
+apiVersion: "garden.io/v1"
+kind: Project
+# ...
+
+environments:
+  - name: dev
+    variables:
+      bucket: dev-bucket
+      keyNamespace:
+      ${kebabCase(local.username)}
+# ...
+
+---
+kind: Deploy
+name: tf-hello
+
+spec:
+  root: .
+  backendConfig:
+    bucket: ${var.bucket} # <--- Resolves to dev-bucket in dev env
+    key: tf-state/${var.keyNamespace}/terraform.tfstate # <--- Resolves to tf-state/<your-username>/terraform.tfstate in dev env
+    region: eu-central-1
+```
+

--- a/examples/terraform-dynamic-backend/README.md
+++ b/examples/terraform-dynamic-backend/README.md
@@ -2,7 +2,7 @@
 
 This example project demonstrates how to use dynamic Terraform backends with Garden.
 
-Terraform itself doesn't allow variables in the backend configuration but with Garden you can enable this behaviour and create unique, on-demand environments for your Terraform stack.
+Terraform itself doesn't allow variables in the backend configuration but with Garden you can enable this behavior and create unique, on-demand environments for your Terraform stack.
 
 > [!TIP]
 > If using S3 or similar as your Terraform backend, set a lifecycle policy on your bucket so that old folders get cleaned up in non-production environments. They'll anyway get re-created if needed.
@@ -35,7 +35,7 @@ terraform {
 
 You'll notice that the actual values are empty because they're set dynamically by Garden (you could also have default values here).
 
-In the Garden config in the `project.garden.yml` file we dynmically set the backend values based on the environment:
+In the Garden config in the `project.garden.yml` file we dynamically set the backend values based on the environment:
 
 ```yaml
 apiVersion: "garden.io/v1"

--- a/examples/terraform-dynamic-backend/main.tf
+++ b/examples/terraform-dynamic-backend/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 0.12"
+  backend "s3" {
+    # Set in Garden config
+    bucket = ""
+    key = ""
+    region = ""
+  }
+}
+
+resource "null_resource" "say-hello" {
+  provisioner "local-exec" {
+    command = "echo 'Hello from Terraform'"
+  }
+}
+

--- a/examples/terraform-dynamic-backend/project.garden.yml
+++ b/examples/terraform-dynamic-backend/project.garden.yml
@@ -1,0 +1,32 @@
+apiVersion: "garden.io/v1"
+kind: Project
+name: terraform-dynamic-backend-example
+defaultEnvironment: dev
+
+environments:
+  - name: dev
+    variables:
+      bucket: dev-bucket
+      keyNamespace: ${kebabCase(local.username)}
+  - name: ci
+    variables:
+      bucket: ci-bucket
+      keyNamespace: ${slice(git.commitHash, 0, 7) || '<detached>'}
+  - name: qa
+    variables:
+      bucket: qa-bucket
+      keyNamespace: ${git.branch}
+
+providers:
+  - name: terraform
+
+---
+kind: Deploy
+name: tf-hello
+
+spec:
+  root: .
+  backendConfig: # <--- Dynamically set the backend for this action, depending on the environment
+    bucket: ${var.bucket}
+    key: tf-state/${var.keyNamespace}/terraform.tfstate
+    region: eu-central-1

--- a/plugins/terraform/package.json
+++ b/plugins/terraform/package.json
@@ -24,8 +24,8 @@
     "chai": "^5.1.2",
     "mocha": "^11.0.1",
     "source-map-support": "^0.5.21",
-    "strip-ansi": "^7.1.0",
-    "split2": "^4.2.0"
+    "split2": "^4.2.0",
+    "strip-ansi": "^7.1.0"
   },
   "scripts": {
     "clean": "shx rm -rf build dist",

--- a/plugins/terraform/src/action.ts
+++ b/plugins/terraform/src/action.ts
@@ -10,7 +10,7 @@ import { createSchema, joi, joiVariables } from "@garden-io/core/build/src/confi
 import { dedent } from "@garden-io/core/build/src/util/string.js"
 import { supportedVersions } from "./cli.js"
 import type { TerraformBaseSpec } from "./helpers.js"
-import { variablesSchema } from "./helpers.js"
+import { terraformBackendConfigSchema, variablesSchema } from "./helpers.js"
 import type { DeployAction, DeployActionConfig } from "@garden-io/core/build/src/actions/deploy.js"
 
 export interface TerraformDeploySpec extends TerraformBaseSpec {
@@ -48,6 +48,7 @@ export const terraformDeploySchemaKeys = () => ({
     Set to \`null\` to use whichever version of \`terraform\` that is on your PATH.
   `),
   workspace: joi.string().allow(null).description("Use the specified Terraform workspace."),
+  backendConfig: terraformBackendConfigSchema(),
 })
 
 export const terraformDeploySchema = createSchema({

--- a/plugins/terraform/src/commands.ts
+++ b/plugins/terraform/src/commands.ts
@@ -9,7 +9,7 @@
 import { terraform } from "./cli.js"
 import type { TerraformProvider } from "./provider.js"
 import { ConfigurationError, ParameterError } from "@garden-io/sdk/build/src/exceptions.js"
-import { prepareVariables, ensureWorkspace, initTerraform } from "./helpers.js"
+import { prepareVariables, ensureWorkspace, ensureTerraformInit } from "./helpers.js"
 import type { ConfigGraph, PluginCommand, PluginCommandParams } from "@garden-io/sdk/build/src/types.js"
 import { join } from "path"
 import fsExtra from "fs-extra"
@@ -53,7 +53,7 @@ function makeRootCommand(commandName: string): PluginCommand {
       const workspace = provider.config.workspace || null
 
       await ensureWorkspace({ ctx, provider, root, log, workspace })
-      await initTerraform({ ctx, provider, root, log })
+      await ensureTerraformInit({ ctx, provider, root, log })
 
       args = [commandName, ...(await prepareVariables(root, provider.config.variables)), ...args]
 
@@ -96,7 +96,7 @@ function makeActionCommand(commandName: string): PluginCommand {
       const workspace = spec.workspace || null
 
       await ensureWorkspace({ ctx, provider, root, log, workspace })
-      await initTerraform({ ctx, provider, root, log })
+      await ensureTerraformInit({ ctx, provider, root, log })
 
       args = [commandName, ...(await prepareVariables(root, spec.variables)), ...args.slice(1)]
       await terraform(ctx, provider).spawnAndWait({

--- a/plugins/terraform/src/handlers.ts
+++ b/plugins/terraform/src/handlers.ts
@@ -15,7 +15,7 @@ import {
   getTfOutputs,
   prepareVariables,
   ensureWorkspace,
-  initTerraform,
+  ensureTerraformInit,
 } from "./helpers.js"
 import type { TerraformProvider } from "./provider.js"
 import type { DeployActionHandler } from "@garden-io/core/build/src/plugin/action-types.js"
@@ -33,7 +33,8 @@ export const getTerraformStatus: DeployActionHandler<"getStatus", TerraformDeplo
   const workspace = spec.workspace || null
 
   await ensureWorkspace({ log, ctx, provider, root, workspace })
-  await initTerraform({ log, ctx, provider, root })
+  await ensureTerraformInit({ log, ctx, provider, root, backendConfig: spec.backendConfig })
+
   const status = await getStackStatus({
     ctx,
     log,
@@ -62,6 +63,8 @@ export const deployTerraform: DeployActionHandler<"deploy", TerraformDeploy> = a
   const root = getModuleStackRoot(action, spec)
 
   if (spec.autoApply) {
+    await ensureWorkspace({ log, ctx, provider, root, workspace })
+    await ensureTerraformInit({ log, ctx, provider, root, backendConfig: spec.backendConfig })
     await applyStack({ log, ctx, provider, root, variables: spec.variables, workspace, actionName: action.name })
   } else {
     const templateKey = `\${runtime.services.${action.name}.outputs.*}`

--- a/plugins/terraform/src/init.ts
+++ b/plugins/terraform/src/init.ts
@@ -14,7 +14,7 @@ import {
   getTfOutputs,
   prepareVariables,
   ensureWorkspace,
-  initTerraform,
+  ensureTerraformInit,
 } from "./helpers.js"
 import { deline } from "@garden-io/sdk/build/src/util/string.js"
 import type { ProviderHandlers } from "@garden-io/sdk/build/src/types.js"
@@ -85,7 +85,7 @@ export const prepareEnvironment: ProviderHandlers["prepareEnvironment"] = async 
   const workspace = provider.config.workspace || null
 
   await ensureWorkspace({ log, ctx, provider, root, workspace })
-  await initTerraform({ log, ctx, provider, root })
+  await ensureTerraformInit({ log, ctx, provider, root, backendConfig: provider.config.backendConfig })
 
   const status = await getStackStatus({
     log,

--- a/plugins/terraform/src/provider.ts
+++ b/plugins/terraform/src/provider.ts
@@ -9,7 +9,7 @@
 import { dedent } from "@garden-io/sdk/build/src/util/string.js"
 import { defaultTerraformVersion, supportedVersions } from "./cli.js"
 import type { TerraformBaseSpec } from "./helpers.js"
-import { variablesSchema } from "./helpers.js"
+import { terraformBackendConfigSchema, variablesSchema } from "./helpers.js"
 import { docsBaseUrl } from "@garden-io/sdk/build/src/constants.js"
 
 import type { BaseProviderConfig, Provider } from "@garden-io/core/build/src/config/provider.js"
@@ -60,5 +60,6 @@ export const terraformProviderConfigSchema = providerConfigBaseSchema()
       .description(
         `Set to \`true\` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to \`false\``
       ),
+    backendConfig: terraformBackendConfigSchema(),
   })
   .unknown(false)

--- a/plugins/terraform/test/terraform.ts
+++ b/plugins/terraform/test/terraform.ts
@@ -7,6 +7,8 @@
  */
 
 import { dirname, join, resolve } from "node:path"
+import http from "node:http"
+import getPort from "get-port"
 
 import { expect } from "chai"
 import fsExtra from "fs-extra"
@@ -27,9 +29,89 @@ import { RunTask } from "@garden-io/core/build/src/tasks/run.js"
 import { defaultTerraformVersion } from "../src/cli.js"
 import { fileURLToPath } from "node:url"
 import { resolveMsg } from "@garden-io/core/build/src/logger/log-entry.js"
+import { getRootLogger, type Logger } from "@garden-io/core/build/src/logger/logger.js"
+import { type TerraformDeploy } from "../src/action.js"
 
 const moduleDirName = dirname(fileURLToPath(import.meta.url))
 
+/**
+ * A mock http server that intercepts Terraform calls for getting/posting state
+ * to an "http" backend.
+ *
+ * Used for testing the `backendConfig` logic.
+ */
+export class TerraformMockBackendServer {
+  private server: http.Server
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private interceptedRequests: any[] = []
+  private port: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private state: any = null
+
+  constructor(port: number = 9090) {
+    this.port = port
+
+    this.server = http.createServer((req, res) => {
+      let body = ""
+      req.on("data", (chunk) => (body += chunk))
+
+      req.on("end", () => {
+        // Log the request
+        const request = {
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body: body ? JSON.parse(body) : null,
+          timestamp: new Date(),
+        }
+        this.interceptedRequests.push(request)
+
+        const mockState = {
+          version: 4,
+          terraform_version: "1.5.0",
+          serial: 1,
+          lineage: "123e4567-e89b-12d3-a456-426614174000",
+          outputs: {},
+          resources: [],
+          check_results: null,
+        }
+
+        // Handle different state operations
+        if (req.method === "GET") {
+          res.writeHead(200, { "Content-Type": "application/json" })
+          res.end(JSON.stringify(mockState))
+        } else if (req.method === "POST") {
+          res.writeHead(200, { "Content-Type": "application/json" })
+          res.end(JSON.stringify({ status: "success" }))
+        }
+      })
+    })
+  }
+
+  start(): Promise<void> {
+    return new Promise((res) => {
+      this.server.listen(this.port, () => {
+        res()
+      })
+    })
+  }
+
+  stop(): Promise<void> {
+    return new Promise((res) => {
+      this.server.close(() => {
+        res()
+      })
+    })
+  }
+
+  getInterceptedRequests() {
+    return this.interceptedRequests
+  }
+
+  clearInterceptedRequests() {
+    this.interceptedRequests = []
+  }
+}
 for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
   describe(`Terraform provider with terraform ${terraformVersion}`, () => {
     const testRoot = resolve(moduleDirName, "../../test/", "test-project")
@@ -47,6 +129,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       if (tfRoot && (await pathExists(testFilePath))) {
         await remove(testFilePath)
       }
+
       if (stateDirPath && (await pathExists(stateDirPath))) {
         await remove(stateDirPath)
       }
@@ -315,12 +398,122 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
         })
       })
     })
+
+    context("backendConfig defined", () => {
+      const testRootBackendConfig = resolve(moduleDirName, "../../test/", "test-project-backendconfig")
+      tfRoot = join(testRootBackendConfig, "tf")
+      stateDirPath = join(tfRoot, ".terraform")
+
+      let server: TerraformMockBackendServer
+      let port: number
+
+      before(async () => {
+        port = await getPort()
+        server = new TerraformMockBackendServer(port)
+        await server.start()
+      })
+
+      beforeEach(async () => {
+        await reset()
+        server.clearInterceptedRequests()
+      })
+
+      afterEach(async () => {
+        getRootLogger()["entries"] = []
+      })
+
+      after(async () => {
+        await server.stop()
+      })
+
+      it("should dynamically set backend config", async () => {
+        const testGarden = await makeTestGarden(testRootBackendConfig, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+            "address": `http://localhost:${port}/terraform/state?some-dynamic-key`,
+          },
+        })
+        await testGarden.resolveProvider({ log: testGarden.log, name: "terraform" })
+
+        const requests = server.getInterceptedRequests()
+        const requestUrl = requests[0].url
+        const messages = getRootLogMessages(testGarden.log, (e) => e.level === LogLevel.info)
+
+        expect(requestUrl).to.eql("/terraform/state?some-dynamic-key")
+        expect(messages).to.not.include(
+          "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
+        )
+      })
+
+      it("should NOT re-initialize Terraform if no state file present", async () => {
+        const testGarden = await makeTestGarden(testRootBackendConfig, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+            "address": `http://localhost:${port}/terraform/state?some-dynamic-key`,
+          },
+        })
+        await testGarden.resolveProvider({ log: testGarden.log, name: "terraform" })
+
+        const messages = getRootLogMessages(testGarden.log, (e) => e.level === LogLevel.info)
+        // A fresh test project won't have a statefile
+        expect(messages).to.not.include(
+          "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
+        )
+      })
+
+      it("should re-initialize Terraform with -reconfigure flag if backendConfig changes", async () => {
+        const testGardenA = await makeTestGarden(testRootBackendConfig, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+            "address": `http://localhost:${port}/terraform/state?some-dynamic-key`,
+          },
+        })
+        await testGardenA.resolveProvider({ log: testGardenA.log, name: "terraform" })
+
+        // Reset logger before running Garden again
+        const logger: Logger = getRootLogger()
+        logger["entries"] = []
+
+        const testGardenB = await makeTestGarden(testRootBackendConfig, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+            "address": `http://localhost:${port}/terraform/state?some-other-dynamic-key`,
+          },
+        })
+        //
+        await testGardenB.resolveProvider({ log: testGardenB.log, name: "terraform" })
+
+        const requests = server.getInterceptedRequests()
+        const messages = getRootLogMessages(testGardenB.log, (e) => e.level === LogLevel.info)
+        const requestUrlForGardenA = requests[0].url
+        // Grab the last request to get one from the second Garden run
+        const requestUrlForGardenB = requests[requests.length - 1].url
+
+        expect(requestUrlForGardenA).to.eql("/terraform/state?some-dynamic-key")
+        expect(requestUrlForGardenB).to.eql("/terraform/state?some-other-dynamic-key")
+        expect(messages).to.include(
+          "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
+        )
+      })
+    })
   })
 
   describe("Terraform action type", () => {
     const testRoot = resolve(moduleDirName, "../../test/", "test-project-action")
-    const tfRoot = join(testRoot, "tf")
-    const stateDirPath = join(tfRoot, "terraform.tfstate")
+    let tfRoot = join(testRoot, "tf")
+    let stateDirPath = join(tfRoot, "terraform.tfstate")
     const backupStateDirPath = join(tfRoot, "terraform.tfstate.backup")
     const stateDirPathWithWorkspaces = join(tfRoot, "terraform.tfstate.d")
     const testFilePath = join(tfRoot, "test.log")
@@ -344,6 +537,9 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
     }
 
     beforeEach(async () => {
+      tfRoot = join(testRoot, "tf")
+      stateDirPath = join(tfRoot, "terraform.tfstate")
+
       await reset()
       garden = await makeTestGarden(testRoot, {
         plugins: [gardenPlugin()],
@@ -647,6 +843,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
     context("autoApply=true", () => {
       it("should apply a stack on init and use configured variables", async () => {
         await runTestTask(true)
+
         expect(
           garden.log.root
             .getLogEntries()
@@ -766,6 +963,177 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
 
         const { selected } = await getWorkspaces({ ctx, provider, root: tfRoot, log: _garden.log })
         expect(selected).to.equal("foo")
+      })
+    })
+
+    context("backendConfig defined", () => {
+      const testRootBackendConfigAction = resolve(moduleDirName, "../../test/", "test-project-backendconfig-action")
+      tfRoot = join(testRootBackendConfigAction, "tf")
+      stateDirPath = join(tfRoot, ".terraform")
+
+      let server: TerraformMockBackendServer
+      let port: number
+
+      before(async () => {
+        port = await getPort()
+        server = new TerraformMockBackendServer(port)
+        await server.start()
+      })
+
+      beforeEach(async () => {
+        tfRoot = join(testRootBackendConfigAction, "tf")
+        stateDirPath = join(tfRoot, ".terraform")
+        await reset()
+        server.clearInterceptedRequests()
+      })
+
+      afterEach(async () => {
+        getRootLogger()["entries"] = []
+      })
+
+      after(async () => {
+        await server.stop()
+      })
+
+      it("should dynamically set backend config", async () => {
+        const testGarden = await makeTestGarden(testRootBackendConfigAction, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+          },
+        })
+        graph = await testGarden.getConfigGraph({ log: testGarden.log, emit: false })
+        const action = graph.getDeploy("tf-backendconfig-deploy") as TerraformDeploy
+        action._config.spec.backendConfig = {
+          address: `http://localhost:${port}/terraform/state?some-dynamic-key-for-action`,
+        }
+        const resolvedAction = await resolveAction<TerraformDeploy>({
+          garden: testGarden,
+          graph,
+          action,
+          log: garden.log,
+        })
+        const deployTask = new DeployTask({
+          garden: testGarden,
+          graph,
+          action: resolvedAction,
+          log: testGarden.log,
+          force: false,
+          forceBuild: false,
+        })
+        await testGarden.processTasks({ tasks: [deployTask], throwOnError: true })
+
+        const requests = server.getInterceptedRequests()
+        const requestUrl = requests[0].url
+
+        expect(requestUrl).to.eql("/terraform/state?some-dynamic-key-for-action")
+      })
+
+      it("should NOT re-initialize Terraform if no state file present", async () => {
+        const testGarden = await makeTestGarden(testRootBackendConfigAction, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+          },
+        })
+        graph = await testGarden.getConfigGraph({ log: testGarden.log, emit: false })
+        const action = graph.getDeploy("tf-backendconfig-deploy") as TerraformDeploy
+        action._config.spec.backendConfig = {
+          address: `http://localhost:${port}/terraform/state?some-dynamic-key-for-action`,
+        }
+        const resolvedAction = await resolveAction<TerraformDeploy>({
+          garden: testGarden,
+          graph,
+          action,
+          log: garden.log,
+        })
+        const deployTask = new DeployTask({
+          garden: testGarden,
+          graph,
+          action: resolvedAction,
+          log: testGarden.log,
+          force: false,
+          forceBuild: false,
+        })
+        await testGarden.processTasks({ tasks: [deployTask], throwOnError: true })
+
+        const messages = getRootLogMessages(testGarden.log, (e) => e.level === LogLevel.info)
+        // A fresh test project won't have a statefile
+        expect(messages).to.not.include(
+          "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
+        )
+      })
+
+      it("should re-initialize Terraform with -reconfigure flag if backendConfig changes", async () => {
+        const testGarden = await makeTestGarden(testRootBackendConfigAction, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+          },
+        })
+
+        graph = await testGarden.getConfigGraph({ log: testGarden.log, emit: false })
+        const action = graph.getDeploy("tf-backendconfig-deploy") as TerraformDeploy
+
+        action._config.spec.backendConfig = {
+          address: `http://localhost:${port}/terraform/state?some-dynamic-key-for-action`,
+        }
+        const resolvedActionA = await resolveAction<TerraformDeploy>({
+          garden: testGarden,
+          graph,
+          action,
+          log: garden.log,
+        })
+        const deployTaskA = new DeployTask({
+          garden: testGarden,
+          graph,
+          action: resolvedActionA,
+          log: testGarden.log,
+          force: false,
+          forceBuild: false,
+        })
+        await testGarden.processTasks({ tasks: [deployTaskA], throwOnError: true })
+
+        // Reset logger before running Garden again since it's a singleton
+        const logger: Logger = getRootLogger()
+        logger["entries"] = []
+
+        action._config.spec.backendConfig = {
+          address: `http://localhost:${port}/terraform/state?some-other-dynamic-key-for-action`,
+        }
+        const resolvedActionB = await resolveAction<TerraformDeploy>({
+          garden: testGarden,
+          graph,
+          action,
+          log: garden.log,
+        })
+        const deployTaskB = new DeployTask({
+          garden: testGarden,
+          graph,
+          action: resolvedActionB,
+          log: testGarden.log,
+          force: false,
+          forceBuild: false,
+        })
+        await testGarden.processTasks({ tasks: [deployTaskB], throwOnError: true })
+
+        const requests = server.getInterceptedRequests()
+        const messages = getRootLogMessages(testGarden.log, (e) => e.level === LogLevel.info)
+        const firstRequestUrl = requests[0].url
+        // Grab the last request to get one from the second Garden run
+        const lastRequestUrl = requests[requests.length - 1].url
+
+        expect(firstRequestUrl).to.eql("/terraform/state?some-dynamic-key-for-action")
+        expect(lastRequestUrl).to.eql("/terraform/state?some-other-dynamic-key-for-action")
+        expect(messages).to.include(
+          "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
+        )
       })
     })
   })

--- a/plugins/terraform/test/test-project-backendconfig-action/garden.yml
+++ b/plugins/terraform/test/test-project-backendconfig-action/garden.yml
@@ -1,0 +1,15 @@
+apiVersion: garden.io/v1
+kind: Project
+name: terraform-provider-backendconfig-action
+environments:
+  - name: local
+  - name: prod
+providers:
+  - name: terraform
+---
+kind: Deploy
+name: tf-backendconfig-deploy
+type: terraform
+spec:
+  autoApply: true
+  root: ./tf

--- a/plugins/terraform/test/test-project-backendconfig-action/tf/main.tf
+++ b/plugins/terraform/test/test-project-backendconfig-action/tf/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.12"
+  backend "http" {
+    address = ""
+  }
+}
+
+resource "null_resource" "say-hello" {
+  provisioner "local-exec" {
+    command = "echo 'Hello friend'"
+  }
+}
+

--- a/plugins/terraform/test/test-project-backendconfig/garden.yml
+++ b/plugins/terraform/test/test-project-backendconfig/garden.yml
@@ -1,0 +1,12 @@
+apiVersion: garden.io/v1
+kind: Project
+name: terraform-provider-backendconfig
+environments:
+  - name: local
+  - name: prod
+providers:
+  - name: terraform
+    autoApply: true
+    initRoot: tf
+    backendConfig:
+      address: ${var.address}

--- a/plugins/terraform/test/test-project-backendconfig/tf/main.tf
+++ b/plugins/terraform/test/test-project-backendconfig/tf/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.12"
+  backend "http" {
+    address = ""
+  }
+}
+
+resource "null_resource" "say-hello" {
+  provisioner "local-exec" {
+    command = "echo 'Hello friend'"
+  }
+}
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This change introduces a `backendConfig` field on the Terraform
provider and action types.

This field allows users to dynamically set the backend config for
their Terraform stacks.

Terraform itself doesn't allow variables in the backend config
so this can be used instead to dynamically set the backend
based on e.g. the environment.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

I still need to update the docs on the Terraform provider and remove the "`sed` hack". It's also an open question whether we mark this as experimental for now. 

But I can address both in a follow up PR.
