### PR TITLE
chore: deprecate `build` config field in runtime actions

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -287,7 +287,7 @@ export const baseRuntimeActionConfigSchema = createSchema({
       )
       .meta({
         templateContext: ActionConfigContext,
-        deprecated: makeDeprecationMessage({ deprecation: "buildConfigFieldOnRuntimeActions" }),
+        deprecated: makeDeprecationMessage({ deprecation: "buildConfigFieldOnRuntimeActions", includeLink: true }),
       }),
   }),
   extend: baseActionConfigSchema,

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -713,7 +713,7 @@ export abstract class RuntimeAction<
         deline`Action ${styles.highlight(this.key())}
         of type ${styles.highlight(config.type)}
         defined in ${styles.highlight(config.internal.configFilePath || config.internal.basePath)}
-        declares deprecated config field ${styles.highlight("build")}`
+        declares deprecated config field ${styles.highlight("build")}.`
       )
       // Report general deprecation warning
       reportDeprecatedFeatureUsage({

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -24,7 +24,7 @@ import {
   unusedApiVersionSchema,
 } from "../config/common.js"
 import { DOCS_BASE_URL, GardenApiVersion } from "../constants.js"
-import { dedent, naturalList, stableStringify } from "../util/string.js"
+import { dedent, deline, naturalList, stableStringify } from "../util/string.js"
 import type { ActionVersion, ModuleVersion, TreeVersion } from "../vcs/vcs.js"
 import { getActionSourcePath, hashStrings, versionStringPrefix } from "../vcs/vcs.js"
 import type { BuildAction, ResolvedBuildAction } from "./build.js"
@@ -710,7 +710,10 @@ export abstract class RuntimeAction<
       const config = params.config
       // Report concrete action name for better UX
       log.warn(
-        `Action ${styles.highlight(config.name)} of type ${styles.highlight(`${config.kind} ${config.type}`)} declares deprecated config field ${styles.highlight("build")}`
+        deline`Action ${styles.highlight(this.key())}
+        of type ${styles.highlight(config.type)}
+        defined in ${styles.highlight(config.internal.configFilePath || config.internal.basePath)}
+        declares deprecated config field ${styles.highlight("build")}`
       )
       // Report general deprecation warning
       reportDeprecatedFeatureUsage({

--- a/core/src/docs/generate.ts
+++ b/core/src/docs/generate.ts
@@ -9,18 +9,17 @@
 import handlebars from "handlebars"
 import { dirname, resolve } from "node:path"
 import { writeCommandReferenceDocs } from "./commands.js"
-import { TEMPLATES_DIR, renderProjectConfigReference, renderConfigReference } from "./config.js"
+import { renderConfigReference, renderProjectConfigReference, TEMPLATES_DIR } from "./config.js"
 import { writeTemplateStringReferenceDocs } from "./template-strings.js"
 import { writeTableOfContents } from "./table-of-contents.js"
 import { Garden } from "../garden.js"
 import { defaultDotIgnoreFile } from "../util/fs.js"
 import { keyBy } from "lodash-es"
 import fsExtra from "fs-extra"
-const { writeFileSync, readFile, writeFile, mkdirp } = fsExtra
-import { renderModuleTypeReference, moduleTypes } from "./module-type.js"
+import { moduleTypes, renderModuleTypeReference } from "./module-type.js"
 import { renderProviderReference } from "./provider.js"
 import { defaultEnvironment, defaultNamespace } from "../config/project.js"
-import type { GardenPluginSpec, GardenPluginReference } from "../plugin/plugin.js"
+import type { GardenPluginReference, GardenPluginSpec } from "../plugin/plugin.js"
 import { workflowConfigSchema } from "../config/workflow.js"
 import { configTemplateSchema } from "../config/config-template.js"
 import { renderActionTypeReference } from "./action-type.js"
@@ -30,12 +29,14 @@ import { pMemoizeClearAll } from "../lib/p-memoize.js"
 import { makeDocsLinkOpts } from "./common.js"
 import { GardenApiVersion } from "../constants.js"
 import { actionKinds } from "../actions/types.js"
-
 import { fileURLToPath } from "node:url"
 import dedent from "dedent"
 import { getDeprecations } from "../util/deprecations.js"
 
+const { writeFileSync, readFile, writeFile, mkdirp } = fsExtra
+
 const moduleDirName = dirname(fileURLToPath(import.meta.url))
+
 /* eslint-disable no-console */
 
 export async function generateDocs(targetDir: string, getPlugins: () => (GardenPluginSpec | GardenPluginReference)[]) {
@@ -230,8 +231,9 @@ async function updateDeprecationGuide(docsRoot: string, deprecationGuideFilename
       breakingChanges.push(`<h3 id="${id}">${featureDesc}</h3>`)
       breakingChanges.push(hint)
       if (hintReferenceLink) {
+        const linkPrefix = hintReferenceLink.link.startsWith("#") ? "" : "../"
         breakingChanges.push(
-          `For more information, please refer to the [${hintReferenceLink.name}](../${hintReferenceLink.link}).`
+          `For more information, please refer to the [${hintReferenceLink.name}](${linkPrefix}${hintReferenceLink.link}).`
         )
       }
     }

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -90,7 +90,10 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       contextDesc: "Acton Configs",
       featureDesc: `The ${style("build")} config field in runtime action configs`,
       hint: `Use ${style("dependencies")} config build to define the build dependencies.`,
-      hintReferenceLink: null,
+      hintReferenceLink: {
+        name: "Migration guide for action configs",
+        link: "guides/deprecations#updating-action-configs",
+      },
     },
   } as const
 }

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -92,7 +92,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       hint: `Use ${style("dependencies")} config build to define the build dependencies.`,
       hintReferenceLink: {
         name: "Migration guide for action configs",
-        link: "guides/deprecations#updating-action-configs",
+        link: "#updating-action-configs",
       },
     },
   } as const

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -91,6 +91,12 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       hint: "These plugins are still enabled by default in Garden 0.13, but will be removed in Garden 0.14. Do not use these plugins explicitly in Garden 0.14.",
       hintReferenceLink: null,
     },
+    buildConfigFieldOnRuntimeActions: {
+      contextDesc: "Acton Configs",
+      featureDesc: `The ${style("build")} config field in runtime action configs`,
+      hint: `Use ${style("dependencies")} config build to define the build dependencies.`,
+      hintReferenceLink: null,
+    },
   } as const
 }
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -5,14 +5,18 @@ title: Deprecations and major-version updates
 
 # Deprecations and major-version updates
 
-The next major version of Garden, 0.14, will contain breaking changes. To make the update as seamless as possible for your team, avoid functionality that has been deprecated in Garden 0.13.
+The next major version of Garden, 0.14, will contain breaking changes. To make the update as seamless as possible for
+your team, avoid functionality that has been deprecated in Garden 0.13.
 
-When using `apiVersion: garden.io/v1` in your project configuration file, Garden will warn you if your configuration depends on features that will be removed in Garden 0.14.
+When using `apiVersion: garden.io/v1` in your project configuration file, Garden will warn you if your configuration
+depends on features that will be removed in Garden 0.14.
 
-**EXPERIMENTAL**: You can opt-in to the new behaviour in Garden 0.14 by using `apiVersion: garden.io/v2`. This setting will make Garden throw errors whenever it detects usage of deprecated functionality.
+**EXPERIMENTAL**: You can opt-in to the new behaviour in Garden 0.14 by using `apiVersion: garden.io/v2`. This setting
+will make Garden throw errors whenever it detects usage of deprecated functionality.
 
 {% hint style="warning" %}
-Please note that as of today, not all warnings are in place, so we are still working on the list of breaking changes. Once the list of breaking changes is final, we will make this known here.
+Please note that as of today, not all warnings are in place, so we are still working on the list of breaking changes.
+Once the list of breaking changes is final, we will make this known here.
 {% endhint %}
 
 # Breaking changes

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -19,6 +19,56 @@ Please note that as of today, not all warnings are in place, so we are still wor
 Once the list of breaking changes is final, we will make this known here.
 {% endhint %}
 
+# Migration hints
+
+## Updating action configs
+
+To get rid of the [deprecated `build`](#acton-configs) usages,
+you need to replace all root-level configuration entries like `build: my-app` with the `dependencies: [build.my-app]`.
+
+For example, a configuration like
+
+```yaml
+kind: Build
+name: backend
+description: Backend service container image
+type: container
+
+---
+kind: Deploy
+name: backend
+description: Backend service container
+type: container
+build: backend # <-- old config style uses `build` field
+
+spec:
+image: ${actions.build.backend.outputs.deploymentImageId}
+...
+```
+
+should be replaced with
+
+```yaml
+kind: Build
+name: backend
+description: Backend service container image
+type: container
+
+---
+kind: Deploy
+name: backend
+description: Backend service container
+type: container
+
+# use `dependencies` field instead of the `build`
+dependencies:
+- build.backend
+
+spec:
+image: ${actions.build.backend.outputs.deploymentImageId}
+...
+```
+
 # Breaking changes
 
 <!-- DO NOT CHANGE BELOW - AUTO-GENERATED -->
@@ -81,3 +131,5 @@ Please do not use this in Garden 0.14
 <h3 id="buildConfigFieldOnRuntimeActions">The `build` config field in runtime action configs</h3>
 
 Use `dependencies` config build to define the build dependencies.
+
+For more information, please refer to the [Migration guide for action configs](../guides/deprecations#updating-action-configs).

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -132,4 +132,4 @@ Please do not use this in Garden 0.14
 
 Use `dependencies` config build to define the build dependencies.
 
-For more information, please refer to the [Migration guide for action configs](../guides/deprecations#updating-action-configs).
+For more information, please refer to the [Migration guide for action configs](#updating-action-configs).

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -62,13 +62,6 @@ This plugin is still enabled by default in Garden 0.13, but will be removed in G
 
 This plugin is still enabled by default in Garden 0.13, but will be removed in Garden 0.14. Do not use this plugin explicitly in Garden 0.14.
 
-These plugins are still enabled by default in Garden 0.13, but will be removed in Garden 0.14. Do not use these plugins explicitly in Garden 0.14.
-
-## Acton Configs
-
-<h3 id="buildConfigFieldOnRuntimeActions">The `build` config field in runtime action configs</h3>
-
-Use `dependencies` config build to define the build dependencies.
 <h3 id="conftestPlugin">The plugin `conftest`</h3>
 
 This plugin is still enabled by default in Garden 0.13, but will be removed in Garden 0.14. Do not use this plugin explicitly in Garden 0.14.
@@ -78,3 +71,9 @@ This plugin is still enabled by default in Garden 0.13, but will be removed in G
 <h3 id="localMode">The `local mode` feature for container, kubernetes and helm deploys</h3>
 
 Please do not use this in Garden 0.14
+
+## Acton Configs
+
+<h3 id="buildConfigFieldOnRuntimeActions">The `build` config field in runtime action configs</h3>
+
+Use `dependencies` config build to define the build dependencies.

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -57,3 +57,9 @@ Do not use this command. It has no effect.
 <h3 id="deprecatedPlugins">The `conftest`, `conftest-container`, `conftest-kubernetes`, `hadolint` and `octant` plugins</h3>
 
 These plugins are still enabled by default in Garden 0.13, but will be removed in Garden 0.14. Do not use these plugins explicitly in Garden 0.14.
+
+## Acton Configs
+
+<h3 id="buildConfigFieldOnRuntimeActions">The `build` config field in runtime action configs</h3>
+
+Use `dependencies` config build to define the build dependencies.

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -248,6 +248,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -245,6 +245,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -249,6 +249,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -252,6 +252,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -251,6 +251,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -254,6 +254,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -249,6 +249,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -252,6 +252,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -256,6 +256,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -253,6 +253,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -248,6 +248,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -245,6 +245,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -251,6 +251,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -254,6 +254,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -249,6 +249,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -252,6 +252,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -248,6 +248,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -245,6 +245,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -251,6 +251,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -254,6 +254,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -250,6 +250,7 @@ Whether the varfile is optional.
 {% hint style="warning" %}
 **Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
 Use `dependencies` config build to define the build dependencies.
+To make sure your configuration does not break when we release Garden 0.14, please follow the steps at https://docs.garden.io/guides/deprecations#buildConfigFieldOnRuntimeActions
 {% endhint %}
 
 Specify a _Build_ action, and resolve this action from the context of that Build.

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -247,6 +247,11 @@ Whether the varfile is optional.
 
 ### `build`
 
+{% hint style="warning" %}
+**Deprecated**: The `build` config field in runtime action configs is deprecated in 0.13 and will be removed in the next major release, Garden 0.14.
+Use `dependencies` config build to define the build dependencies.
+{% endhint %}
+
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2094,15 +2094,6 @@ actionConfigs:
       # The spec for the specific action type.
       spec:
 
-      # Specify a _Build_ action, and resolve this action from the context of that Build.
-      #
-      # For example, you might create an `exec` Build which prepares some manifests, and then reference that in a
-      # `kubernetes` _Deploy_ action, and the resulting manifests from the Build.
-      #
-      # This would mean that instead of looking for manifest files relative to this action's location in your project
-      # structure, the output directory for the referenced `exec` Build would be the source.
-      build:
-
       kind:
 
       # Timeout for the deploy to complete, in seconds.
@@ -2249,15 +2240,6 @@ actionConfigs:
       # The spec for the specific action type.
       spec:
 
-      # Specify a _Build_ action, and resolve this action from the context of that Build.
-      #
-      # For example, you might create an `exec` Build which prepares some manifests, and then reference that in a
-      # `kubernetes` _Deploy_ action, and the resulting manifests from the Build.
-      #
-      # This would mean that instead of looking for manifest files relative to this action's location in your project
-      # structure, the output directory for the referenced `exec` Build would be the source.
-      build:
-
       kind:
 
       # Set a timeout for the run to complete, in seconds.
@@ -2403,15 +2385,6 @@ actionConfigs:
 
       # The spec for the specific action type.
       spec:
-
-      # Specify a _Build_ action, and resolve this action from the context of that Build.
-      #
-      # For example, you might create an `exec` Build which prepares some manifests, and then reference that in a
-      # `kubernetes` _Deploy_ action, and the resulting manifests from the Build.
-      #
-      # This would mean that instead of looking for manifest files relative to this action's location in your project
-      # structure, the output directory for the referenced `exec` Build would be the source.
-      build:
 
       kind:
 

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -191,6 +191,16 @@ Use the specified Terraform workspace.
 | -------- | -------- |
 | `string` | No       |
 
+### `providers[].streamLogsToCloud`
+
+[providers](#providers) > streamLogsToCloud
+
+Set to `true` to make logs from Terraform Deploy actions visible in Garden Cloud/Enterprise. Defaults to `false`
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
 ### `providers[].backendConfig`
 
 [providers](#providers) > backendConfig


### PR DESCRIPTION
**What this PR does / why we need it**:

The `build` config field is not recommended to use since #5700 and #6207.
This PR officially deprecates that config field.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
