### PR TITLE
feat(template)!: disallow optional values (`?` syntax) in template strings

### DIFF
--- a/core/src/template/parser.pegjs
+++ b/core/src/template/parser.pegjs
@@ -202,7 +202,7 @@ TemplateStrings
   }
 
 FormatString
-  = EscapeStart (!FormatEndWithOptional SourceCharacter)* FormatEndWithOptional {
+  = EscapeStart (!FormatEnd SourceCharacter)* FormatEnd {
     const isEscapedValue = true
     return new ast.LiteralExpression(text(), location(), text(), isEscapedValue)
   }
@@ -218,7 +218,7 @@ FormatString
         throw new TemplateStringError({ message: `Unrecognized block operator: ${op}`, loc: location() })
     }
   }
-  / pre:FormatStartWithEscape blockOperator:(ExpressionBlockOperator __)* e:Expression end:FormatEndWithOptional {
+  / pre:FormatStartWithEscape blockOperator:(ExpressionBlockOperator __)* e:Expression end:FormatEnd {
       const isEscapedValue = pre[0] === escapePrefix
       if (isEscapedValue) {
         return new ast.LiteralExpression(text(), location(), text(), isEscapedValue)
@@ -256,13 +256,6 @@ FormatStartWithEscape
 
 FormatEnd
   = __ "}"
-
-OptionalFormatEnd
-  = __ "}?"
-
-FormatEndWithOptional
-  = OptionalFormatEnd
-  / FormatEnd
 
 BlockOperator
   = "else"

--- a/core/test/data/test-build-dependants/template.garden.yaml
+++ b/core/test/data/test-build-dependants/template.garden.yaml
@@ -7,5 +7,5 @@ modules:
     varfile: dependencies.yaml
     include: [./**]
     build:
-      dependencies: ${var.dependencies}?
+      dependencies: ${var.dependencies || []}
       command: [echo, "build ${parent.name} module"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the UX issue when using template strings in URLs. For example `${var.baseUrl}?foo=bar` results in `http://example.comfoo=bar` which users may find unexpected.

Users should use `${var.baseUrl || 'defaultValue'}` instead.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
