### PR TITLE
feat(cli): add more fields to garden get actions detailed output

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -28,6 +28,8 @@ import type { VariablesContext } from "../config/template-contexts/variables.js"
 
 export type { ActionKind } from "../plugin/action-types.js"
 
+export type { ActionVersion } from "../vcs/vcs.js"
+
 export const actionKinds: ActionKind[] = ["Build", "Deploy", "Run", "Test"]
 export const actionKindsLower = actionKinds.map((k) => k.toLowerCase())
 

--- a/core/src/commands/get/get-actions.ts
+++ b/core/src/commands/get/get-actions.ts
@@ -58,6 +58,26 @@ export const getActionsCmdOutputSchema = createSchema({
       .description("The state of the action."),
     path: joi.string().description("The relative path of the action config file."),
     disabled: joi.boolean().description("Flag to identify if action is disabled."),
+    version: joi
+      .object()
+      .keys({
+        configVersion: joi.string().required().description("The version string of the action's config."),
+        sourceVersion: joi.string().required().description("The version string of the action's source."),
+        versionString: joi.string().required().description("The version string of the action."),
+        dependencyVersions: joi
+          .object()
+          .pattern(joi.string(), joi.string())
+          .required()
+          .description("Map with the version strings of the action's dependencies."),
+        files: joiArray(joi.string()).required().description("List of the files included in the action."),
+      })
+      .description("Object with the full version information of the action."),
+    allowPublish: joi
+      .boolean()
+      .description("Flag to identify whether publishing the build is enabled. Only available for build actions."),
+    publishId: joi
+      .string()
+      .description("The image ID used to publish the image of the action. Only available for build actions."),
     moduleName: joi
       .string()
       .description("The name of the module the action is derived from. Only available for converted actions."),

--- a/core/src/commands/get/get-actions.ts
+++ b/core/src/commands/get/get-actions.ts
@@ -7,7 +7,7 @@
  */
 
 import { getActionState, getRelativeActionConfigPath } from "../../actions/helpers.js"
-import type { ActionKind, ActionState, ResolvedAction } from "../../actions/types.js"
+import type { ActionKind, ActionState, ActionVersion, ResolvedAction } from "../../actions/types.js"
 import { actionKinds, actionStates } from "../../actions/types.js"
 import { BooleanParameter, ChoicesParameter, StringsParameter } from "../../cli/params.js"
 import { createSchema, joi, joiArray } from "../../config/common.js"
@@ -25,6 +25,9 @@ interface GetActionsCommandResultItem {
   state?: ActionState
   path?: string
   disabled?: boolean
+  version?: ActionVersion
+  allowPublish?: boolean
+  publishId?: string
   moduleName?: string
   dependencies?: string[]
   dependents?: string[]
@@ -216,6 +219,9 @@ export class GetActionsCommand extends Command {
             .map((d) => d.key())
             .sort(),
           disabled: a.isDisabled(),
+          version: a.getFullVersion(),
+          allowPublish: a.getConfig().allowPublish ?? undefined,
+          publishId: a.getSpec("publishId") ?? undefined,
           moduleName: a.moduleName() ?? undefined,
         }
       }

--- a/core/test/unit/src/commands/get/get-actions.ts
+++ b/core/test/unit/src/commands/get/get-actions.ts
@@ -53,6 +53,9 @@ export const getActionsToDetailedOutput = (a: Action, garden: TestGarden, graph:
       .map((d) => d.key())
       .sort(),
     disabled: a.isDisabled(),
+    version: a.getFullVersion(),
+    allowPublish: a.getConfig().allowPublish ?? undefined,
+    publishId: a.getConfig().spec.publishId ?? undefined,
     moduleName: a.moduleName() ?? undefined,
   }
 }
@@ -80,6 +83,9 @@ export const getActionsToDetailedWithStateOutput = async (
         .map((d) => d.key())
         .sort(),
       disabled: a.isDisabled(),
+      version: a.getFullVersion(),
+      allowPublish: a.getConfig().allowPublish ?? undefined,
+      publishId: a.getConfig().spec.publishId ?? undefined,
       moduleName: a.moduleName() ?? undefined,
     }
   }

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3547,6 +3547,30 @@ actions:
     # Flag to identify if action is disabled.
     disabled:
 
+    # Object with the full version information of the action.
+    version:
+      # The version string of the action's config.
+      configVersion:
+
+      # The version string of the action's source.
+      sourceVersion:
+
+      # The version string of the action.
+      versionString:
+
+      # Map with the version strings of the action's dependencies.
+      dependencyVersions:
+        <name>:
+
+      # List of the files included in the action.
+      files:
+
+    # Flag to identify whether publishing the build is enabled. Only available for build actions.
+    allowPublish:
+
+    # The image ID used to publish the image of the action. Only available for build actions.
+    publishId:
+
     # The name of the module the action is derived from. Only available for converted actions.
     moduleName:
 
@@ -3609,6 +3633,30 @@ actions:
 
     # Flag to identify if action is disabled.
     disabled:
+
+    # Object with the full version information of the action.
+    version:
+      # The version string of the action's config.
+      configVersion:
+
+      # The version string of the action's source.
+      sourceVersion:
+
+      # The version string of the action.
+      versionString:
+
+      # Map with the version strings of the action's dependencies.
+      dependencyVersions:
+        <name>:
+
+      # List of the files included in the action.
+      files:
+
+    # Flag to identify whether publishing the build is enabled. Only available for build actions.
+    allowPublish:
+
+    # The image ID used to publish the image of the action. Only available for build actions.
+    publishId:
 
     # The name of the module the action is derived from. Only available for converted actions.
     moduleName:
@@ -3673,6 +3721,30 @@ actions:
     # Flag to identify if action is disabled.
     disabled:
 
+    # Object with the full version information of the action.
+    version:
+      # The version string of the action's config.
+      configVersion:
+
+      # The version string of the action's source.
+      sourceVersion:
+
+      # The version string of the action.
+      versionString:
+
+      # Map with the version strings of the action's dependencies.
+      dependencyVersions:
+        <name>:
+
+      # List of the files included in the action.
+      files:
+
+    # Flag to identify whether publishing the build is enabled. Only available for build actions.
+    allowPublish:
+
+    # The image ID used to publish the image of the action. Only available for build actions.
+    publishId:
+
     # The name of the module the action is derived from. Only available for converted actions.
     moduleName:
 
@@ -3736,6 +3808,30 @@ actions:
     # Flag to identify if action is disabled.
     disabled:
 
+    # Object with the full version information of the action.
+    version:
+      # The version string of the action's config.
+      configVersion:
+
+      # The version string of the action's source.
+      sourceVersion:
+
+      # The version string of the action.
+      versionString:
+
+      # Map with the version strings of the action's dependencies.
+      dependencyVersions:
+        <name>:
+
+      # List of the files included in the action.
+      files:
+
+    # Flag to identify whether publishing the build is enabled. Only available for build actions.
+    allowPublish:
+
+    # The image ID used to publish the image of the action. Only available for build actions.
+    publishId:
+
     # The name of the module the action is derived from. Only available for converted actions.
     moduleName:
 
@@ -3798,6 +3894,30 @@ actions:
 
     # Flag to identify if action is disabled.
     disabled:
+
+    # Object with the full version information of the action.
+    version:
+      # The version string of the action's config.
+      configVersion:
+
+      # The version string of the action's source.
+      sourceVersion:
+
+      # The version string of the action.
+      versionString:
+
+      # Map with the version strings of the action's dependencies.
+      dependencyVersions:
+        <name>:
+
+      # List of the files included in the action.
+      files:
+
+    # Flag to identify whether publishing the build is enabled. Only available for build actions.
+    allowPublish:
+
+    # The image ID used to publish the image of the action. Only available for build actions.
+    publishId:
 
     # The name of the module the action is derived from. Only available for converted actions.
     moduleName:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

See #6902 for more background. This adds additional fields to the `garden get actions --detail` output, which can be parsed to use images published by Garden for other deployments.

It adds the following new fields to the actions output:
- `version`: the full resolved version of a Garden action, including `versionString` and `files`.
- `allowPublish`: the value of `allowPublish` in the Garden action.
- `publishId`: the value of the `publishId` in the Garden action spec, or the default publish ID derived by Garden from the action name.

**Which issue(s) this PR fixes**:

Fixes #6902

**Special notes for your reviewer**:
