### PR TITLE
fix(core): always suppress logs when `--output` is used

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -421,6 +421,7 @@ ${renderCommands(commands)}
         level: parseLogLevel(logLevelStr),
         storeEntries: false,
         displayWriterType: getTerminalWriterType({ silent, output, loggerType }),
+        outputRenderer: output,
         useEmoji: emoji,
         showTimestamps,
         force: this.initLogger,

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -34,6 +34,8 @@ export const OUTPUT_RENDERERS = {
   },
 }
 
+export type OutputRenderer = keyof typeof OUTPUT_RENDERERS
+
 export const validDurationUnits = ["d", "h", "m", "s"]
 
 function splitDuration(duration: string) {
@@ -399,7 +401,7 @@ export const globalDisplayOptions = {
   "output": new ChoicesParameter({
     aliases: ["o"],
     choices: Object.keys(OUTPUT_RENDERERS),
-    help: "Output command result in specified format (note: disables progress logging and interactive functionality).",
+    help: "Output command result in the specified format. When used, this option disables line-by-line logging, even if the GARDEN_LOGGER_TYPE environment variable is used.",
   }),
   "emoji": new BooleanParameter({
     help: "Enable emoji in output (defaults to true if the environment supports it).",

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -22,6 +22,7 @@ import { QuietWriter } from "./writers/quiet-writer.js"
 import type { PluginEventBroker } from "../plugin-context.js"
 import { EventLogWriter } from "./writers/event-writer.js"
 import { naturalList } from "../util/string.js"
+import type { OutputRenderer } from "../cli/params.js"
 
 export type LoggerType = "quiet" | "default" | "basic" | "json" | "ink"
 export const LOGGER_TYPES = new Set<LoggerType>(["quiet", "default", "basic", "json", "ink"])
@@ -145,7 +146,7 @@ export interface Logger extends Required<LoggerConfigBase> {
   getWriters(): LoggerWriters
 }
 
-interface LoggerInitParams extends LoggerConfigBase {
+export interface LoggerInitParams extends LoggerConfigBase {
   /**
    * The type of display writer to use. This is configurable by the user
    * and exposed as a "logger type" which is a bit more user friendly.
@@ -153,6 +154,15 @@ interface LoggerInitParams extends LoggerConfigBase {
    * The logger also has a set of file writers that are set internally.
    */
   displayWriterType: LoggerType
+  /**
+   * The output renderer to use. This is intended to produce machine-readable/parse-able output (e.g. JSON or YAML) for
+   * the Garden command. When a this option is used, this essentially suppresses all line-by-line log output, except
+   * for the serialized command result at the end of the command.
+   *
+   * This is because non JSON/YAML log lines would make the command's output not a valid JSON/YAML string, and thus
+   * break any parsing logic that expects the output of the Garden to be aalid JSON/YAML.
+   */
+  outputRenderer?: OutputRenderer
   force?: boolean
 }
 
@@ -355,41 +365,15 @@ export class RootLogger extends LoggerBase {
       return RootLogger.instance
     }
 
-    // The GARDEN_LOG_LEVEL env variable takes precedence over the config param
-    if (gardenEnv.GARDEN_LOG_LEVEL) {
-      try {
-        config.level = parseLogLevel(gardenEnv.GARDEN_LOG_LEVEL)
-      } catch (err) {
-        if (!(err instanceof ParameterError)) {
-          throw err
-        }
-        throw new CommandError({ message: `Invalid log level set for GARDEN_LOG_LEVEL: ${err.message}` })
-      }
-    }
+    const updatedConfig = RootLogger.applyEnvToLoggerConfig(config)
 
-    // GARDEN_LOGGER_TYPE env variable takes precedence over the config param
-    if (gardenEnv.GARDEN_LOGGER_TYPE) {
-      const loggerTypeFromEnv = <LoggerType>gardenEnv.GARDEN_LOGGER_TYPE
-
-      if (!LOGGER_TYPES.has(loggerTypeFromEnv)) {
-        throw new ParameterError({
-          message: `Invalid logger type specified: ${loggerTypeFromEnv}. Available types: ${naturalList(
-            Array.from(LOGGER_TYPES)
-          )}`,
-        })
-      }
-
-      config.displayWriterType = loggerTypeFromEnv
-    }
-
-    const terminalWriter = getTerminalWriterInstance(config.displayWriterType, config.level)
+    const terminalWriter = getTerminalWriterInstance(updatedConfig.displayWriterType, updatedConfig.level)
     const writers = {
       display: terminalWriter,
       file: [],
     }
 
-    const instance = new RootLogger({ ...config, storeEntries: config.storeEntries, writers })
-
+    const instance = new RootLogger({ ...updatedConfig, storeEntries: updatedConfig.storeEntries, writers })
     const initLog = instance.createLog()
 
     if (gardenEnv.GARDEN_LOG_LEVEL) {
@@ -401,6 +385,38 @@ export class RootLogger extends LoggerBase {
 
     RootLogger.instance = instance
     return instance
+  }
+
+  static applyEnvToLoggerConfig(config: LoggerInitParams) {
+    // Make a shallow copy instead of mutating the param.
+    const updated = { ...config }
+    // The GARDEN_LOG_LEVEL env variable takes precedence over the config param
+    if (gardenEnv.GARDEN_LOG_LEVEL) {
+      try {
+        updated.level = parseLogLevel(gardenEnv.GARDEN_LOG_LEVEL)
+      } catch (err) {
+        if (!(err instanceof ParameterError)) {
+          throw err
+        }
+        throw new CommandError({ message: `Invalid log level set for GARDEN_LOG_LEVEL: ${err.message}` })
+      }
+    }
+
+    // GARDEN_LOGGER_TYPE env variable takes precedence over the updated param, unless the `--output` option is used.
+    if (gardenEnv.GARDEN_LOGGER_TYPE && !updated.outputRenderer) {
+      const loggerTypeFromEnv = <LoggerType>gardenEnv.GARDEN_LOGGER_TYPE
+
+      if (!LOGGER_TYPES.has(loggerTypeFromEnv)) {
+        throw new ParameterError({
+          message: `Invalid logger type specified: ${loggerTypeFromEnv}. Available types: ${naturalList(
+            Array.from(LOGGER_TYPES)
+          )}`,
+        })
+      }
+
+      updated.displayWriterType = loggerTypeFromEnv
+    }
+    return updated
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, setting the `GARDEN_LOGGER_TYPE` environment variable to `basic` would cause line-by-line logs to be written even if the `--output` option was being used.

This caused the output of the command no longer to be valid JSON/YAML.