### PR TITLE
chore: release `0.13.55`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Bug Fixes
 
-* do not store duplicate logs in cache ([bf5e1a63e](https://github.com/garden-io/garden/commit/bf5e1a63e))
-* change field name of helm-pod result details to match its semantics ([98c15c32c](https://github.com/garden-io/garden/commit/98c15c32c))
 * improve error message when servicePort does not reference a port by name ([#6894](https://github.com/garden-io/garden/issues/6894)) ([6e0cf71c5](https://github.com/garden-io/garden/commit/6e0cf71c5))
 * **build-staging:** fix the detection of paths to be deleted ([#6904](https://github.com/garden-io/garden/issues/6904)) ([ee976ad2b](https://github.com/garden-io/garden/commit/ee976ad2b))
 * **config:** throw validation errors when encountering unknown keys in action configs ([#6875](https://github.com/garden-io/garden/issues/6875)) ([06448a086](https://github.com/garden-io/garden/commit/06448a086))
 * **core:** always suppress logs when `--output` is used ([#6909](https://github.com/garden-io/garden/issues/6909)) ([3434a55dd](https://github.com/garden-io/garden/commit/3434a55dd))
 * **docs:** propagate correct action kind to k8s Run/Test reference docs ([#6923](https://github.com/garden-io/garden/issues/6923)) ([08b0eeaa6](https://github.com/garden-io/garden/commit/08b0eeaa6))
-* **k8s:** respect `spec.cacheResult` flag in `kubernetes-pod` Test actions ([6de41aa3b](https://github.com/garden-io/garden/commit/6de41aa3b))
+* **k8s:** improve error message when servicePort does not reference a port by name ([#6894](https://github.com/garden-io/garden/issues/6894)) ([6e0cf71c5](https://github.com/garden-io/garden/commit/6e0cf71c5))
+* **k8s:** respect `spec.cacheResult` flag in `kubernetes-pod` Test actions ([#6924](https://github.com/garden-io/garden/issues/6924))
+* **k8s:** do not cache duplicate logs in Run and Test results ([#6927](https://github.com/garden-io/garden/issues/6927))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 
+<a name="0.13.55"></a>
+## [0.13.55](https://github.com/garden-io/garden/compare/0.13.54...0.13.55) (2025-03-11)
+
+### Bug Fixes
+
+* do not store duplicate logs in cache ([bf5e1a63e](https://github.com/garden-io/garden/commit/bf5e1a63e))
+* change field name of helm-pod result details to match its semantics ([98c15c32c](https://github.com/garden-io/garden/commit/98c15c32c))
+* improve error message when servicePort does not reference a port by name ([#6894](https://github.com/garden-io/garden/issues/6894)) ([6e0cf71c5](https://github.com/garden-io/garden/commit/6e0cf71c5))
+* **build-staging:** fix the detection of paths to be deleted ([#6904](https://github.com/garden-io/garden/issues/6904)) ([ee976ad2b](https://github.com/garden-io/garden/commit/ee976ad2b))
+* **config:** throw validation errors when encountering unknown keys in action configs ([#6875](https://github.com/garden-io/garden/issues/6875)) ([06448a086](https://github.com/garden-io/garden/commit/06448a086))
+* **core:** always suppress logs when `--output` is used ([#6909](https://github.com/garden-io/garden/issues/6909)) ([3434a55dd](https://github.com/garden-io/garden/commit/3434a55dd))
+* **docs:** propagate correct action kind to k8s Run/Test reference docs ([#6923](https://github.com/garden-io/garden/issues/6923)) ([08b0eeaa6](https://github.com/garden-io/garden/commit/08b0eeaa6))
+* **k8s:** respect `spec.cacheResult` flag in `kubernetes-pod` Test actions ([6de41aa3b](https://github.com/garden-io/garden/commit/6de41aa3b))
+
+### Features
+
+* **cli:** add more fields to garden get actions detailed output ([#6903](https://github.com/garden-io/garden/issues/6903)) ([1f4de4e3b](https://github.com/garden-io/garden/commit/1f4de4e3b))
+* **container:** add `cacheResult` config option  for `container` Test actions ([#6925](https://github.com/garden-io/garden/issues/6925)) ([6c0f8f019](https://github.com/garden-io/garden/commit/6c0f8f019))
+
+### Improvements
+
+* **k8s:** improve logs when maximum retry attempts exceeded ([#6888](https://github.com/garden-io/garden/issues/6888)) ([305958e5a](https://github.com/garden-io/garden/commit/305958e5a))
+
 <a name="0.13.54"></a>
 ## [0.13.54](https://github.com/garden-io/garden/compare/0.13.53...0.13.54) (2025-02-20)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _If you love Garden, please ★ star this repository to show your support :green
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://docs.garden.io/?utm_source=github">Docs</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://github.com/garden-io/garden/tree/0.13.54/examples">Examples</a>
+  <a href="https://github.com/garden-io/garden/tree/0.13.55/examples">Examples</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://garden.io/blog/?utm_source=github">Blog</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/cli",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Cloud native testing platform for testing and developing container applications on Kubernetes",
   "type": "module",
   "repository": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/core",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "A full-featured development framework for containers and serverless",
   "type": "module",
   "repository": {

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -111,6 +111,6 @@ If you'd like to better understand how a Garden project is configured, we recomm
 through our [first project tutorial](../tutorials/your-first-project/README.md) which walks you through configuring a Garden project step-by-step.
 
 If you like to dive right in and configure your own project for Garden, we recommend referencing our [example
-projects on GitHub](https://github.com/garden-io/garden/tree/0.13.54/examples) and the section of our docs title [Using Garden](../using-garden/configuration-overview.md), which covers all parts of Garden in detail.
+projects on GitHub](https://github.com/garden-io/garden/tree/0.13.55/examples) and the section of our docs title [Using Garden](../using-garden/configuration-overview.md), which covers all parts of Garden in detail.
 
 If you have any questions or feedback—or just want to say hi 🙂—we encourage you to join our [Discord community](https://go.garden.io/discord)!

--- a/docs/guides/using-garden-in-circleci.md
+++ b/docs/guides/using-garden-in-circleci.md
@@ -11,7 +11,7 @@ For the purposes of this example we'll be using [CircleCI](https://circleci.com)
 
 ## Project overview
 
-The project is based on our basic [demo-project](https://github.com/garden-io/garden/tree/0.13.54/examples/demo-project) example, but configured for multiple environments. Additionally it contains a CircleCI config file. You'll find the entire source code [here](https://github.com/garden-io/ci-demo-project).
+The project is based on our basic [demo-project](https://github.com/garden-io/garden/tree/0.13.55/examples/demo-project) example, but configured for multiple environments. Additionally it contains a CircleCI config file. You'll find the entire source code [here](https://github.com/garden-io/ci-demo-project).
 
 The CI pipeline is configured so that Garden tests the project and deploys it to a **preview** environment on every pull request. Additionally, it tests the project and deploys it to a separate **staging** environment on every merge to the `main` branch.
 

--- a/docs/k8s-plugins/actions/deploy/kubernetes.md
+++ b/docs/k8s-plugins/actions/deploy/kubernetes.md
@@ -228,7 +228,7 @@ spec:
 
 With this approach, you can add the Garden action to your project without making any changes to existing config.
 
-Here's a [complete example project](https://github.com/garden-io/garden/tree/0.13.54/examples/k8s-deploy-patch-resources) using this approach.
+Here's a [complete example project](https://github.com/garden-io/garden/tree/0.13.55/examples/k8s-deploy-patch-resources) using this approach.
 
 ### Option 2: Using Garden template strings
 
@@ -259,7 +259,7 @@ spec:
           image: ${actions.build.api.outputs.deployment-image-id} # <--- Garden will resolve this to the correct image before applying the manifest
 ```
 
-Here's a [complete example](https://github.com/garden-io/garden/tree/0.13.54/examples/k8s-deploy-shared-manifests) using this approach. The downside though is that this is no longer a valid Kubernetes manifest.
+Here's a [complete example](https://github.com/garden-io/garden/tree/0.13.55/examples/k8s-deploy-shared-manifests) using this approach. The downside though is that this is no longer a valid Kubernetes manifest.
 
 Similarly, if you define your manifest inline you can set the image like so:
 

--- a/docs/k8s-plugins/remote-k8s/ingress-and-dns.md
+++ b/docs/k8s-plugins/remote-k8s/ingress-and-dns.md
@@ -5,7 +5,7 @@ order: 3
 
 # 3. Set Up Ingress, TLS and DNS
 
-By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/). You can find an example for [using Garden with Istio](https://github.com/garden-io/garden/tree/0.13.54/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/0.13.54/examples).
+By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/). You can find an example for [using Garden with Istio](https://github.com/garden-io/garden/tree/0.13.55/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/0.13.55/examples).
 
 You'll also need to point one or more DNS entries to your cluster, and configure a TLS certificate for the hostnames
 you will expose for ingress.

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -7,7 +7,7 @@ tocTitle: "`jib-container` Build"
 
 ## Description
 
-Extends the [container type](./container.md) to build the image with [Jib](https://github.com/GoogleContainerTools/jib). Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.13.54/examples/jib-container) to see it in action.
+Extends the [container type](./container.md) to build the image with [Jib](https://github.com/GoogleContainerTools/jib). Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.13.55/examples/jib-container) to see it in action.
 
 The image is always built locally, directly from the source directory (see the note on that below), before shipping the container image to the right place. You can set `build.tarOnly: true` to only build the image as a tarball.
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -11,7 +11,7 @@ Modules are deprecated and will be removed in version `0.14`. Please use [action
 
 ## Description
 
-Extends the [container type](./container.md) to build the image with [Jib](https://github.com/GoogleContainerTools/jib). Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.13.54/examples/jib-container) to see it in action.
+Extends the [container type](./container.md) to build the image with [Jib](https://github.com/GoogleContainerTools/jib). Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.13.55/examples/jib-container) to see it in action.
 
 The image is always built locally, directly from the source directory (see the note on that below), before shipping the container image to the right place. You can set `build.tarOnly: true` to only build the image as a tarball.
 

--- a/docs/reference/providers/conftest-kubernetes.md
+++ b/docs/reference/providers/conftest-kubernetes.md
@@ -14,7 +14,7 @@ Simply add this provider to your project configuration, and configure your polic
 reference for how to configure default policies, default namespaces, and test failure thresholds for the generated
 actions.
 
-See the [conftest example project](https://github.com/garden-io/garden/tree/0.13.54/examples/conftest) for a simple
+See the [conftest example project](https://github.com/garden-io/garden/tree/0.13.55/examples/conftest) for a simple
 usage example.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).

--- a/docs/reference/providers/conftest.md
+++ b/docs/reference/providers/conftest.md
@@ -9,7 +9,7 @@ tocTitle: "`conftest`"
 
 This provider allows you to validate your configuration files against policies that you specify, using the [conftest tool](https://github.com/open-policy-agent/conftest) and Open Policy Agent rego query files. The provider creates Test action types of the same name, which allow you to specify files to validate.
 
-Note that, in many cases, you'll actually want to use more specific providers that can automatically configure your `conftest` actions, e.g. the [`conftest-container`](./conftest-container.md) and/or [`conftest-kubernetes`](./conftest-kubernetes.md) providers. See the [conftest example project](https://github.com/garden-io/garden/tree/0.13.54/examples/conftest) for a simple usage example of the latter.
+Note that, in many cases, you'll actually want to use more specific providers that can automatically configure your `conftest` actions, e.g. the [`conftest-container`](./conftest-container.md) and/or [`conftest-kubernetes`](./conftest-kubernetes.md) providers. See the [conftest example project](https://github.com/garden-io/garden/tree/0.13.55/examples/conftest) for a simple usage example of the latter.
 
 If those don't match your needs, you can use this provider directly and manually configure your `conftest` actions. Simply add this provider to your project configuration, and see the [conftest action documentation](../action-types/Test/conftest.md) for a detailed reference. Also, check out the below reference for how to configure default policies, default namespaces, and test failure thresholds for all `conftest` actions.
 

--- a/docs/reference/providers/hadolint.md
+++ b/docs/reference/providers/hadolint.md
@@ -11,7 +11,7 @@ This provider creates a [`hadolint`](../action-types/Test/hadolint.md) Test acti
 
 To configure `hadolint`, you can use `.hadolint.yaml` config files. For each Test, we first look for one in the relevant action's root. If none is found there, we check the project root, and if none is there we fall back to default configuration. Note that for reasons of portability, we do not fall back to global/user configuration files.
 
-See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it, and the [hadolint example project](https://github.com/garden-io/garden/tree/0.13.54/examples/hadolint) for a usage example.
+See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it, and the [hadolint example project](https://github.com/garden-io/garden/tree/0.13.55/examples/hadolint) for a usage example.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 

--- a/docs/reference/providers/jib.md
+++ b/docs/reference/providers/jib.md
@@ -11,7 +11,7 @@ tocTitle: "`jib`"
 
 Provides support for [Jib](https://github.com/GoogleContainerTools/jib) via the [jib action type](../action-types/Build/jib-container.md).
 
-Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.13.54/examples/jib-container) to see it in action.
+Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.13.55/examples/jib-container) to see it in action.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 

--- a/docs/terraform-plugin/about.md
+++ b/docs/terraform-plugin/about.md
@@ -15,7 +15,7 @@ Under the hood, Garden simply wraps Terraform, so there's no magic involved. Gar
 
 Terraform resources can be provisioned through the `terraform` provider when initializing Garden, or via `terraform` actions that are utilized like other actions in your stack.
 
-The former, having a single Terraform stack for your whole project, is most helpful if other provider configurations need to reference the outputs from your Terraform stack, or if most/all of your services depend on the infrastructure provisioned in your Terraform stack. A good example of this is the [terraform-gke example](https://github.com/garden-io/garden/tree/0.13.54/examples/terraform-gke) project, which provisions a GKE cluster that the `kubernetes` provider then runs on, along with the services in the project. The drawback is that Garden doesn't currently watch for changes in those Terraform files, and you need to restart to apply new changes, or apply them manually.
+The former, having a single Terraform stack for your whole project, is most helpful if other provider configurations need to reference the outputs from your Terraform stack, or if most/all of your services depend on the infrastructure provisioned in your Terraform stack. A good example of this is the [terraform-gke example](https://github.com/garden-io/garden/tree/0.13.55/examples/terraform-gke) project, which provisions a GKE cluster that the `kubernetes` provider then runs on, along with the services in the project. The drawback is that Garden doesn't currently watch for changes in those Terraform files, and you need to restart to apply new changes, or apply them manually.
 
 Using `terraform` _Deploy actions_, can be better if your other providers don't need to reference the stack outputs but other Deploy, Run and Test actions do. In this style, you can basically create small Terraform stacks that are part of your Stack Graph much like other services. A good example would be deploying a database instance, that other services in your project can then connect to.
 
@@ -58,5 +58,5 @@ multiple AWS labmdas that should each have their own stack), check out [the Terr
 ## Next steps
 
 Check out how to configure the Terraform provider and/or actions in the following pages.
-You'll find some [Terraform examples here](https://github.com/garden-io/garden/tree/0.13.54/examples).
+You'll find some [Terraform examples here](https://github.com/garden-io/garden/tree/0.13.55/examples).
 

--- a/docs/terraform-plugin/configure-provider.md
+++ b/docs/terraform-plugin/configure-provider.md
@@ -17,7 +17,7 @@ providers:
   ...
 ```
 
-If you'd like to apply the stack when starting Garden, and then reference the stack outputs in other providers (or actions), you need to add a couple of more flags. Here's the project config from the aforementioned [terraform-gke example](https://github.com/garden-io/garden/tree/0.13.54/examples/terraform-gke):
+If you'd like to apply the stack when starting Garden, and then reference the stack outputs in other providers (or actions), you need to add a couple of more flags. Here's the project config from the aforementioned [terraform-gke example](https://github.com/garden-io/garden/tree/0.13.55/examples/terraform-gke):
 
 ```yaml
 apiVersion: garden.io/v1

--- a/docs/use-cases/jumpstart-idp.md
+++ b/docs/use-cases/jumpstart-idp.md
@@ -39,6 +39,6 @@ Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Ga
 
 ## Examples
 
-- [Remote sources example project](https://github.com/garden-io/garden/tree/0.13.54/examples/remote-sources)
+- [Remote sources example project](https://github.com/garden-io/garden/tree/0.13.55/examples/remote-sources)
 
-- [kubernetes Deploy action type example with config templates](https://github.com/garden-io/garden/tree/0.13.54/examples/k8s-deploy-config-templates)
+- [kubernetes Deploy action type example with config templates](https://github.com/garden-io/garden/tree/0.13.55/examples/k8s-deploy-config-templates)

--- a/docs/use-cases/local-development-remote-clusters.md
+++ b/docs/use-cases/local-development-remote-clusters.md
@@ -61,5 +61,5 @@ Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Ga
 
 ## Examples
 
-- [Kubernetes Deploy action example project](https://github.com/garden-io/garden/tree/0.13.54/examples/k8s-deploy-patch-resources)
-- [Local mode for `kubernetes` action type](https://github.com/garden-io/garden/tree/0.13.54/examples/local-mode-k8s)
+- [Kubernetes Deploy action example project](https://github.com/garden-io/garden/tree/0.13.55/examples/k8s-deploy-patch-resources)
+- [Local mode for `kubernetes` action type](https://github.com/garden-io/garden/tree/0.13.55/examples/local-mode-k8s)

--- a/docs/use-cases/on-demand-preview-envs.md
+++ b/docs/use-cases/on-demand-preview-envs.md
@@ -60,4 +60,4 @@ Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Ga
 
 ## Examples
 
-- [Kubernetes Deploy action example project](https://github.com/garden-io/garden/tree/0.13.54/examples/k8s-deploy-patch-resources)
+- [Kubernetes Deploy action example project](https://github.com/garden-io/garden/tree/0.13.55/examples/k8s-deploy-patch-resources)

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/e2e",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "End-to-end tests for the Garden CLI",
   "type": "module",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garden",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garden",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "workspaces": [
         "cli",
@@ -81,7 +81,7 @@
     },
     "cli": {
       "name": "@garden-io/cli",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -1095,7 +1095,7 @@
     },
     "core": {
       "name": "@garden-io/core",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@codenamize/codenamize": "^1.1.1",
@@ -5210,7 +5210,7 @@
     },
     "e2e": {
       "name": "@garden-io/e2e",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/cli": "*",
@@ -43291,7 +43291,7 @@
     },
     "plugins/conftest": {
       "name": "@garden-io/garden-conftest",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -43311,7 +43311,7 @@
     },
     "plugins/conftest-container": {
       "name": "@garden-io/garden-conftest-container",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -44333,7 +44333,7 @@
     },
     "plugins/conftest-kubernetes": {
       "name": "@garden-io/garden-conftest-kubernetes",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -46310,7 +46310,7 @@
     },
     "plugins/jib": {
       "name": "@garden-io/garden-jib",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -47327,7 +47327,7 @@
     },
     "plugins/pulumi": {
       "name": "@garden-io/garden-pulumi",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -48361,7 +48361,7 @@
     },
     "plugins/terraform": {
       "name": "@garden-io/garden-terraform",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",
@@ -49409,7 +49409,7 @@
     },
     "sdk": {
       "name": "@garden-io/sdk",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "license": "MPL-2.0",
       "dependencies": {
         "@garden-io/core": "*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/garden-io/garden.git"
   },
-  "version": "0.13.54",
+  "version": "0.13.55",
   "author": "Garden Technologies, Inc. <info@garden.io>",
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",

--- a/plugins/conftest-container/package.json
+++ b/plugins/conftest-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-conftest-container",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Auto-generator for the conftest plugin and Garden container modules",
   "type": "module",
   "main": "build/src/index.js",

--- a/plugins/conftest-kubernetes/package.json
+++ b/plugins/conftest-kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-conftest-kubernetes",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Auto-generator for the conftest plugin and Garden kubernetes/helm modules",
   "type": "module",
   "main": "build/src/index.js",

--- a/plugins/conftest/package.json
+++ b/plugins/conftest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-conftest",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "conftest plugin for Garden",
   "type": "module",
   "main": "build/src/index.js",

--- a/plugins/jib/package.json
+++ b/plugins/jib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-jib",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Jib container plugin for Garden",
   "type": "module",
   "main": "build/src/index.js",

--- a/plugins/pulumi/package.json
+++ b/plugins/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-pulumi",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Pulumi plugin for Garden",
   "type": "module",
   "main": "build/src/index.js",

--- a/plugins/terraform/package.json
+++ b/plugins/terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-terraform",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Terraform plugin for Garden",
   "type": "module",
   "main": "build/src/index.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/sdk",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "TypeScript plugin SDK for Garden",
   "type": "module",
   "repository": {


### PR DESCRIPTION
# Garden 0.13.55 is out! :tada:

This is a maintenance release that includes some bug fixes, features, and improvements.

Garden 0.14 (Cedar) will be out soon, and this release of 0.13 (Bonsai) will warn you when you're relying on functionality that will be removed or that will be changed in the upcoming Garden 0.14 (Cedar) release.
If you're seeing such warnings, we recommend to follow the steps behind the link to silence them.

For the complete list of breaking changes in Garden 0.14, please refer to the [Deprecations and updating to Cedar](https://docs.garden.io/bonsai-0.13/guides/deprecations) guide in the docs.

Many thanks to @klara-meyer for contributing #6903 to this release!

## Assets

Download the Garden binary for your platform from below or simply run `garden self-update` if you already have it installed.

* [Garden v0.13.55 for Alpine AMD64 (tar.gz)](https://download.garden.io/core/0.13.55/garden-0.13.55-alpine-amd64.tar.gz)
* [Garden v0.13.55 for Linux AMD64 (tar.gz)](https://download.garden.io/core/0.13.55/garden-0.13.55-linux-amd64.tar.gz)
* [Garden v0.13.55 for Linux ARM64 (tar.gz)](https://download.garden.io/core/0.13.55/garden-0.13.55-linux-arm64.tar.gz)
* [Garden v0.13.55 for MacOS AMD64 (tar.gz)](https://download.garden.io/core/0.13.55/garden-0.13.55-macos-amd64.tar.gz)
* [Garden v0.13.55 for MacOS ARM64 (tar.gz)](https://download.garden.io/core/0.13.55/garden-0.13.55-macos-arm64.tar.gz)
* [Garden v0.13.55 for Windows AMD64 (.zip)](https://download.garden.io/core/0.13.55/garden-0.13.55-windows-amd64.zip)

## Changelog

<a name="0.13.55"></a>
## [0.13.55](https://github.com/garden-io/garden/compare/0.13.54...0.13.55) (2025-03-11)

### Bug Fixes

* **build-staging:** fix the detection of paths to be deleted ([#6904](https://github.com/garden-io/garden/issues/6904)) ([ee976ad2b](https://github.com/garden-io/garden/commit/ee976ad2b))
* **config:** throw validation errors when encountering unknown keys in action configs ([#6875](https://github.com/garden-io/garden/issues/6875)) ([06448a086](https://github.com/garden-io/garden/commit/06448a086))
* **core:** always suppress logs when `--output` is used ([#6909](https://github.com/garden-io/garden/issues/6909)) ([3434a55dd](https://github.com/garden-io/garden/commit/3434a55dd))
* **docs:** propagate correct action kind to k8s Run/Test reference docs ([#6923](https://github.com/garden-io/garden/issues/6923)) ([08b0eeaa6](https://github.com/garden-io/garden/commit/08b0eeaa6))
* **k8s:** improve error message when servicePort does not reference a port by name ([#6894](https://github.com/garden-io/garden/issues/6894)) ([6e0cf71c5](https://github.com/garden-io/garden/commit/6e0cf71c5))
* **k8s:** respect `spec.cacheResult` flag in `kubernetes-pod` Test actions ([6de41aa3b](https://github.com/garden-io/garden/commit/6de41aa3b))
* **k8s:** change field name of helm-pod result details to match its semantics ([98c15c32c](https://github.com/garden-io/garden/commit/98c15c32c))
* **k8s:** do not store duplicate logs in cache ([bf5e1a63e](https://github.com/garden-io/garden/commit/bf5e1a63e))

### Features

* **cli:** add more fields to garden get actions detailed output ([#6903](https://github.com/garden-io/garden/issues/6903)) ([1f4de4e3b](https://github.com/garden-io/garden/commit/1f4de4e3b))
* **container:** add `cacheResult` config option  for `container` Test actions ([#6925](https://github.com/garden-io/garden/issues/6925)) ([6c0f8f019](https://github.com/garden-io/garden/commit/6c0f8f019))

### Improvements

* **k8s:** improve logs when maximum retry attempts exceeded ([#6888](https://github.com/garden-io/garden/issues/6888)) ([305958e5a](https://github.com/garden-io/garden/commit/305958e5a))
