### PR TITLE
fix(template): partially resolve template strings while action config preprocessing

### DIFF
--- a/core/src/config/template-contexts/actions.ts
+++ b/core/src/config/template-contexts/actions.ts
@@ -76,6 +76,8 @@ export class ActionConfigContext extends TemplatableConfigContext {
   }
 }
 
+export const actionConfigContextKeys = Object.freeze(Object.keys(ActionConfigContext.getSchema().describe()["keys"]))
+
 interface ActionReferenceContextParams {
   name: string
   disabled: boolean

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -757,27 +757,26 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
       context: builtinFieldContext,
       opts: {},
     })
+    config = { ...config, ...resolvedBuiltin }
+
     const { spec = {} } = config
 
-    config = {
-      ...config,
-      // Validate fully resolved keys (the above + those that don't allow any templating)
-      ...validateWithPath({
-        config: {
-          ...resolvedBuiltin,
-          variables: {},
-          spec: {},
-        },
-        schema: getActionSchema(config.kind),
-        configType: describeActionConfig(config),
-        name: config.name,
-        path: config.internal.basePath,
-        projectRoot: garden.projectRoot,
-        source: { yamlDoc: config.internal.yamlDoc, path: [] },
-      }),
-      spec,
-      variables: config.variables,
-    }
+    // Validate fully resolved keys (the above + those that don't allow any templating)
+    config = validateWithPath({
+      config: {
+        ...config,
+        variables: {},
+        spec: {},
+      },
+      schema: getActionSchema(config.kind),
+      configType: describeActionConfig(config),
+      name: config.name,
+      path: config.internal.basePath,
+      projectRoot: garden.projectRoot,
+      source: { yamlDoc: config.internal.yamlDoc, path: [] },
+    })
+
+    config = { ...config, variables: config.variables, spec }
   }
 
   resolveTemplates()

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -777,6 +777,15 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
     })
 
     config = { ...config, variables: config.variables, spec }
+
+    // Partially resolve other fields
+    // @ts-expect-error todo: correct types for unresolved configs
+    const resolvedOther = deepEvaluate(omit(config, builtinConfigKeys), {
+      context: builtinFieldContext,
+      opts: { isFinalContext: false },
+    })
+    // @ts-expect-error todo: correct types for unresolved configs
+    config = { ...config, ...resolvedOther }
   }
 
   resolveTemplates()

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -64,7 +64,7 @@ import { getSourcePath } from "../vcs/vcs.js"
 import { styles } from "../logger/styles.js"
 import { isUnresolvableValue, someReferences } from "../template/analysis.js"
 import { getActionTemplateReferences } from "../config/references.js"
-import { conditionallyDeepEvaluate, deepEvaluate } from "../template/evaluate.js"
+import { conditionallyDeepEvaluateSafe, deepEvaluate } from "../template/evaluate.js"
 import type { UnresolvedTemplateValue } from "../template/types.js"
 import { type ParsedTemplate } from "../template/types.js"
 import { validateWithPath } from "../config/validation.js"
@@ -811,7 +811,7 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
 
     // Partially resolve other fields
     const skipPossiblyNonResolvableKeysCondition = getSkipPossiblyNonResolvableKeysCondition(builtinFieldContext)
-    const resolvedOther = conditionallyDeepEvaluate(
+    const resolvedOther = conditionallyDeepEvaluateSafe(
       // @ts-expect-error todo: correct types for unresolved configs
       omit(config, builtinConfigKeys),
       {

--- a/core/src/template/evaluate.ts
+++ b/core/src/template/evaluate.ts
@@ -46,6 +46,27 @@ export function conditionallyDeepEvaluate(
   })
 }
 
+export function conditionallyDeepEvaluateSafe(
+  collection: ParsedTemplate,
+  args: EvaluateTemplateArgs,
+  condition: (v: UnresolvedTemplateValue) => boolean
+): ParsedTemplate {
+  return deepMap(collection, (v) => {
+    if (v instanceof UnresolvedTemplateValue && condition(v)) {
+      try {
+        const evaluated = evaluate(v, args)
+        if (evaluated.partial) {
+          return conditionallyDeepEvaluateSafe(evaluated.resolved, args, condition)
+        }
+        return evaluated.resolved
+      } catch (_) {
+        return v
+      }
+    }
+    return v
+  })
+}
+
 export function evaluate(value: ParsedTemplate, args: EvaluateTemplateArgs): TemplateEvaluationResult {
   if (value instanceof UnresolvedTemplateValue) {
     return value.evaluate(args)


### PR DESCRIPTION
**What this PR does / why we need it**:

Restores [partial action config resolution](https://github.com/garden-io/garden/commit/c968c616#diff-87efeddad61156c502b8d97ff8a0666e31a9419dbf108b2792fc44f5dbde3946L840-L851) from 0.13.52 which was removed in #6745.

The action config can contain some if/else/then structural operators, or other conditions.

We need to evaluate such conditions here if possible, otherwise the dependency detection may bring false-positive results.

<details>
<summary>Click to see reproducible example</summary>

```yml
apiVersion: garden.io/v1
kind: Project
name: structural-operators
defaultEnvironment: development

environments:
  - name: development
  - name: production

providers:
  - name: exec
    environments: [ development, production ]
  - name: terraform
    environments: [ development, production ]

---
kind: Run
name: run-task
type: exec
environments:
  - production
  - development
#dependencies:
#  $if: ${environment.name == 'production'}
#  $then:
#    - deploy.tf-production
spec:
  $if: ${environment.name != 'production'}
  $then:
    command: [ "sh", "-c", "echo 'Hello from garden-remote in development'" ]
  $else:
    # this should not be evaluated if the branch condition is false,
   # and sould not be considered as dependency
    command: [ "sh", "-c", "echo '${runtime.services.tf-production.outputs.welcome_message}'" ]

---
kind: Deploy
type: terraform
name: tf-production
environments:
  - production
spec:
  root: .

```

</details>

**Which issue(s) this PR fixes**:

Fixes regression introduced in #6745. 

**Special notes for your reviewer**:
