### PR TITLE
fix(dev): fix unresolved templates in cmd results

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -54,7 +54,7 @@ import type {
   ResolvedAction,
   ResolvedActionWrapperParams,
 } from "./types.js"
-import { actionKinds, actionStateTypes } from "./types.js"
+import { actionKinds, actionStates } from "./types.js"
 import { baseInternalFieldsSchema, varfileDescription } from "../config/base.js"
 import type { DeployAction } from "./deploy.js"
 import type { TestAction } from "./test.js"
@@ -298,7 +298,7 @@ export const actionStatusSchema = createSchema({
   keys: () => ({
     state: joi
       .string()
-      .allow(...actionStateTypes)
+      .allow(...actionStates)
       .only()
       .required()
       .description("The state of the action."),

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -112,8 +112,8 @@ export interface ActionConfigTypes {
  *
  * See https://melvingeorge.me/blog/convert-array-into-string-literal-union-type-typescript
  */
-export const actionStateTypes = ["ready", "not-ready", "processing", "failed", "unknown"] as const
-export type ActionState = (typeof actionStateTypes)[number]
+export const actionStates = ["ready", "not-ready", "processing", "failed", "unknown"] as const
+export type ActionState = (typeof actionStates)[number]
 
 export interface ActionStatus<
   T extends BaseAction = BaseAction,

--- a/core/src/commands/get/get-actions.ts
+++ b/core/src/commands/get/get-actions.ts
@@ -8,7 +8,7 @@
 
 import { getActionState, getRelativeActionConfigPath } from "../../actions/helpers.js"
 import type { ActionKind, ActionState, ResolvedAction } from "../../actions/types.js"
-import { actionKinds, actionStateTypes } from "../../actions/types.js"
+import { actionKinds, actionStates } from "../../actions/types.js"
 import { BooleanParameter, ChoicesParameter, StringsParameter } from "../../cli/params.js"
 import { createSchema, joi, joiArray } from "../../config/common.js"
 import { printHeader } from "../../logger/util.js"
@@ -50,7 +50,7 @@ export const getActionsCmdOutputSchema = createSchema({
     type: joi.string().required().description(`Action Type (e.g. 'container').`),
     state: joi
       .string()
-      .allow(...actionStateTypes)
+      .allow(...actionStates)
       .only()
       .description("The state of the action."),
     path: joi.string().description("The relative path of the action config file."),

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -186,6 +186,7 @@ export class ServeCommand<
             const distroName = getCloudDistributionName(defaultGarden.cloudDomain)
             const livePageUrl = cloudApi.getLivePageUrl({ shortId: session.shortId }).toString()
             const msg = dedent`\n${printEmoji("🌸", log)}Connected to ${distroName} ${printEmoji("🌸", log)}
+
               Follow the link below to stream logs, run commands, and more from the Garden dashboard ${printEmoji(
                 "👇",
                 log

--- a/core/src/events/action-status-events.ts
+++ b/core/src/events/action-status-events.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { actionStateTypes } from "../actions/types.js"
+import { actionStates } from "../actions/types.js"
 import type { BuildState } from "../plugin/handlers/Build/get-status.js"
 import type { ActionRuntime, RunState } from "../plugin/plugin.js"
 import type { DeployState } from "../types/service.js"
@@ -18,7 +18,7 @@ export type ActionStatusDetailedState = DeployState | BuildState | RunState
  * These are the states emitted in status events. Here, we include additional states to help distinguish status event
  * emitted around status/cache checks VS statuses emitted around the execution after a failed status check.
  */
-const actionStateTypesForEvent = [...actionStateTypes, "getting-status", "cached"] as const
+const actionStateTypesForEvent = [...actionStates, "getting-status", "cached"] as const
 /**
  * This type represents the lifecycle of an individual action execution as emitted to Cloud. Note that the
  * internal semantics are slightly different (e.g. Garden uses "ready" instead of "cached" internally).

--- a/core/src/plugin/base.ts
+++ b/core/src/plugin/base.ts
@@ -182,14 +182,15 @@ export const artifactsPathSchema = memoize(() =>
   joi.string().required().description("A directory path where the handler should write any exported artifacts to.")
 )
 
-export type RunState = "outdated" | "unknown" | "running" | "succeeded" | "failed" | "not-implemented"
+export const runStates = ["outdated", "unknown", "running", "succeeded", "failed", "not-implemented"] as const
+export type RunState = (typeof runStates)[number]
 
 export interface RunStatusForEventPayload {
   state: RunState
 }
 
 export const outputSchemaDocs = dedent`
-  The schema must be a single level object, with string keys. Each value must be a primitive (null, boolean, number or string).
+  The schema must be a single level object, with string keys. Each vaue must be a primitive (null, boolean, number or string).
 
   If no schema is provided, an error may be thrown if a plugin handler attempts to return an output key.
 

--- a/core/src/plugin/handlers/Build/get-status.ts
+++ b/core/src/plugin/handlers/Build/get-status.ts
@@ -21,7 +21,8 @@ import type { ActionStatus, ActionStatusMap, Resolved } from "../../../actions/t
  * - `built`: The build was completed successfully.
  * - `failed`: An error occurred while fetching or building.
  */
-export type BuildState = "fetching" | "fetched" | "outdated" | "building" | "built" | "failed" | "unknown"
+export const buildStates = ["fetching", "fetched", "outdated", "building", "built", "failed", "unknown"] as const
+export type BuildState = (typeof buildStates)[number]
 
 export interface BuildStatusForEventPayload {
   state: BuildState

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -380,7 +380,6 @@ export class GardenServer extends EventEmitter {
           parentSessionId: this.sessionId,
         })
         this.debugLog.debug(`Command '${command.name}' completed successfully`)
-
         ctx.response.body = sanitizeValue(result)
       } catch (error) {
         // Return 200 with errors attached, since commands can legitimately fail (e.g. tests erroring etc.)
@@ -706,7 +705,9 @@ export class GardenServer extends EventEmitter {
           })
           // Here we handle the actual command result.
           .then((commandResult) => {
-            const { result, errors } = commandResult
+            const errors = commandResult.errors
+            // TODO-DODDI-0.14: Remove this line once we've removed graphResults from ProcessCommandResult.
+            const result = omit(commandResult.result, "graphResults")
             send(
               "commandResult",
               sanitizeValue({

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -233,7 +233,7 @@ export class GardenServer extends EventEmitter {
         }
       } while (!serverStarted)
     }
-    this.log.info(`Garden server has successfully started at port ${styles.highlight(this.port.toString())}\n`)
+    this.log.info(`Garden server has successfully started at port ${styles.highlight(this.port.toString())}`)
 
     const processRecord = await this.globalConfigStore.get("activeProcesses", String(process.pid))
 

--- a/core/src/util/ink-divider.tsx
+++ b/core/src/util/ink-divider.tsx
@@ -44,7 +44,15 @@ const getNumberOfCharsPerWidth = (char, width) => width / stringWidth(char)
 const PAD = " "
 
 // Divider
-const Divider = ({ title, width, padding, titlePadding, titleColor, dividerChar, dividerColor }) => {
+const Divider = ({
+  title,
+  width = 50,
+  padding = 1,
+  titlePadding = 1,
+  titleColor = "white",
+  dividerChar = "─",
+  dividerColor = "grey",
+}) => {
   const titleString = title ? `${PAD.repeat(titlePadding) + title + PAD.repeat(titlePadding)}` : ""
   const titleWidth = stringWidth(titleString)
 
@@ -75,16 +83,6 @@ Divider.propTypes = {
   titleColor: PropTypes.string,
   dividerChar: PropTypes.string,
   dividerColor: PropTypes.string,
-}
-
-Divider.defaultProps = {
-  title: null,
-  width: 50,
-  padding: 1,
-  titlePadding: 1,
-  titleColor: "white",
-  dividerChar: "─",
-  dividerColor: "grey",
 }
 
 export default Divider

--- a/core/src/util/logging.ts
+++ b/core/src/util/logging.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { isArray, isPlainObject, isString, mapValues } from "lodash-es"
+import { isArray, isPlainObject, isString, mapValues, omit } from "lodash-es"
 import stripAnsi from "strip-ansi"
 import { isPrimitive } from "../config/common.js"
 import { deepFilter } from "./objects.js"
@@ -22,6 +22,11 @@ export function sanitizeValue(value: any, _parents?: WeakSet<any>): any {
     throw new InternalError({
       message: "`toSanitizedValue` is not allowed to call `sanitizeValue` because that can cause infinite recursion.",
     })
+  }
+
+  // TODO-DODDI-0.14: Remove this line once we've removed graphResults from ProcessCommandResult.
+  if (isPlainObject(value) && "graphResults" in value) {
+    value = omit(value, "graphResults")
   }
 
   if (!_parents) {


### PR DESCRIPTION
**What this PR does / why we need it**:

We were including the raw graph results in the results of commands requested over HTTP from the live page. This was always unnecessary (and the data structures involved were excessively large), but only started resulting in errors with our recent templating improvements (previously, we'd just leave the unresolved template strings in there).

**Which issue(s) this PR fixes**:

Fixes live-mode commands run from the Cloud UI to fail under certain conditions.