### PR TITLE
feat(container): add `cacheResult` flag for `container` Test actions

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -34,6 +34,7 @@ import { templateStringLiteral } from "../../docs/common.js"
 import { syncGuideLink } from "../kubernetes/constants.js"
 import { makeSecret, type Secret } from "../../util/secrets.js"
 import { makeDeprecationMessage } from "../../util/deprecations.js"
+import type { ActionKind } from "../../plugin/action-types.js"
 
 export const defaultDockerfileName = "Dockerfile"
 
@@ -919,15 +920,21 @@ export interface ContainerTestActionSpec extends ContainerCommonRuntimeSpec {
   artifacts: ArtifactSpec[]
   image?: string
   volumes: ContainerVolumeSpec[]
+  cacheResult: boolean
 }
 
 export type ContainerTestActionConfig = TestActionConfig<"container", ContainerTestActionSpec>
 export type ContainerTestAction = TestAction<ContainerTestActionConfig, ContainerTestOutputs>
 
-export const containerTestSpecKeys = memoize(() => ({
+export const containerRunAndTestSpecKeys = memoize((kind: ActionKind) => ({
   ...containerCommonRuntimeSchemaKeys(),
   artifacts: artifactsSchema(),
   image: containerImageSchema(),
+  cacheResult: runCacheResultSchema(kind),
+}))
+
+export const containerTestSpecKeys = memoize(() => ({
+  ...containerRunAndTestSpecKeys("Test"),
 }))
 
 export const containerTestActionSchema = createSchema({
@@ -941,16 +948,13 @@ export type ContainerRunOutputs = ContainerTestOutputs
 
 export const containerRunOutputSchema = () => containerTestOutputSchema()
 
-export interface ContainerRunActionSpec extends ContainerTestActionSpec {
-  cacheResult: boolean
-}
+export type ContainerRunActionSpec = ContainerTestActionSpec
 
 export type ContainerRunActionConfig = RunActionConfig<"container", ContainerRunActionSpec>
 export type ContainerRunAction = RunAction<ContainerRunActionConfig, ContainerRunOutputs>
 
 export const containerRunSpecKeys = memoize(() => ({
-  ...containerTestSpecKeys(),
-  cacheResult: runCacheResultSchema("Run"),
+  ...containerRunAndTestSpecKeys("Run"),
 }))
 
 export const containerRunActionSchema = createSchema({

--- a/core/src/plugins/kubernetes/container/test.ts
+++ b/core/src/plugins/kubernetes/container/test.ts
@@ -48,12 +48,14 @@ export const k8sContainerTest: TestActionHandler<"run", ContainerTestAction> = a
     ...res,
   }
 
-  await storeTestResult({
-    ctx,
-    log,
-    action,
-    result,
-  })
+  if (action.getSpec("cacheResult")) {
+    await storeTestResult({
+      ctx,
+      log,
+      action,
+      result,
+    })
+  }
 
   return { state: runResultToActionState(result), detail: result, outputs: { log: res.log } }
 }

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -401,6 +401,7 @@ describe("plugins.container", () => {
             name: "unit",
             args: ["echo", "OK"],
             artifacts: [],
+            cacheResult: true,
             dependencies: [],
             disabled: false,
             env: {
@@ -739,6 +740,7 @@ describe("plugins.container", () => {
               name: "test-a",
               args: [],
               artifacts: [],
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               env: {},
@@ -827,6 +829,7 @@ describe("plugins.container", () => {
               name: "unit",
               args: ["echo", "OK"],
               artifacts: [],
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               env: {},

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -589,6 +589,16 @@ Specify an image ID to deploy. Should be a valid Docker image identifier. Requir
 | -------- | -------- |
 | `string` | No       |
 
+### `spec.cacheResult`
+
+[spec](#spec) > cacheResult
+
+Set to false if you don't want the Test action result to be cached. Use this if the Test action needs to be run any time your project (or one or more of the Test action's dependants) is deployed. Otherwise the Test action is only re-run when its version changes, or when you run `garden run`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
+
 
 ## Outputs
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -639,6 +639,11 @@ tests:
     # Specify an image ID to deploy. Should be a valid Docker image identifier. Required if no `build` is specified.
     image:
 
+    # Set to false if you don't want the Test action result to be cached. Use this if the Test action needs to be run
+    # any time your project (or one or more of the Test action's dependants) is deployed. Otherwise the Test action is
+    # only re-run when its version changes, or when you run `garden run`.
+    cacheResult: true
+
 # A list of tasks that can be run from this container module. These can be used as dependencies for services (executed
 # before the service is deployed) or for other tasks.
 tasks:
@@ -2428,6 +2433,16 @@ Specify an image ID to deploy. Should be a valid Docker image identifier. Requir
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tests[].cacheResult`
+
+[tests](#tests) > cacheResult
+
+Set to false if you don't want the Test action result to be cached. Use this if the Test action needs to be run any time your project (or one or more of the Test action's dependants) is deployed. Otherwise the Test action is only re-run when its version changes, or when you run `garden run`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `tasks[]`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -707,6 +707,11 @@ tests:
     # Specify an image ID to deploy. Should be a valid Docker image identifier. Required if no `build` is specified.
     image:
 
+    # Set to false if you don't want the Test action result to be cached. Use this if the Test action needs to be run
+    # any time your project (or one or more of the Test action's dependants) is deployed. Otherwise the Test action is
+    # only re-run when its version changes, or when you run `garden run`.
+    cacheResult: true
+
 # A list of tasks that can be run from this container module. These can be used as dependencies for services (executed
 # before the service is deployed) or for other tasks.
 tasks:
@@ -2643,6 +2648,16 @@ Specify an image ID to deploy. Should be a valid Docker image identifier. Requir
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tests[].cacheResult`
+
+[tests](#tests) > cacheResult
+
+Set to false if you don't want the Test action result to be cached. Use this if the Test action needs to be run any time your project (or one or more of the Test action's dependants) is deployed. Otherwise the Test action is only re-run when its version changes, or when you run `garden run`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `tasks[]`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `spec.cacheResult` config entry for `container` Test type.

Default value is `true`. This keep configuration feature parity between Run and Test actions.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
