### PR TITLE
fix: do not consider implicit dependencies from action references in dead code branches

### DIFF
--- a/core/src/config/provider.ts
+++ b/core/src/config/provider.ts
@@ -29,7 +29,7 @@ import type { ActionState } from "../actions/types.js"
 import type { ValidResultType } from "../tasks/base.js"
 import { uuidv4 } from "../util/random.js"
 import { s } from "./zod.js"
-import { getContextLookupReferences, visitAll } from "../template/analysis.js"
+import { defaultVisitorOpts, getContextLookupReferences, visitAll } from "../template/analysis.js"
 import type { ConfigContext } from "./template-contexts/base.js"
 import type { UnresolvedProviderConfig } from "./project.js"
 
@@ -184,6 +184,7 @@ export function getProviderTemplateReferences(config: UnresolvedProviderConfig, 
   const generator = getContextLookupReferences(
     visitAll({
       value: config.unresolvedConfig,
+      opts: defaultVisitorOpts,
     }),
     context,
     {}

--- a/core/src/config/references.ts
+++ b/core/src/config/references.ts
@@ -8,6 +8,7 @@
 
 import isString from "lodash-es/isString.js"
 import {
+  defaultVisitorOpts,
   getContextLookupReferences,
   isUnresolvableValue,
   visitAll,
@@ -167,6 +168,7 @@ export function* getActionTemplateReferences(
   const generator = getContextLookupReferences(
     visitAll({
       value: config as ObjectWithName,
+      opts: defaultVisitorOpts,
     }),
     context,
     {}
@@ -190,6 +192,7 @@ export function getModuleTemplateReferences(config: ModuleConfig, context: Modul
   const generator = getContextLookupReferences(
     visitAll({
       value: config as ObjectWithName,
+      opts: defaultVisitorOpts,
     }),
     context,
     {}

--- a/core/src/config/secrets.ts
+++ b/core/src/config/secrets.ts
@@ -8,7 +8,7 @@
 
 import isString from "lodash-es/isString.js"
 import type { Log } from "../logger/log-entry.js"
-import { getContextLookupReferences, visitAll } from "../template/analysis.js"
+import { defaultVisitorOpts, getContextLookupReferences, visitAll } from "../template/analysis.js"
 import { dedent, deline } from "../util/string.js"
 import type { ObjectWithName } from "../util/util.js"
 import type { StringMap } from "./common.js"
@@ -123,6 +123,7 @@ export function detectMissingSecretKeys({
   const generator = getContextLookupReferences(
     visitAll({
       value: obj,
+      opts: defaultVisitorOpts,
     }),
     context,
     {}

--- a/core/src/outputs.ts
+++ b/core/src/outputs.ts
@@ -12,7 +12,7 @@ import type { Log } from "./logger/log-entry.js"
 import type { OutputSpec } from "./config/project.js"
 import type { ActionReference } from "./config/common.js"
 import { GraphResults } from "./graph/results.js"
-import { getContextLookupReferences, visitAll } from "./template/analysis.js"
+import { defaultVisitorOpts, getContextLookupReferences, visitAll } from "./template/analysis.js"
 import { isString } from "lodash-es"
 import type { ObjectWithName } from "./util/util.js"
 import { extractActionReference, extractRuntimeReference } from "./config/references.js"
@@ -35,6 +35,7 @@ export async function resolveProjectOutputs(garden: Garden, log: Log): Promise<O
   const generator = getContextLookupReferences(
     visitAll({
       value: garden.rawOutputs as ObjectWithName[],
+      opts: defaultVisitorOpts,
     }),
     new OutputConfigContext({
       garden,

--- a/core/src/template/ast.ts
+++ b/core/src/template/ast.ts
@@ -18,7 +18,6 @@ import { type ConfigSource, validateSchema } from "../config/validation.js"
 import type { Branch } from "./analysis.js"
 import { TemplateStringError } from "./errors.js"
 import { styles } from "../logger/styles.js"
-import { r } from "tar"
 
 type ASTEvaluateArgs = EvaluateTemplateArgs & {
   yamlSource: ConfigSource

--- a/core/src/template/capture.ts
+++ b/core/src/template/capture.ts
@@ -11,7 +11,6 @@ import { LayeredContext } from "../config/template-contexts/base.js"
 import type { Collection } from "../util/objects.js"
 import { deepMap } from "../util/objects.js"
 import type { VisitorOpts } from "./analysis.js"
-import { visitAll, type VisitorFindingGenerator } from "./analysis.js"
 import { evaluate } from "./evaluate.js"
 import type {
   EvaluateTemplateArgs,

--- a/core/src/template/capture.ts
+++ b/core/src/template/capture.ts
@@ -10,7 +10,8 @@ import type { ConfigContext, ContextResolveOpts } from "../config/template-conte
 import { LayeredContext } from "../config/template-contexts/base.js"
 import type { Collection } from "../util/objects.js"
 import { deepMap } from "../util/objects.js"
-import { visitAll, type TemplateExpressionGenerator } from "./analysis.js"
+import type { VisitorOpts } from "./analysis.js"
+import { visitAll, type VisitorFindingGenerator } from "./analysis.js"
 import { evaluate } from "./evaluate.js"
 import type {
   EvaluateTemplateArgs,
@@ -77,13 +78,12 @@ export class CapturedContextTemplateValue extends UnresolvedTemplateValue {
     })
   }
 
-  override *visitAll({ onlyEssential = false }): TemplateExpressionGenerator {
-    if (this.wrapped instanceof UnresolvedTemplateValue) {
-      this.wrapped.visitAll({ onlyEssential })
-    } else if (!onlyEssential) {
-      // wrapped is either a primitive or a collection.
-      // Thus, we only visit all if onlyEssential is false.
-      yield* visitAll({ value: this.wrapped })
+  override getChildren(opts: VisitorOpts): ParsedTemplate[] {
+    if (opts.onlyEssential && !(this.wrapped instanceof UnresolvedTemplateValue)) {
+      // if wrapped is UnresolvedTemplateValue, it's essential - if it is a collection, it's not
+      return []
     }
+
+    return [this.wrapped]
   }
 }

--- a/core/src/template/lazy-merge.ts
+++ b/core/src/template/lazy-merge.ts
@@ -7,7 +7,8 @@
  */
 
 import { deepMap, isArray, type CollectionOrValue } from "../util/objects.js"
-import { visitAll, type TemplateExpressionGenerator } from "./analysis.js"
+import type { VisitorOpts } from "./analysis.js"
+import { visitAll, type VisitorFindingGenerator } from "./analysis.js"
 import { evaluate } from "./evaluate.js"
 import type { EvaluateTemplateArgs, ParsedTemplate, TemplateEvaluationResult, TemplatePrimitive } from "./types.js"
 import { isTemplatePrimitive, UnresolvedTemplateValue } from "./types.js"
@@ -74,7 +75,7 @@ export class LazyMergePatch extends UnresolvedTemplateValue {
     return deepMap(this.items, (v) => (v instanceof UnresolvedTemplateValue ? v.toJSON() : v))
   }
 
-  public override *visitAll(): TemplateExpressionGenerator {
-    yield* visitAll({ value: this.items })
+  public override getChildren(): ParsedTemplate[] {
+    return this.items
   }
 }

--- a/core/src/template/lazy-merge.ts
+++ b/core/src/template/lazy-merge.ts
@@ -7,8 +7,6 @@
  */
 
 import { deepMap, isArray, type CollectionOrValue } from "../util/objects.js"
-import type { VisitorOpts } from "./analysis.js"
-import { visitAll, type VisitorFindingGenerator } from "./analysis.js"
 import { evaluate } from "./evaluate.js"
 import type { EvaluateTemplateArgs, ParsedTemplate, TemplateEvaluationResult, TemplatePrimitive } from "./types.js"
 import { isTemplatePrimitive, UnresolvedTemplateValue } from "./types.js"

--- a/core/src/template/types.ts
+++ b/core/src/template/types.ts
@@ -11,7 +11,7 @@ import { isPrimitive } from "utility-types"
 import type { Collection, CollectionOrValue } from "../util/objects.js"
 import { deepMap } from "../util/objects.js"
 import type { ConfigContext, ContextResolveOpts } from "../config/template-contexts/base.js"
-import type { TemplateExpressionGenerator } from "./analysis.js"
+import type { Branch, VisitorOpts } from "./analysis.js"
 import { InternalError } from "../exceptions.js"
 
 export function isTemplatePrimitive(value: unknown): value is TemplatePrimitive {
@@ -103,9 +103,15 @@ export abstract class UnresolvedTemplateValue {
     })
   }
 
+  public isBranch(): this is Branch<ParsedTemplate> {
+    return false
+  }
+
   public abstract evaluate(args: EvaluateTemplateArgs): TemplateEvaluationResult
 
   public abstract toJSON(): CollectionOrValue<TemplatePrimitive>
+
+  public abstract getChildren(opts: VisitorOpts): ParsedTemplate[]
 
   /**
    * @see sanitizeValue
@@ -113,19 +119,6 @@ export abstract class UnresolvedTemplateValue {
   public toSanitizedValue() {
     return this.toJSON()
   }
-
-  public abstract visitAll(opts: {
-    /**
-     * If true, the returned template expression generator will only yield template expressions that
-     * will be evaluated when calling `evaluate`.
-     *
-     * If `evaluate` returns `partial: true`, and `onlyEssential` is set to true, then the unresolved
-     * expressions returned by evaluate will not be emitted by the returned generator.
-     *
-     * @default false
-     */
-    onlyEssential?: boolean
-  }): TemplateExpressionGenerator
 
   public toString(): string {
     return `UnresolvedTemplateValue(${this.constructor.name})`

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -31,6 +31,7 @@ import { TestContext } from "./config/template-contexts/base.js"
 import type { Collection } from "../../../src/util/objects.js"
 import type { ParsedTemplate } from "../../../src/template/types.js"
 import type { ConfigContext } from "../../../src/config/template-contexts/base.js"
+import { expression } from "@hapi/joi"
 
 describe("template string access protection", () => {
   it("should crash when an unresolved value is accidentally treated as resolved", () => {
@@ -2804,13 +2805,14 @@ describe("getContextLookupReferences", () => {
   }
 
   const branchTestCases = [
+    // logical OR
     {
-      name: "logicalOrTrue",
+      name: "logical OR - true",
       expression: "${true || unreachable}",
       expectedReferences: [],
     },
     {
-      name: "logicalOrFalse",
+      name: "logical OR - false",
       expression: "${false || reachable}",
       expectedReferences: [
         {
@@ -2819,7 +2821,7 @@ describe("getContextLookupReferences", () => {
       ],
     },
     {
-      name: "logicalOrDoesNotExist",
+      name: "logical OR - failed lookup",
       expression: "${doesNotExist || reachable}",
       expectedReferences: [
         {
@@ -2830,13 +2832,15 @@ describe("getContextLookupReferences", () => {
         },
       ],
     },
+
+    // logical AND
     {
-      name: "logicalAndFalse",
+      name: "logical AND - false",
       expression: "${false && unreachable}",
       expectedReferences: [],
     },
     {
-      name: "logicalAndTrue",
+      name: "logical AND - true",
       expression: "${true && reachable}",
       expectedReferences: [
         {
@@ -2845,11 +2849,43 @@ describe("getContextLookupReferences", () => {
       ],
     },
     {
-      name: "logicalAndDoesNotExist",
+      name: "logical AND - failed lookup",
       expression: "${doesNotExist && unreachable}",
       expectedReferences: [
         {
           keyPath: ["doesNotExist"],
+        },
+      ],
+    },
+
+    // ternary expression
+    {
+      name: "ternary expression - true",
+      expression: "${ true ? reachableConsequent : unreachableAlternate }",
+      expectedReferences: [
+        {
+          keyPath: ["reachableConsequent"],
+        },
+      ],
+    },
+    {
+      name: "ternary expression - false",
+      expression: "${ false ? unreachableConsequent : reachableAlternate }",
+      expectedReferences: [
+        {
+          keyPath: ["reachableAlternate"],
+        },
+      ],
+    },
+    {
+      name: "ternary expression - failed lookup",
+      expression: "${ doesNotExist ? unreachableConsequent : reachableAlternate }",
+      expectedReferences: [
+        {
+          keyPath: ["doesNotExist"],
+        },
+        {
+          keyPath: ["reachableAlternate"],
         },
       ],
     },

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -31,7 +31,6 @@ import { TestContext } from "./config/template-contexts/base.js"
 import type { Collection } from "../../../src/util/objects.js"
 import type { ParsedTemplate } from "../../../src/template/types.js"
 import type { ConfigContext } from "../../../src/config/template-contexts/base.js"
-import { expression } from "@hapi/joi"
 
 describe("template string access protection", () => {
   it("should crash when an unresolved value is accidentally treated as resolved", () => {
@@ -2930,6 +2929,62 @@ describe("getContextLookupReferences", () => {
       expectedReferences: [
         {
           keyPath: ["doesNotExist"],
+        },
+      ],
+    },
+
+    // if structural operator
+    {
+      name: "if structural operator - true",
+      expression: {
+        $if: "${true}",
+        $then: "${reachableConsequent}",
+        $else: "${unreachableAlternate}",
+      },
+      expectedReferences: [
+        {
+          keyPath: ["reachableConsequent"],
+        },
+      ],
+    },
+    {
+      name: "if structural operator - false",
+      expression: {
+        $if: "${false}",
+        $then: "${unreachableConsequent}",
+        $else: "${reachableAlternate}",
+      },
+      expectedReferences: [
+        {
+          keyPath: ["reachableAlternate"],
+        },
+      ],
+    },
+    {
+      name: "if structural operator - non-boolean",
+      expression: {
+        $if: "non-boolean value",
+        $then: "${unreachableConsequent}",
+        $else: "${unreachableAlternate}",
+      },
+      expectedReferences: [],
+    },
+    {
+      name: "if structural operator - failed lookup",
+      expression: {
+        $if: "${doesNotExist}",
+        $then: "${reachableConsequent}",
+        $else: "${reachableAlternate}",
+      },
+      expectedReferences: [
+        {
+          keyPath: ["doesNotExist"],
+        },
+        {
+          keyPath: ["reachableConsequent"],
+        },
+        {
+          keyPath: ["reachableAlternate"],
         },
       ],
     },

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -2889,6 +2889,50 @@ describe("getContextLookupReferences", () => {
         },
       ],
     },
+
+    // if block expression
+    {
+      name: "if block expression - true",
+      expression: "${if true}${reachableConsequent}${else}${unreachableAlternate}${endif}",
+      expectedReferences: [
+        {
+          keyPath: ["reachableConsequent"],
+        },
+      ],
+    },
+    {
+      name: "if block expression - false",
+      expression: "${if false}${unreachableConsequent}${else}${reachableAlternate}${endif}",
+      expectedReferences: [
+        {
+          keyPath: ["reachableAlternate"],
+        },
+      ],
+    },
+    {
+      name: "if block expression - failed lookup",
+      expression: "${if doesNotExist}${reachableConsequent}${else}${reachableAlternate}${endif}",
+      expectedReferences: [
+        {
+          keyPath: ["doesNotExist"],
+        },
+        {
+          keyPath: ["reachableConsequent"],
+        },
+        {
+          keyPath: ["reachableAlternate"],
+        },
+      ],
+    },
+    {
+      name: "if block expression without consequent",
+      expression: "${if doesNotExist}",
+      expectedReferences: [
+        {
+          keyPath: ["doesNotExist"],
+        },
+      ],
+    },
   ]
   for (const testCase of branchTestCases) {
     it(`correctly avoids dead code branches (test case: ${testCase.name})`, () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR changes `getContextLookupReferences` to ignore dead code
branches

**Which issue(s) this PR fixes**:

Fixes an issue where we considered implicit dependencies from action references in dead code branches.

**Addititional info**:

There was an alternate solution attempt, here: https://github.com/garden-io/garden/pull/6849

One of the benefits of the approach of detecting dead branches is that it now also works with logical AND (`&&`), logical OR (`||`), ternary expressions (`? :`) and if block expressions (`${if ...}`) and not just with structural if operators (`$if:` yaml keys).

Example / minimal repro:

```
kind: Project
apiVersion: garden.io/v1
name: test
environments:
 - name: local
variables:
 disabled: ${true}
---
kind: Run
type: exec
name: myrun
spec:
  command: [echo, "${ !var.disabled ? actions.deploy.mydeploy.outputs.logs : '<not executed>'}"]
---
kind: Deploy
type: exec
name: mydeploy
disabled: ${var.disabled}
spec:
  deployCommand: [echo, "${var.disabled ? 'I should not run' : 'I should run'}"]
```

Command: `garden run myrun`
Expected behaviour: the deploy "mydeploy" should not be executed.

The docs for the `disabled` flag do not reflect the current behaviour where we execute disabled actions, if another action references one of their outputs. This is a separate issue that will be dealt with in a separate PR.