### PR TITLE
fix: dependency error message rendering

### DIFF
--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -36,6 +36,7 @@ import {
 } from "../events/util.js"
 import { styles } from "../logger/styles.js"
 import type { ActionRuntime } from "../plugin/base.js"
+import { deline } from "../util/string.js"
 
 export function makeBaseKey(type: string, name: string) {
   return `${type}.${name}`
@@ -282,8 +283,10 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
         if (disabled && action.kind !== "Build") {
           // TODO-0.13.1: Need to handle conditional references, over in dependenciesFromAction()
           throw new GraphError({
-            message: `${this.action.longDescription()} depends on one or more runtime outputs from action
-             ${action.key}, which is disabled. Please either remove the reference or enable the action.`,
+            message: deline`
+            ${this.action.longDescription()} depends on one or more runtime outputs from action
+             ${styles.highlight(action.key())}, which is disabled.
+             Please either remove the reference or enable the action.`,
           })
         }
         return [this.getExecuteTask(action)]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the case when an action depends on runtime outputs of a disabled action.

Error rendering example before fix:
```console
Run type=exec name=run-task depends on one or more runtime outputs from action
             key() {
        return actionReferenceToString(this);
    }, which is disabled. Please either remove the reference or enable the action.
```

Error rendering example after fix:
```console
Run type=exec name=run-task depends on one or more runtime outputs from action deploy.tf-production, which is disabled. Please either remove the reference or enable the action.
```

The `action.key` function was not called in the error message, so it was rendered as a part of the code. Now it's fixed.
This PR also fixes some action name highlighting and removes unnecessary newline breaks from the error message.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
