### PR TITLE
chore(sync-mode): use new machinery for `sync start` deprecation

### DIFF
--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -20,7 +20,7 @@ import { createActionLog } from "../../logger/log-entry.js"
 import type { DeployAction } from "../../actions/deploy.js"
 import type { ConfigGraph } from "../../graph/config-graph.js"
 import type { Garden } from "../../index.js"
-import { styles } from "../../logger/styles.js"
+import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 
 const syncStartArgs = {
   names: new StringsParameter({
@@ -97,14 +97,11 @@ export class SyncStartCommand extends Command<Args, Opts> {
     const { garden, log, args, opts } = params
 
     if (!params.parentCommand) {
-      log.warn(
-        dedent`Behaviour of ${styles.command(
-          "sync start"
-        )} is now deprecated and will be changed in a future breaking change release.
-        Instead we recommend running ${styles.command("garden deploy --sync")} or starting syncs ${styles.italic(
-          "inside"
-        )} the dev console with either ${styles.command("deploy --sync")} or ${styles.command("sync start")}.`
-      )
+      reportDeprecatedFeatureUsage({
+        apiVersion: garden.projectApiVersion,
+        log,
+        deprecation: "syncStartCommand",
+      })
     }
 
     // We default to starting syncs for all Deploy actions

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -77,6 +77,16 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       hint: "Do not use this command. It has no effect.",
       hintReferenceLink: null,
     },
+    syncStartCommand: {
+      contextDesc: "Sync mode",
+      featureDesc: `The ${style("sync-start")} command.`,
+      hint: dedent`Behaviour of ${style(
+        "sync start"
+      )} is now deprecated and will be changed in a future breaking change release.
+        Instead, we recommend running ${style("garden deploy --sync")} or starting syncs inside the dev console
+        with either ${style("deploy --sync")} or ${style("sync start")}.`,
+      hintReferenceLink: null,
+    },
     hadolintPlugin: makePluginDeprecation("hadolint", style),
     octantPlugin: makePluginDeprecation("octant", style),
     conftestPlugin: makePluginDeprecation("conftest", style),

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -72,7 +72,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       },
     },
     kubernetesClusterInitCommand: {
-      contextDesc: "Garden Commands",
+      contextDesc: "Garden commands",
       featureDesc: `The Kubernetes plugin command ${style("cluster-init")}`,
       hint: "Do not use this command. It has no effect.",
       hintReferenceLink: null,
@@ -97,7 +97,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       hintReferenceLink: null,
     },
     buildConfigFieldOnRuntimeActions: {
-      contextDesc: "Acton Configs",
+      contextDesc: "Acton configs",
       featureDesc: `The ${style("build")} config field in runtime action configs`,
       hint: `Use ${style("dependencies")} config build to define the build dependencies.`,
       hintReferenceLink: {

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -100,7 +100,7 @@ Please use the `scan` field instead.
 
 For more information, please refer to the [`scan` reference documentation](../reference/project-config.md#scan).
 
-## Garden Commands
+## Garden commands
 
 <h3 id="kubernetesClusterInitCommand">The Kubernetes plugin command `cluster-init`</h3>
 
@@ -134,7 +134,7 @@ This plugin is still enabled by default in Garden 0.13, but will be removed in G
 
 Please do not use this in Garden 0.14
 
-## Acton Configs
+## Acton configs
 
 <h3 id="buildConfigFieldOnRuntimeActions">The `build` config field in runtime action configs</h3>
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -106,6 +106,14 @@ For more information, please refer to the [`scan` reference documentation](../re
 
 Do not use this command. It has no effect.
 
+## Sync mode
+
+<h3 id="syncStartCommand">The `sync-start` command.</h3>
+
+Behaviour of `sync start` is now deprecated and will be changed in a future breaking change release.
+Instead, we recommend running `garden deploy --sync` or starting syncs inside the dev console
+with either `deploy --sync` or `sync start`.
+
 ## Garden Plugins
 
 <h3 id="hadolintPlugin">The plugin `hadolint`</h3>


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-work #5747 to use the new deprecation machinery introduced in #6820 and #6823.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
