### PR TITLE
fix(k8s): respect `spec.cacheResult` flag in `kubernetes-pod` Test actions

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
@@ -42,6 +42,7 @@ export interface KubernetesPodRunActionSpec extends KubernetesCommonRunSpec {
   resource?: KubernetesTargetResourceSpec
   podSpec?: V1PodSpec
 }
+
 export type KubernetesPodRunActionConfig = RunActionConfig<"kubernetes-pod", KubernetesPodRunActionSpec>
 export type KubernetesPodRunAction = RunAction<KubernetesPodRunActionConfig, KubernetesRunOutputs>
 
@@ -157,12 +158,14 @@ export const kubernetesPodTestDefinition = (): TestActionDefinition<KubernetesPo
         ...res,
       }
 
-      await storeTestResult({
-        ctx: k8sCtx,
-        log,
-        action,
-        result: detail,
-      })
+      if (action.getSpec("cacheResult")) {
+        await storeTestResult({
+          ctx: k8sCtx,
+          log,
+          action,
+          result: detail,
+        })
+      }
 
       return { state: runResultToActionState(detail), detail, outputs: { log: res.log } }
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to fix the `spec.cacheResult: false` would not have any effect for Test actions of type `kubernetes-pod`.

This PR fixes it to respect the behaviour of that flag described in the [docs](https://docs.garden.io/reference/action-types/test/kubernetes-pod#spec.cacheresult).

The default value is still `true`. So, there are no breaking changes in the behaviour.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
