### PR TITLE
chore: deprecate rsync-based file syncing for build staging

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -181,6 +181,7 @@ import { deepEvaluate } from "./template/evaluate.js"
 import type { ResolvedTemplate } from "./template/types.js"
 import { serialiseUnresolvedTemplates } from "./template/types.js"
 import type { VariablesContext } from "./config/template-contexts/variables.js"
+import { reportDeprecatedFeatureUsage } from "./util/deprecations.js"
 
 const defaultLocalAddress = "localhost"
 
@@ -426,6 +427,13 @@ export class Garden {
 
     const legacyBuildSync =
       params.opts.legacyBuildSync === undefined ? gardenEnv.GARDEN_LEGACY_BUILD_STAGE : params.opts.legacyBuildSync
+    if (legacyBuildSync) {
+      reportDeprecatedFeatureUsage({
+        apiVersion: params.projectApiVersion,
+        log: params.log,
+        deprecation: "rsyncBuildStaging",
+      })
+    }
 
     const buildDirCls = legacyBuildSync ? BuildStagingRsync : BuildStaging
     if (legacyBuildSync) {

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -95,6 +95,12 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         link: "#updating-action-configs",
       },
     },
+    rsyncBuildStaging: {
+      contextDesc: "Build Staging",
+      featureDesc: `The ${style("legacy rsync-based file syncing")} for build staging`,
+      hint: `Do not use ${style("`GARDEN_LEGACY_BUILD_STAGE`")} environment variable in 0.14.`,
+      hintReferenceLink: null,
+    },
   } as const
 }
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -133,3 +133,9 @@ Please do not use this in Garden 0.14
 Use `dependencies` config build to define the build dependencies.
 
 For more information, please refer to the [Migration guide for action configs](#updating-action-configs).
+
+## Build Staging
+
+<h3 id="rsyncBuildStaging">The `legacy rsync-based file syncing` for build staging</h3>
+
+Do not use ``GARDEN_LEGACY_BUILD_STAGE`` environment variable in 0.14.


### PR DESCRIPTION
**What this PR does / why we need it**:

The legacy (rsync-based) file syncing mode for build staging has not been used since #6758.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
