### PR TITLE
chore(k8s): deprecate `configmap` and `persistentvolumeclaim` deploy actions

### DIFF
--- a/core/src/plugins/kubernetes/volumes/configmap.ts
+++ b/core/src/plugins/kubernetes/volumes/configmap.ts
@@ -24,6 +24,7 @@ import type { KubernetesDeployActionConfig } from "../kubernetes-type/config.js"
 import type { Resolved } from "../../../actions/types.js"
 import { makeDocsLinkPlain } from "../../../docs/common.js"
 import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl.js"
+import { reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
 
 // TODO: If we make a third one in addition to this and `persistentvolumeclaim`, we should dedupe some code.
 
@@ -59,7 +60,13 @@ export const configmapDeployDefinition = (): DeployActionDefinition<ConfigmapAct
   docs: getDocs(),
   schema: joi.object().keys(commonSpecKeys()),
   handlers: {
-    configure: async ({ config }) => {
+    configure: async ({ config, ctx, log }) => {
+      reportDeprecatedFeatureUsage({
+        apiVersion: ctx.projectApiVersion,
+        log,
+        deprecation: "configmapDeployAction",
+      })
+
       config.include = []
       return { config, supportedModes: {} }
     },

--- a/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
+++ b/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
@@ -8,7 +8,6 @@
 
 import type { V1PersistentVolumeClaim, V1PersistentVolumeClaimSpec } from "@kubernetes/client-node"
 import fsExtra from "fs-extra"
-const { readFileSync } = fsExtra
 import { memoize } from "lodash-es"
 import { join } from "path"
 import type { DeployAction, DeployActionConfig } from "../../../actions/deploy.js"
@@ -27,6 +26,9 @@ import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl.js"
 import type { KubernetesDeployActionConfig } from "../kubernetes-type/config.js"
 import { deleteKubernetesDeploy, getKubernetesDeployStatus, kubernetesDeploy } from "../kubernetes-type/handlers.js"
 import type { KubernetesResource } from "../types.js"
+import { reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
+
+const { readFileSync } = fsExtra
 
 export interface PersistentVolumeClaimDeploySpec {
   namespace?: string
@@ -81,7 +83,13 @@ export const persistentvolumeclaimDeployDefinition = (): DeployActionDefinition<
   `,
   schema: joi.object().keys(commonSpecKeys()),
   handlers: {
-    configure: async ({ config }) => {
+    configure: async ({ config, ctx, log }) => {
+      reportDeprecatedFeatureUsage({
+        apiVersion: ctx.projectApiVersion,
+        log,
+        deprecation: "persistentvolumeclaimDeployAction",
+      })
+
       // No need to scan for files
       config.include = []
 

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -40,7 +40,7 @@ function makeDeployActionTypeDeprecation(actionType: DeprecatedDeployActionType,
   return {
     contextDesc: "Garden action types",
     featureDesc: `The ${style(`${actionType} Deploy`)} action type`,
-    hint: "Do not use this deploy action type in Garden 0.14.",
+    hint: "Do not use this action in Garden 0.14.",
     hintReferenceLink: null,
   }
 }

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -34,6 +34,17 @@ function makePluginDeprecation(pluginName: DeprecatedPluginName, style: (s: stri
   }
 }
 
+export type DeprecatedDeployActionType = "configmap" | "persistentvolumeclaim"
+
+function makeDeployActionTypeDeprecation(actionType: DeprecatedDeployActionType, style: (s: string) => string) {
+  return {
+    contextDesc: "Garden action types",
+    featureDesc: `The ${style(`${actionType} Deploy`)} action type`,
+    hint: "Do not use this deploy action type in Garden 0.14.",
+    hintReferenceLink: null,
+  }
+}
+
 export function getDeprecations(style: (s: string) => string = styles.highlight) {
   return {
     containerDeploymentStrategy: {
@@ -101,6 +112,8 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       hint: `Do not use ${style("`GARDEN_LEGACY_BUILD_STAGE`")} environment variable in 0.14.`,
       hintReferenceLink: null,
     },
+    configmapDeployAction: makeDeployActionTypeDeprecation("configmap", style),
+    persistentvolumeclaimDeployAction: makeDeployActionTypeDeprecation("persistentvolumeclaim", style),
   } as const
 }
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -152,8 +152,8 @@ Do not use ``GARDEN_LEGACY_BUILD_STAGE`` environment variable in 0.14.
 
 <h3 id="configmapDeployAction">The `configmap Deploy` action type</h3>
 
-Do not use this deploy action type in Garden 0.14.
+Do not use this action in Garden 0.14.
 
 <h3 id="persistentvolumeclaimDeployAction">The `persistentvolumeclaim Deploy` action type</h3>
 
-Do not use this deploy action type in Garden 0.14.
+Do not use this action in Garden 0.14.

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -139,3 +139,13 @@ For more information, please refer to the [Migration guide for action configs](#
 <h3 id="rsyncBuildStaging">The `legacy rsync-based file syncing` for build staging</h3>
 
 Do not use ``GARDEN_LEGACY_BUILD_STAGE`` environment variable in 0.14.
+
+## Garden action types
+
+<h3 id="configmapDeployAction">The `configmap Deploy` action type</h3>
+
+Do not use this deploy action type in Garden 0.14.
+
+<h3 id="persistentvolumeclaimDeployAction">The `persistentvolumeclaim Deploy` action type</h3>
+
+Do not use this deploy action type in Garden 0.14.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

If a migration guide is necessary, it can be written in a follow-up PR. We have a project task to compose a migration guide, so the guide will not be missed.