### PR TITLE
fix(logger): fix alignment for empty lines msg has section

### DIFF
--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -121,7 +121,9 @@ export function renderMsg(entry: LogEntry): string {
 
   const origin = context.origin ? `[${styles.italic(context.origin)}] ` : ""
 
-  return style(`${logLevelName}${origin}${msg}`)
+  const fullMsg = `${logLevelName}${origin}${msg}`
+
+  return fullMsg ? style(fullMsg) : ""
 }
 
 export function renderData(entry: LogEntry): string {
@@ -137,7 +139,7 @@ export function renderData(entry: LogEntry): string {
 }
 
 export function renderSection(entry: LogEntry): string {
-  const { msg } = entry
+  const msg = renderMsg(entry)
   const section = getSection(entry)
 
   if (section && msg) {


### PR DESCRIPTION
Before this fix, empty messages from origins such as Kubernetes or Terraform would be misaligned. This fixes that.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
