### PR TITLE
improvement(terraform): enable streaming logs to cloud

### DIFF
--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -54,6 +54,6 @@ Do not use this command. It has no effect.
 
 ## Garden Plugins
 
-<h3 id="hadolintPlugin">The `Hadolint` plugin</h3>
+<h3 id="deprecatedPlugins">The `conftest`, `conftest-container`, `conftest-kubernetes`, `hadolint` and `octant` plugins</h3>
 
-Do not use this plugin.
+These plugins are still enabled by default in Garden 0.13, but will be removed in Garden 0.14. Do not use these plugins explicitly in Garden 0.14.

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -53,6 +53,9 @@ providers:
 
     # Use the specified Terraform workspace.
     workspace:
+
+    # Set to `true` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to `false`
+    streamLogsToCloud: false
 ```
 ## Configuration Keys
 
@@ -180,4 +183,14 @@ Use the specified Terraform workspace.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `providers[].streamLogsToCloud`
+
+[providers](#providers) > streamLogsToCloud
+
+Set to `true` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to `false`
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 

--- a/plugins/terraform/src/handlers.ts
+++ b/plugins/terraform/src/handlers.ts
@@ -62,7 +62,7 @@ export const deployTerraform: DeployActionHandler<"deploy", TerraformDeploy> = a
   const root = getModuleStackRoot(action, spec)
 
   if (spec.autoApply) {
-    await applyStack({ log, ctx, provider, root, variables: spec.variables, workspace })
+    await applyStack({ log, ctx, provider, root, variables: spec.variables, workspace, actionName: action.name })
   } else {
     const templateKey = `\${runtime.services.${action.name}.outputs.*}`
     log.warn(

--- a/plugins/terraform/src/provider.ts
+++ b/plugins/terraform/src/provider.ts
@@ -19,6 +19,7 @@ import { joi } from "@garden-io/core/build/src/config/common.js"
 export type TerraformProviderConfig = BaseProviderConfig &
   TerraformBaseSpec & {
     initRoot?: string
+    streamLogsToCloud: boolean
   }
 
 export type TerraformProvider = Provider<TerraformProviderConfig>
@@ -53,5 +54,11 @@ export const terraformProviderConfigSchema = providerConfigBaseSchema()
         The version of Terraform to use. Set to \`null\` to use whichever version of \`terraform\` that is on your PATH.
       `),
     workspace: joi.string().description("Use the specified Terraform workspace."),
+    streamLogsToCloud: joi
+      .boolean()
+      .default(false)
+      .description(
+        `Set to \`true\` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to \`false\``
+      ),
   })
   .unknown(false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commit introduces a config option to optionally stream Terraform
logs to Garden Cloud/Enterprise.

Defaults to `false` but we may reconsider in a later breaking change
release.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
