### PR TITLE
chore(sync): deprecate `sync` commands outside dev console

### DIFF
--- a/core/src/commands/sync/sync-restart.ts
+++ b/core/src/commands/sync/sync-restart.ts
@@ -14,7 +14,7 @@ import type { CommandParams, CommandResult } from "../base.js"
 import { Command } from "../base.js"
 import { createActionLog } from "../../logger/log-entry.js"
 import { startSyncWithoutDeploy } from "./sync-start.js"
-import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
+import { reportDeprecatedSyncCommandUsage } from "../../util/deprecations.js"
 
 const syncRestartArgs = {
   names: new StringsParameter({
@@ -32,7 +32,7 @@ const syncRestartOpts = {}
 type Opts = typeof syncRestartOpts
 
 export class SyncRestartCommand extends Command<Args, Opts> {
-  name = "restart"
+  name = "restart" as const
   help = "Restart any active syncs to the given Deploy action(s)."
 
   override protected = true
@@ -57,14 +57,13 @@ export class SyncRestartCommand extends Command<Args, Opts> {
     printHeader(log, "Restarting sync(s)", "🔁")
   }
 
-  async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
-    const { garden, log, args } = params
-
-    if (!params.parentCommand) {
-      reportDeprecatedFeatureUsage({
+  async action({ garden, log, args, parentCommand }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
+    if (!parentCommand) {
+      reportDeprecatedSyncCommandUsage({
         apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncRestartCommand",
+        syncCommandName: this.name,
       })
     }
 

--- a/core/src/commands/sync/sync-restart.ts
+++ b/core/src/commands/sync/sync-restart.ts
@@ -14,6 +14,7 @@ import type { CommandParams, CommandResult } from "../base.js"
 import { Command } from "../base.js"
 import { createActionLog } from "../../logger/log-entry.js"
 import { startSyncWithoutDeploy } from "./sync-start.js"
+import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 
 const syncRestartArgs = {
   names: new StringsParameter({
@@ -58,6 +59,14 @@ export class SyncRestartCommand extends Command<Args, Opts> {
 
   async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     const { garden, log, args } = params
+
+    if (!params.parentCommand) {
+      reportDeprecatedFeatureUsage({
+        apiVersion: garden.projectApiVersion,
+        log,
+        deprecation: "syncRestartCommand",
+      })
+    }
 
     const names = args.names || []
 

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -26,6 +26,7 @@ import { styles } from "../../logger/styles.js"
 import { makeDocsLinkStyled } from "../../docs/common.js"
 
 import { syncGuideRelPath } from "../../plugins/kubernetes/constants.js"
+import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 
 const syncStatusArgs = {
   names: new StringsParameter({
@@ -93,7 +94,21 @@ export class SyncStatusCommand extends Command<Args, Opts> {
     printHeader(log, "Getting sync statuses", "📟")
   }
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<SyncStatusCommandResult> {
+  async action({
+    garden,
+    log,
+    args,
+    opts,
+    parentCommand,
+  }: CommandParams<Args, Opts>): Promise<SyncStatusCommandResult> {
+    if (!parentCommand) {
+      reportDeprecatedFeatureUsage({
+        apiVersion: garden.projectApiVersion,
+        log,
+        deprecation: "syncStatusCommand",
+      })
+    }
+
     // TODO: Use regular graph and resolve only the needed Deploys below
     const graph = await garden.getResolvedConfigGraph({ log, emit: true })
     const skipDetail = opts["skip-detail"]

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -26,7 +26,7 @@ import { styles } from "../../logger/styles.js"
 import { makeDocsLinkStyled } from "../../docs/common.js"
 
 import { syncGuideRelPath } from "../../plugins/kubernetes/constants.js"
-import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
+import { reportDeprecatedSyncCommandUsage } from "../../util/deprecations.js"
 
 const syncStatusArgs = {
   names: new StringsParameter({
@@ -63,7 +63,7 @@ interface SyncStatusCommandResult {
 }
 
 export class SyncStatusCommand extends Command<Args, Opts> {
-  name = "status"
+  name = "status" as const
   help = "Get sync statuses."
 
   override protected = true
@@ -102,10 +102,11 @@ export class SyncStatusCommand extends Command<Args, Opts> {
     parentCommand,
   }: CommandParams<Args, Opts>): Promise<SyncStatusCommandResult> {
     if (!parentCommand) {
-      reportDeprecatedFeatureUsage({
+      reportDeprecatedSyncCommandUsage({
         apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncStatusCommand",
+        syncCommandName: this.name,
       })
     }
 

--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -13,7 +13,7 @@ import { dedent, naturalList } from "../../util/string.js"
 import type { CommandParams, CommandResult } from "../base.js"
 import { Command } from "../base.js"
 import { createActionLog } from "../../logger/log-entry.js"
-import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
+import { reportDeprecatedSyncCommandUsage } from "../../util/deprecations.js"
 
 const syncStopArgs = {
   names: new StringsParameter({
@@ -33,7 +33,7 @@ const syncStopOpts = {
 type Opts = typeof syncStopOpts
 
 export class SyncStopCommand extends Command<Args, Opts> {
-  name = "stop"
+  name = "stop" as const
   help = "Stop any active syncs to the given Deploy action(s)."
 
   override protected = true
@@ -58,14 +58,13 @@ export class SyncStopCommand extends Command<Args, Opts> {
     printHeader(log, "Stopping sync(s)", "🔁")
   }
 
-  async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
-    const { garden, log, args } = params
-
-    if (!params.parentCommand) {
-      reportDeprecatedFeatureUsage({
+  async action({ garden, log, args, parentCommand }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
+    if (!parentCommand) {
+      reportDeprecatedSyncCommandUsage({
         apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncStopCommand",
+        syncCommandName: this.name,
       })
     }
 

--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -13,6 +13,7 @@ import { dedent, naturalList } from "../../util/string.js"
 import type { CommandParams, CommandResult } from "../base.js"
 import { Command } from "../base.js"
 import { createActionLog } from "../../logger/log-entry.js"
+import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 
 const syncStopArgs = {
   names: new StringsParameter({
@@ -59,6 +60,14 @@ export class SyncStopCommand extends Command<Args, Opts> {
 
   async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     const { garden, log, args } = params
+
+    if (!params.parentCommand) {
+      reportDeprecatedFeatureUsage({
+        apiVersion: garden.projectApiVersion,
+        log,
+        deprecation: "syncStopCommand",
+      })
+    }
 
     // We default to stopping all syncs.
     const names = args.names || ["*"]

--- a/core/src/commands/sync/sync.ts
+++ b/core/src/commands/sync/sync.ts
@@ -18,3 +18,5 @@ export class SyncCommand extends CommandGroup {
 
   subCommands = [SyncStartCommand, SyncStopCommand, SyncRestartCommand, SyncStatusCommand]
 }
+
+export type SyncCommandName = SyncCommand["subCommands"][number]["name"]

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -105,6 +105,14 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         Instead, we recommend stopping syncs inside the dev console with ${style("sync stop")}.`,
       hintReferenceLink: null,
     },
+    syncRestartCommand: {
+      contextDesc: "Sync mode",
+      featureDesc: `The ${style("sync restart")} command.`,
+      hint: deline`The command ${style("sync restart")} will only be available inside dev console in a future breaking change release.
+        Do not use it as a standalone Garden command.
+        Instead, we recommend restarting syncs inside the dev console with ${style("sync restart")}.`,
+      hintReferenceLink: null,
+    },
     hadolintPlugin: makePluginDeprecation("hadolint", style),
     octantPlugin: makePluginDeprecation("octant", style),
     conftestPlugin: makePluginDeprecation("conftest", style),

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -91,7 +91,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     syncStartCommand: {
       contextDesc: "Sync mode",
-      featureDesc: `The ${style("sync start")} command.`,
+      featureDesc: `The ${style("sync start")} command`,
       hint: deline`The command ${style("sync start")} will only be available inside dev console in a future breaking change release.
         Do not use it as a standalone Garden command.
         Instead, we recommend running ${style("garden deploy --sync")} or starting syncs inside the dev console with either ${style("deploy --sync")} or ${style("sync start")}.`,
@@ -99,7 +99,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     syncStopCommand: {
       contextDesc: "Sync mode",
-      featureDesc: `The ${style("sync stop")} command.`,
+      featureDesc: `The ${style("sync stop")} command`,
       hint: deline`The command ${style("sync stop")} will only be available inside dev console in a future breaking change release.
         Do not use it as a standalone Garden command.
         Instead, we recommend stopping syncs inside the dev console with ${style("sync stop")}.`,
@@ -107,7 +107,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     syncRestartCommand: {
       contextDesc: "Sync mode",
-      featureDesc: `The ${style("sync restart")} command.`,
+      featureDesc: `The ${style("sync restart")} command`,
       hint: deline`The command ${style("sync restart")} will only be available inside dev console in a future breaking change release.
         Do not use it as a standalone Garden command.
         Instead, we recommend restarting syncs inside the dev console with ${style("sync restart")}.`,
@@ -115,7 +115,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     syncStatusCommand: {
       contextDesc: "Sync mode",
-      featureDesc: `The ${style("sync status")} command.`,
+      featureDesc: `The ${style("sync status")} command`,
       hint: deline`The command ${style("sync status")} will only be available inside dev console in a future breaking change release.
         Do not use it as a standalone Garden command.
         Instead, we recommend getting sync statuses inside the dev console with ${style("sync status")}.`,

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -113,6 +113,14 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         Instead, we recommend restarting syncs inside the dev console with ${style("sync restart")}.`,
       hintReferenceLink: null,
     },
+    syncStatusCommand: {
+      contextDesc: "Sync mode",
+      featureDesc: `The ${style("sync status")} command.`,
+      hint: deline`The command ${style("sync status")} will only be available inside dev console in a future breaking change release.
+        Do not use it as a standalone Garden command.
+        Instead, we recommend getting sync statuses inside the dev console with ${style("sync status")}.`,
+      hintReferenceLink: null,
+    },
     hadolintPlugin: makePluginDeprecation("hadolint", style),
     octantPlugin: makePluginDeprecation("octant", style),
     conftestPlugin: makePluginDeprecation("conftest", style),

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -90,7 +90,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     syncStartCommand: {
       contextDesc: "Sync mode",
-      featureDesc: `The ${style("sync-start")} command.`,
+      featureDesc: `The ${style("sync start")} command.`,
       hint: dedent`Behaviour of ${style(
         "sync start"
       )} is now deprecated and will be changed in a future breaking change release.

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -12,6 +12,7 @@ import { GardenError } from "../exceptions.js"
 import { emitNonRepeatableWarning } from "../warnings.js"
 import type { Log } from "../logger/log-entry.js"
 import dedent from "dedent"
+import { deline } from "./string.js"
 
 const deprecatedPluginNames = ["conftest", "conftest-container", "conftest-kubernetes", "hadolint", "octant"] as const
 export type DeprecatedPluginName = (typeof deprecatedPluginNames)[number]
@@ -91,11 +92,17 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     syncStartCommand: {
       contextDesc: "Sync mode",
       featureDesc: `The ${style("sync start")} command.`,
-      hint: dedent`Behaviour of ${style(
-        "sync start"
-      )} is now deprecated and will be changed in a future breaking change release.
-        Instead, we recommend running ${style("garden deploy --sync")} or starting syncs inside the dev console
-        with either ${style("deploy --sync")} or ${style("sync start")}.`,
+      hint: deline`The command ${style("sync start")} will only be available inside dev console in a future breaking change release.
+        Do not use it as a standalone Garden command.
+        Instead, we recommend running ${style("garden deploy --sync")} or starting syncs inside the dev console with either ${style("deploy --sync")} or ${style("sync start")}.`,
+      hintReferenceLink: null,
+    },
+    syncStopCommand: {
+      contextDesc: "Sync mode",
+      featureDesc: `The ${style("sync stop")} command.`,
+      hint: deline`The command ${style("sync stop")} will only be available inside dev console in a future breaking change release.
+        Do not use it as a standalone Garden command.
+        Instead, we recommend stopping syncs inside the dev console with ${style("sync stop")}.`,
       hintReferenceLink: null,
     },
     hadolintPlugin: makePluginDeprecation("hadolint", style),

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -121,9 +121,11 @@ Do not use this command. It has no effect.
 
 <h3 id="syncStartCommand">The `sync start` command.</h3>
 
-Behaviour of `sync start` is now deprecated and will be changed in a future breaking change release.
-Instead, we recommend running `garden deploy --sync` or starting syncs inside the dev console
-with either `deploy --sync` or `sync start`.
+The command `sync start` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend running `garden deploy --sync` or starting syncs inside the dev console with either `deploy --sync` or `sync start`.
+
+<h3 id="syncStopCommand">The `sync stop` command.</h3>
+
+The command `sync stop` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend stopping syncs inside the dev console with `sync stop`.
 
 ## Garden Plugins
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -119,7 +119,7 @@ Do not use this command. It has no effect.
 
 ## Sync mode
 
-<h3 id="syncStartCommand">The `sync-start` command.</h3>
+<h3 id="syncStartCommand">The `sync start` command.</h3>
 
 Behaviour of `sync start` is now deprecated and will be changed in a future breaking change release.
 Instead, we recommend running `garden deploy --sync` or starting syncs inside the dev console

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -119,19 +119,19 @@ Do not use this command. It has no effect.
 
 ## Sync mode
 
-<h3 id="syncStartCommand">The `sync start` command.</h3>
+<h3 id="syncStartCommand">The `sync start` command</h3>
 
 The command `sync start` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend running `garden deploy --sync` or starting syncs inside the dev console with either `deploy --sync` or `sync start`.
 
-<h3 id="syncStopCommand">The `sync stop` command.</h3>
+<h3 id="syncStopCommand">The `sync stop` command</h3>
 
 The command `sync stop` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend stopping syncs inside the dev console with `sync stop`.
 
-<h3 id="syncRestartCommand">The `sync restart` command.</h3>
+<h3 id="syncRestartCommand">The `sync restart` command</h3>
 
 The command `sync restart` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend restarting syncs inside the dev console with `sync restart`.
 
-<h3 id="syncStatusCommand">The `sync status` command.</h3>
+<h3 id="syncStatusCommand">The `sync status` command</h3>
 
 The command `sync status` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend getting sync statuses inside the dev console with `sync status`.
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -127,6 +127,10 @@ The command `sync start` will only be available inside dev console in a future b
 
 The command `sync stop` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend stopping syncs inside the dev console with `sync stop`.
 
+<h3 id="syncRestartCommand">The `sync restart` command.</h3>
+
+The command `sync restart` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend restarting syncs inside the dev console with `sync restart`.
+
 ## Garden Plugins
 
 <h3 id="hadolintPlugin">The plugin `hadolint`</h3>

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -131,6 +131,10 @@ The command `sync stop` will only be available inside dev console in a future br
 
 The command `sync restart` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend restarting syncs inside the dev console with `sync restart`.
 
+<h3 id="syncStatusCommand">The `sync status` command.</h3>
+
+The command `sync status` will only be available inside dev console in a future breaking change release. Do not use it as a standalone Garden command. Instead, we recommend getting sync statuses inside the dev console with `sync status`.
+
 ## Garden Plugins
 
 <h3 id="hadolintPlugin">The plugin `hadolint`</h3>


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR deprecates all `sync` sub-commands if those are executed not in the dev console.

In the next major release we can make these commands only available in the dev console.
This will make the sync lifecycle management more stable and robust.

The initial attempt was done in #5733 - there `sync start` and `sync stop` commands were made available only in dev console.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
