### PR TITLE
refactor(k8s): introduce cache abstraction for `getResult` handlers of Run and Test actions

### DIFF
--- a/core/src/plugins/kubernetes/container/run.ts
+++ b/core/src/plugins/kubernetes/container/run.ts
@@ -9,12 +9,12 @@
 import type { ContainerRunAction } from "../../container/moduleConfig.js"
 import { runAndCopy } from "../run.js"
 import type { KubernetesPluginContext } from "../config.js"
-import { composeCacheableRunResult, toRunActionStatus } from "../run-results.js"
-import { storeRunResult } from "../run-results.js"
+import { composeCacheableRunResult, runResultCache } from "../run-results.js"
 import { makePodName } from "../util.js"
 import { getNamespaceStatus } from "../namespace.js"
 import type { RunActionHandler } from "../../../plugin/action-types.js"
 import { getDeployedImageId } from "./util.js"
+import { toActionStatus } from "../results-cache.js"
 
 export const k8sContainerRun: RunActionHandler<"run", ContainerRunAction> = async (params) => {
   const { ctx, log, action } = params
@@ -46,7 +46,7 @@ export const k8sContainerRun: RunActionHandler<"run", ContainerRunAction> = asyn
   const detail = composeCacheableRunResult({ result, action, namespaceStatus })
 
   if (action.getSpec("cacheResult")) {
-    await storeRunResult({
+    await runResultCache.store({
       ctx,
       log,
       action,
@@ -54,5 +54,5 @@ export const k8sContainerRun: RunActionHandler<"run", ContainerRunAction> = asyn
     })
   }
 
-  return toRunActionStatus(detail)
+  return toActionStatus(detail)
 }

--- a/core/src/plugins/kubernetes/container/test.ts
+++ b/core/src/plugins/kubernetes/container/test.ts
@@ -7,14 +7,14 @@
  */
 
 import type { ContainerTestAction } from "../../container/moduleConfig.js"
-import { composeCacheableTestResult, toTestActionStatus } from "../test-results.js"
-import { storeTestResult } from "../test-results.js"
+import { composeCacheableTestResult, testResultCache } from "../test-results.js"
 import { runAndCopy } from "../run.js"
 import { makePodName } from "../util.js"
 import { getNamespaceStatus } from "../namespace.js"
 import type { KubernetesPluginContext } from "../config.js"
 import type { TestActionHandler } from "../../../plugin/action-types.js"
 import { getDeployedImageId } from "./util.js"
+import { toActionStatus } from "../results-cache.js"
 
 export const k8sContainerTest: TestActionHandler<"run", ContainerTestAction> = async (params) => {
   const { ctx, log, action } = params
@@ -46,7 +46,7 @@ export const k8sContainerTest: TestActionHandler<"run", ContainerTestAction> = a
   const detail = composeCacheableTestResult({ result, action, namespaceStatus })
 
   if (action.getSpec("cacheResult")) {
-    await storeTestResult({
+    await testResultCache.store({
       ctx,
       log,
       action,
@@ -54,5 +54,5 @@ export const k8sContainerTest: TestActionHandler<"run", ContainerTestAction> = a
     })
   }
 
-  return toTestActionStatus(detail)
+  return toActionStatus(detail)
 }

--- a/core/src/plugins/kubernetes/helm/helm-pod.ts
+++ b/core/src/plugins/kubernetes/helm/helm-pod.ts
@@ -14,16 +14,16 @@ import type { RunActionDefinition, TestActionDefinition } from "../../../plugin/
 import type { CommonRunParams } from "../../../plugin/handlers/Run/run.js"
 import type { KubernetesPluginContext } from "../config.js"
 import { getActionNamespaceStatus } from "../namespace.js"
-import { composeCacheableRunResult, toRunActionStatus } from "../run-results.js"
-import { k8sGetRunResult, storeRunResult } from "../run-results.js"
+import { composeCacheableRunResult, runResultCache } from "../run-results.js"
+import { k8sGetRunResult } from "../run-results.js"
 import { getResourceContainer, getResourcePodSpec, getTargetResource, makePodName } from "../util.js"
 import type { HelmPodRunAction, HelmPodTestAction } from "./config.js"
 import { helmPodRunSchema } from "./config.js"
 import { runAndCopy } from "../run.js"
 import { filterManifests, prepareManifests, prepareTemplates } from "./common.js"
-import { composeCacheableTestResult, toTestActionStatus } from "../test-results.js"
-import { storeTestResult } from "../test-results.js"
+import { composeCacheableTestResult, testResultCache } from "../test-results.js"
 import { kubernetesRunOutputsSchema } from "../kubernetes-type/config.js"
+import { toActionStatus } from "../results-cache.js"
 
 const helmRunPodOutputsSchema = kubernetesRunOutputsSchema
 const helmTestPodOutputsSchema = helmRunPodOutputsSchema
@@ -54,7 +54,7 @@ export const helmPodRunDefinition = (): RunActionDefinition<HelmPodRunAction> =>
       const detail = composeCacheableRunResult({ result, action, namespaceStatus })
 
       if (action.getSpec("cacheResult")) {
-        await storeRunResult({
+        await runResultCache.store({
           ctx,
           log,
           action,
@@ -62,7 +62,7 @@ export const helmPodRunDefinition = (): RunActionDefinition<HelmPodRunAction> =>
         })
       }
 
-      return toRunActionStatus(detail)
+      return toActionStatus(detail)
     },
 
     getResult: k8sGetRunResult,
@@ -95,7 +95,7 @@ export const helmPodTestDefinition = (): TestActionDefinition<HelmPodTestAction>
       const detail = composeCacheableTestResult({ result, action, namespaceStatus })
 
       if (action.getSpec("cacheResult")) {
-        await storeTestResult({
+        await testResultCache.store({
           ctx,
           log,
           action,
@@ -103,7 +103,7 @@ export const helmPodTestDefinition = (): TestActionDefinition<HelmPodTestAction>
         })
       }
 
-      return toTestActionStatus(detail)
+      return toActionStatus(detail)
     },
 
     getResult: k8sGetRunResult,

--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
@@ -8,8 +8,8 @@
 
 import type { KubernetesCommonRunSpec, KubernetesPluginContext, KubernetesTargetResourceSpec } from "../config.js"
 import { kubernetesCommonRunSchemaKeys, runPodResourceSchema, runPodSpecSchema } from "../config.js"
-import { composeCacheableRunResult, toRunActionStatus } from "../run-results.js"
-import { k8sGetRunResult, storeRunResult } from "../run-results.js"
+import { composeCacheableRunResult, runResultCache } from "../run-results.js"
+import { k8sGetRunResult } from "../run-results.js"
 import { getActionNamespaceStatus } from "../namespace.js"
 import type { ActionKind, RunActionDefinition, TestActionDefinition } from "../../../plugin/action-types.js"
 import { dedent } from "../../../util/string.js"
@@ -31,8 +31,9 @@ import type { KubernetesKustomizeSpec } from "./kustomize.js"
 import { kustomizeSpecSchema } from "./kustomize.js"
 import type { ObjectSchema } from "@hapi/joi"
 import type { TestActionConfig, TestAction } from "../../../actions/test.js"
-import { composeCacheableTestResult, toTestActionStatus } from "../test-results.js"
-import { storeTestResult, k8sGetTestResult } from "../test-results.js"
+import { composeCacheableTestResult, testResultCache } from "../test-results.js"
+import { k8sGetTestResult } from "../test-results.js"
+import { toActionStatus } from "../results-cache.js"
 
 // RUN //
 
@@ -120,7 +121,7 @@ export const kubernetesPodRunDefinition = (): RunActionDefinition<KubernetesPodR
       const detail = composeCacheableRunResult({ result, action, namespaceStatus })
 
       if (action.getSpec("cacheResult")) {
-        await storeRunResult({
+        await runResultCache.store({
           ctx,
           log,
           action,
@@ -128,7 +129,7 @@ export const kubernetesPodRunDefinition = (): RunActionDefinition<KubernetesPodR
         })
       }
 
-      return toRunActionStatus(detail)
+      return toActionStatus(detail)
     },
 
     getResult: k8sGetRunResult,
@@ -167,7 +168,7 @@ export const kubernetesPodTestDefinition = (): TestActionDefinition<KubernetesPo
       const detail = composeCacheableTestResult({ result, action, namespaceStatus })
 
       if (action.getSpec("cacheResult")) {
-        await storeTestResult({
+        await testResultCache.store({
           ctx,
           log,
           action,
@@ -175,7 +176,7 @@ export const kubernetesPodTestDefinition = (): TestActionDefinition<KubernetesPo
         })
       }
 
-      return toTestActionStatus(detail)
+      return toActionStatus(detail)
     },
 
     getResult: k8sGetTestResult,

--- a/core/src/plugins/kubernetes/results-cache.ts
+++ b/core/src/plugins/kubernetes/results-cache.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018-2024 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { PluginContext } from "../../plugin-context.js"
+import type { Log } from "../../logger/log-entry.js"
+import type { Action, ActionStatus } from "../../actions/types.js"
+import type { RunResult } from "../../plugin/base.js"
+import type { NamespaceStatus } from "../../types/namespace.js"
+import type { RunAction } from "../../actions/run.js"
+import type { TestAction } from "../../actions/test.js"
+import { runResultToActionState } from "../../actions/base.js"
+
+export type CacheableResult = RunResult & {
+  namespaceStatus: NamespaceStatus
+  actionName: string
+}
+
+export interface LoadResultParams<A extends RunAction | TestAction> {
+  ctx: PluginContext
+  log: Log
+  action: A
+}
+
+export type ClearResultParams<A extends RunAction | TestAction> = LoadResultParams<A>
+
+export interface StoreResultParams<A extends RunAction | TestAction, R extends CacheableResult> {
+  ctx: PluginContext
+  log: Log
+  action: A
+  result: R
+}
+
+export function composeCacheableResult({
+  result,
+  action,
+  namespaceStatus,
+}: {
+  result: RunResult
+  action: Action
+  namespaceStatus: NamespaceStatus
+}): CacheableResult {
+  return {
+    ...result,
+    namespaceStatus,
+    actionName: action.name,
+  }
+}
+
+export function toActionStatus<T extends CacheableResult>(detail: T): ActionStatus {
+  return { state: runResultToActionState(detail), detail, outputs: { log: detail.log } }
+}
+
+export interface ResultCache<A extends RunAction | TestAction, R extends CacheableResult> {
+  load(params: LoadResultParams<A>): Promise<R | undefined>
+
+  store(params: StoreResultParams<A, R>): Promise<R>
+
+  clear(param: ClearResultParams<A>): Promise<void>
+}

--- a/core/src/plugins/kubernetes/run-results.ts
+++ b/core/src/plugins/kubernetes/run-results.ts
@@ -12,170 +12,149 @@ import { KubeApi, KubernetesError } from "./api.js"
 import { getAppNamespace } from "./namespace.js"
 import { deserializeValues } from "../../util/serialization.js"
 import type { PluginContext } from "../../plugin-context.js"
-import type { Log } from "../../logger/log-entry.js"
 import { gardenAnnotationKey } from "../../util/string.js"
 import { hashSync } from "hasha"
 import { upsertConfigMap } from "./util.js"
 import { trimRunOutput } from "./helm/common.js"
-import { runResultToActionState } from "../../actions/base.js"
-import type { Action, ActionStatus } from "../../actions/types.js"
+import type { Action } from "../../actions/types.js"
 import type { RunResult } from "../../plugin/base.js"
 import type { RunActionHandler } from "../../plugin/action-types.js"
 import type { HelmPodRunAction } from "./helm/config.js"
 import type { KubernetesRunAction } from "./kubernetes-type/config.js"
 import { GardenError } from "../../exceptions.js"
 import type { NamespaceStatus } from "../../types/namespace.js"
+import type {
+  CacheableResult,
+  ClearResultParams,
+  LoadResultParams,
+  ResultCache,
+  StoreResultParams,
+} from "./results-cache.js"
+import { toActionStatus } from "./results-cache.js"
+import { composeCacheableResult } from "./results-cache.js"
 
 // TODO: figure out how to get rid of the any cast here
 export const k8sGetRunResult: RunActionHandler<"getResult", any> = async (params) => {
   const { action, ctx, log } = params
-  const cachedResult = await loadRunResult({ action, ctx, log })
+  const cachedResult = await runResultCache.load({ action, ctx, log })
 
   if (!cachedResult) {
     return { state: "not-ready", detail: null, outputs: { log: "" } }
   }
 
-  return toRunActionStatus(cachedResult)
-}
-
-export function getRunResultKey(ctx: PluginContext, action: Action) {
-  // change the result format version if the result format changes breaking backwards-compatibility e.g. serialization format
-  const resultFormatVersion = 2
-  const key = `${ctx.projectName}--${action.type}.${action.name}--${action.versionString()}--${resultFormatVersion}`
-  const hash = hashSync(key, { algorithm: "sha1" })
-  return `run-result--${hash.slice(0, 32)}`
+  return toActionStatus(cachedResult)
 }
 
 export type CacheableRunAction = ContainerRunAction | KubernetesRunAction | HelmPodRunAction
 
-interface LoadRunResultParams {
-  ctx: PluginContext
-  log: Log
-  action: CacheableRunAction
-}
-
-export async function loadRunResult(params: LoadRunResultParams): Promise<CacheableRunResult | undefined> {
-  const { action, ctx, log } = params
-  const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
-  const runResultNamespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
-  const resultKey = getRunResultKey(ctx, action)
-
-  try {
-    const res = await api.core.readNamespacedConfigMap({ name: resultKey, namespace: runResultNamespace })
-    const result = deserializeValues(res.data!)
-    return result as CacheableRunResult
-  } catch (err) {
-    if (!(err instanceof KubernetesError)) {
-      throw err
-    }
-    if (err.responseStatusCode === 404) {
-      return undefined
-    } else {
-      throw err
-    }
-  }
-}
-
-interface StoreRunResultParams {
-  ctx: PluginContext
-  log: Log
-  action: CacheableRunAction
-  result: CacheableRunResult
-}
-
-export type CacheableRunResult = RunResult & {
-  namespaceStatus: NamespaceStatus
-  actionName: string
+export type CacheableRunResult = CacheableResult & {
   /**
    * @deprecated use {@link #actionName} instead
    */
   taskName: string
 }
 
-export function composeCacheableRunResult({
-  result,
-  action,
-  namespaceStatus,
-}: {
+export function composeCacheableRunResult(params: {
   result: RunResult
   action: Action
   namespaceStatus: NamespaceStatus
 }): CacheableRunResult {
+  const result = composeCacheableResult(params)
   return {
     ...result,
-    namespaceStatus,
-    actionName: action.name,
-    taskName: action.name,
+    taskName: result.actionName,
   }
 }
 
-export function toRunActionStatus(detail: CacheableRunResult): ActionStatus {
-  return { state: runResultToActionState(detail), detail, outputs: { log: detail.log } }
-}
+export class RunResultCache implements ResultCache<CacheableRunAction, CacheableRunResult> {
+  public async load({
+    action,
+    ctx,
+    log,
+  }: LoadResultParams<CacheableRunAction>): Promise<CacheableRunResult | undefined> {
+    const k8sCtx = <KubernetesPluginContext>ctx
+    const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
+    const runResultNamespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
+    const resultKey = this.cacheKey(ctx, action)
 
-/**
- * Store a task run result as a ConfigMap in the cluster.
- *
- * TODO: Implement a CRD for this.
- */
-export async function storeRunResult({ ctx, log, action, result }: StoreRunResultParams): Promise<CacheableRunResult> {
-  const k8sCtx = ctx as KubernetesPluginContext
-  const provider = ctx.provider as KubernetesProvider
-  const api = await KubeApi.factory(log, k8sCtx, provider)
-  const runResultNamespace = await getAppNamespace(k8sCtx, log, provider)
-
-  // FIXME: We should store the logs separately, because of the 1MB size limit on ConfigMaps.
-  const data = trimRunOutput(result)
-
-  try {
-    await upsertConfigMap({
-      api,
-      namespace: runResultNamespace,
-      key: getRunResultKey(ctx, action),
-      labels: {
-        [gardenAnnotationKey("action")]: action.key(),
-        [gardenAnnotationKey("actionType")]: action.type,
-        [gardenAnnotationKey("version")]: action.versionString(),
-      },
-      data,
-    })
-  } catch (err) {
-    if (!(err instanceof GardenError)) {
-      throw err
-    }
-    log.warn(`Unable to store run result: ${err}`)
-  }
-
-  return data
-}
-
-/**
- * Clear the stored result for the given task. No-op if no result had been stored for it.
- */
-export async function clearRunResult({
-  ctx,
-  log,
-  action,
-}: {
-  ctx: PluginContext
-  log: Log
-  action: Action
-}): Promise<void> {
-  const provider = <KubernetesProvider>ctx.provider
-  const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = await getAppNamespace(ctx as KubernetesPluginContext, log, provider)
-
-  const key = getRunResultKey(ctx, action)
-
-  try {
-    await api.core.deleteNamespacedConfigMap({ name: key, namespace })
-  } catch (err) {
-    if (!(err instanceof KubernetesError)) {
-      throw err
-    }
-    if (err.responseStatusCode !== 404) {
-      throw err
+    try {
+      const res = await api.core.readNamespacedConfigMap({ name: resultKey, namespace: runResultNamespace })
+      const result = deserializeValues(res.data!)
+      return result as CacheableRunResult
+    } catch (err) {
+      if (!(err instanceof KubernetesError)) {
+        throw err
+      }
+      if (err.responseStatusCode === 404) {
+        return undefined
+      } else {
+        throw err
+      }
     }
   }
+
+  public async store({
+    action,
+    ctx,
+    log,
+    result,
+  }: StoreResultParams<CacheableRunAction, CacheableRunResult>): Promise<CacheableRunResult> {
+    const k8sCtx = ctx as KubernetesPluginContext
+    const provider = ctx.provider as KubernetesProvider
+    const api = await KubeApi.factory(log, k8sCtx, provider)
+    const runResultNamespace = await getAppNamespace(k8sCtx, log, provider)
+
+    // FIXME: We should store the logs separately, because of the 1MB size limit on ConfigMaps.
+    const data = trimRunOutput(result)
+
+    try {
+      await upsertConfigMap({
+        api,
+        namespace: runResultNamespace,
+        key: this.cacheKey(ctx, action),
+        labels: {
+          [gardenAnnotationKey("action")]: action.key(),
+          [gardenAnnotationKey("actionType")]: action.type,
+          [gardenAnnotationKey("version")]: action.versionString(),
+        },
+        data,
+      })
+    } catch (err) {
+      if (!(err instanceof GardenError)) {
+        throw err
+      }
+      log.warn(`Unable to store run result: ${err}`)
+    }
+
+    return data
+  }
+
+  public async clear({ action, ctx, log }: ClearResultParams<CacheableRunAction>): Promise<void> {
+    const provider = <KubernetesProvider>ctx.provider
+    const api = await KubeApi.factory(log, ctx, provider)
+    const namespace = await getAppNamespace(ctx as KubernetesPluginContext, log, provider)
+
+    const key = this.cacheKey(ctx, action)
+
+    try {
+      await api.core.deleteNamespacedConfigMap({ name: key, namespace })
+    } catch (err) {
+      if (!(err instanceof KubernetesError)) {
+        throw err
+      }
+      if (err.responseStatusCode !== 404) {
+        throw err
+      }
+    }
+  }
+
+  cacheKey(ctx: PluginContext, action: CacheableRunAction): string {
+    // change the result format version if the result format changes breaking backwards-compatibility e.g. serialization format
+    const resultFormatVersion = 2
+    const key = `${ctx.projectName}--${action.type}.${action.name}--${action.versionString()}--${resultFormatVersion}`
+    const hash = hashSync(key, { algorithm: "sha1" })
+    return `run-result--${hash.slice(0, 32)}`
+  }
 }
+
+export const runResultCache = new RunResultCache()

--- a/core/src/plugins/kubernetes/test-results.ts
+++ b/core/src/plugins/kubernetes/test-results.ts
@@ -11,146 +11,135 @@ import { KubeApi, KubernetesError } from "./api.js"
 import type { ContainerTestAction } from "../container/moduleConfig.js"
 import type { PluginContext } from "../../plugin-context.js"
 import type { KubernetesPluginContext, KubernetesProvider } from "./config.js"
-import type { Log } from "../../logger/log-entry.js"
 import { hashSync } from "hasha"
 import { gardenAnnotationKey } from "../../util/string.js"
 import { upsertConfigMap } from "./util.js"
 import { trimRunOutput } from "./helm/common.js"
 import { getSystemNamespace } from "./namespace.js"
 import type { TestActionHandler } from "../../plugin/action-types.js"
-import { runResultToActionState } from "../../actions/base.js"
 import type { HelmPodTestAction } from "./helm/config.js"
 import type { KubernetesTestAction } from "./kubernetes-type/config.js"
 import { GardenError } from "../../exceptions.js"
 import type { RunResult } from "../../plugin/base.js"
 import type { NamespaceStatus } from "../../types/namespace.js"
-import type { Action, ActionStatus } from "../../actions/types.js"
+import type { Action } from "../../actions/types.js"
+import type {
+  CacheableResult,
+  ClearResultParams,
+  LoadResultParams,
+  ResultCache,
+  StoreResultParams,
+} from "./results-cache.js"
+import { toActionStatus } from "./results-cache.js"
+import { composeCacheableResult } from "./results-cache.js"
 
 // TODO: figure out how to get rid of the any cast
 export const k8sGetTestResult: TestActionHandler<"getResult", any> = async (params) => {
   const { action, ctx, log } = params
-  const cachedResult = await loadTestResult({ action, ctx, log })
+  const cachedResult = await testResultCache.load({ action, ctx, log })
 
   if (!cachedResult) {
     return { state: "not-ready", detail: null, outputs: { log: "" } }
   }
 
-  return toTestActionStatus(cachedResult)
-}
-
-export function getTestResultKey(ctx: PluginContext, action: StoreTestResultParams["action"]) {
-  // change the result format version if the result format changes breaking backwards-compatibility e.g. serialization format
-  const resultFormatVersion = 3
-  const key = `${ctx.projectName}--${action.name}--${action.versionString()}--${resultFormatVersion}`
-  const hash = hashSync(key, { algorithm: "sha1" })
-  return `test-result--${hash.slice(0, 32)}`
+  return toActionStatus(cachedResult)
 }
 
 export type CacheableTestAction = ContainerTestAction | KubernetesTestAction | HelmPodTestAction
 
-interface LoadTestResultParams {
-  ctx: PluginContext
-  log: Log
-  action: CacheableTestAction
-}
-
-export async function loadTestResult(params: LoadTestResultParams): Promise<CacheableTestResult | undefined> {
-  const { action, ctx, log } = params
-  const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
-  const testResultNamespace = await getSystemNamespace(k8sCtx, k8sCtx.provider, log)
-  const resultKey = getTestResultKey(k8sCtx, action)
-
-  try {
-    const res = await api.core.readNamespacedConfigMap({ name: resultKey, namespace: testResultNamespace })
-    const result = deserializeValues(res.data!)
-
-    return result as CacheableTestResult
-  } catch (err) {
-    if (!(err instanceof KubernetesError)) {
-      throw err
-    }
-    if (err.responseStatusCode === 404) {
-      return undefined
-    } else {
-      throw err
-    }
-  }
-}
-
-interface StoreTestResultParams {
-  ctx: PluginContext
-  log: Log
-  action: CacheableTestAction
-  result: CacheableTestResult
-}
-
-export type CacheableTestResult = RunResult & {
-  namespaceStatus: NamespaceStatus
-  actionName: string
+export type CacheableTestResult = CacheableResult & {
   /**
    * @deprecated use {@link #actionName} instead
    */
   testName: string
 }
 
-export function composeCacheableTestResult({
-  result,
-  action,
-  namespaceStatus,
-}: {
+export function composeCacheableTestResult(params: {
   result: RunResult
   action: Action
   namespaceStatus: NamespaceStatus
 }): CacheableTestResult {
+  const result = composeCacheableResult(params)
   return {
     ...result,
-    namespaceStatus,
-    actionName: action.name,
-    testName: action.name,
+    testName: result.actionName,
   }
 }
 
-export function toTestActionStatus(detail: CacheableTestResult): ActionStatus {
-  return { state: runResultToActionState(detail), detail, outputs: { log: detail.log } }
-}
+export class TestResultCache implements ResultCache<CacheableTestAction, CacheableTestResult> {
+  public async load({
+    action,
+    ctx,
+    log,
+  }: LoadResultParams<CacheableTestAction>): Promise<CacheableTestResult | undefined> {
+    const k8sCtx = <KubernetesPluginContext>ctx
+    const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
+    const testResultNamespace = await getSystemNamespace(k8sCtx, k8sCtx.provider, log)
+    const resultKey = this.cacheKey(k8sCtx, action)
 
-/**
- * Store a test run result as a ConfigMap in the cluster.
- *
- * TODO: Implement a CRD for this.
- */
-export async function storeTestResult({
-  ctx,
-  log,
-  action,
-  result,
-}: StoreTestResultParams): Promise<CacheableTestResult> {
-  const k8sCtx = ctx as KubernetesPluginContext
-  const provider = ctx.provider as KubernetesProvider
-  const api = await KubeApi.factory(log, k8sCtx, provider)
-  const testResultNamespace = await getSystemNamespace(k8sCtx, provider, log)
-
-  const data = trimRunOutput(result)
-
-  try {
-    await upsertConfigMap({
-      api,
-      namespace: testResultNamespace,
-      key: getTestResultKey(k8sCtx, action),
-      labels: {
-        [gardenAnnotationKey("action")]: action.key(),
-        [gardenAnnotationKey("actionType")]: action.type,
-        [gardenAnnotationKey("version")]: action.versionString(),
-      },
-      data,
-    })
-  } catch (err) {
-    if (!(err instanceof GardenError)) {
-      throw err
+    try {
+      const res = await api.core.readNamespacedConfigMap({ name: resultKey, namespace: testResultNamespace })
+      const result = deserializeValues(res.data!)
+      return result as CacheableTestResult
+    } catch (err) {
+      if (!(err instanceof KubernetesError)) {
+        throw err
+      }
+      if (err.responseStatusCode === 404) {
+        return undefined
+      } else {
+        throw err
+      }
     }
-    log.warn(`Unable to store test result: ${err}`)
   }
 
-  return data
+  public async store({
+    action,
+    ctx,
+    log,
+    result,
+  }: StoreResultParams<CacheableTestAction, CacheableTestResult>): Promise<CacheableTestResult> {
+    const k8sCtx = ctx as KubernetesPluginContext
+    const provider = ctx.provider as KubernetesProvider
+    const api = await KubeApi.factory(log, k8sCtx, provider)
+    const testResultNamespace = await getSystemNamespace(k8sCtx, provider, log)
+
+    const data = trimRunOutput(result)
+
+    try {
+      await upsertConfigMap({
+        api,
+        namespace: testResultNamespace,
+        key: this.cacheKey(k8sCtx, action),
+        labels: {
+          [gardenAnnotationKey("action")]: action.key(),
+          [gardenAnnotationKey("actionType")]: action.type,
+          [gardenAnnotationKey("version")]: action.versionString(),
+        },
+        data,
+      })
+    } catch (err) {
+      if (!(err instanceof GardenError)) {
+        throw err
+      }
+      log.warn(`Unable to store test result: ${err}`)
+    }
+
+    return data
+  }
+
+  public async clear(_: ClearResultParams<CacheableTestAction>): Promise<void> {
+    // not supported yet
+    return
+  }
+
+  cacheKey(ctx: PluginContext, action: CacheableTestAction): string {
+    // change the result format version if the result format changes breaking backwards-compatibility e.g. serialization format
+    const resultFormatVersion = 3
+    const key = `${ctx.projectName}--${action.name}--${action.versionString()}--${resultFormatVersion}`
+    const hash = hashSync(key, { algorithm: "sha1" })
+    return `test-result--${hash.slice(0, 32)}`
+  }
 }
+
+export const testResultCache = new TestResultCache()

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -16,7 +16,7 @@ import fsExtra from "fs-extra"
 const { emptyDir, pathExists } = fsExtra
 import { join } from "path"
 import { getContainerTestGarden } from "./container.js"
-import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results.js"
+import { runResultCache } from "../../../../../../src/plugins/kubernetes/run-results.js"
 import type { KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config.js"
 import type { ContainerRunAction } from "../../../../../../src/plugins/container/config.js"
 import { createActionLog } from "../../../../../../src/logger/log-entry.js"
@@ -58,7 +58,7 @@ describe("runContainerTask", () => {
     garden.events.eventLog = []
 
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })
     const result = results.results.getResult(testTask)
@@ -106,7 +106,7 @@ describe("runContainerTask", () => {
     })
 
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     await garden.processTasks({ tasks: [testTask], throwOnError: true })
 
@@ -142,7 +142,7 @@ describe("runContainerTask", () => {
     })
 
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     await expectError(
       async () => await garden.processTasks({ tasks: [testTask], throwOnError: true }),

--- a/core/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -16,7 +16,7 @@ import { RunTask } from "../../../../../../src/tasks/run.js"
 import fsExtra from "fs-extra"
 const { emptyDir, pathExists } = fsExtra
 import { join } from "path"
-import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results.js"
+import { runResultCache } from "../../../../../../src/plugins/kubernetes/run-results.js"
 import { createActionLog } from "../../../../../../src/logger/log-entry.js"
 
 describe("Helm Pod Run", () => {
@@ -46,7 +46,7 @@ describe("Helm Pod Run", () => {
     // Clear any existing Run result
     const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })
     const result = results.results.getResult(testTask)
@@ -86,7 +86,7 @@ describe("Helm Pod Run", () => {
     // Clear any existing Run result
     const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     await garden.processTasks({ tasks: [testTask], throwOnError: true })
 

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-type/kubernetes-exec-run.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-type/kubernetes-exec-run.ts
@@ -13,7 +13,7 @@ import { findNamespaceStatusEvent } from "../../../../../helpers.js"
 import type { ConfigGraph } from "../../../../../../src/graph/config-graph.js"
 import { getKubernetesTestGarden } from "./common.js"
 import { RunTask } from "../../../../../../src/tasks/run.js"
-import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results.js"
+import { runResultCache } from "../../../../../../src/plugins/kubernetes/run-results.js"
 
 describe("kubernetes-type exec Run", () => {
   let garden: TestGarden
@@ -42,7 +42,7 @@ describe("kubernetes-type exec Run", () => {
     // Clear any existing Run result
     const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     garden.events.eventLog = []
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })
@@ -71,7 +71,7 @@ describe("kubernetes-type exec Run", () => {
     // Clear any existing Run result
     const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     garden.events.eventLog = []
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-type/kubernetes-exec-test.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-type/kubernetes-exec-test.ts
@@ -12,7 +12,6 @@ import type { TestGarden } from "../../../../../helpers.js"
 import { findNamespaceStatusEvent } from "../../../../../helpers.js"
 import type { ConfigGraph } from "../../../../../../src/graph/config-graph.js"
 import { getKubernetesTestGarden } from "./common.js"
-import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results.js"
 import { TestTask } from "../../../../../../src/tasks/test.js"
 
 describe("kubernetes-type exec Test", () => {
@@ -38,11 +37,6 @@ describe("kubernetes-type exec Test", () => {
       force: true,
       forceBuild: false,
     })
-
-    // Clear any existing Run result
-    const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
-    const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
 
     garden.events.eventLog = []
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-type/kubernetes-pod-run.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-type/kubernetes-pod-run.ts
@@ -16,7 +16,7 @@ import { RunTask } from "../../../../../../src/tasks/run.js"
 import fsExtra from "fs-extra"
 const { emptyDir, pathExists } = fsExtra
 import { join } from "path"
-import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results.js"
+import { runResultCache } from "../../../../../../src/plugins/kubernetes/run-results.js"
 import type { KubernetesPodRunAction } from "../../../../../../src/plugins/kubernetes/kubernetes-type/kubernetes-pod.js"
 import { createActionLog } from "../../../../../../src/logger/log-entry.js"
 
@@ -47,7 +47,7 @@ describe("kubernetes-type pod Run", () => {
     // Clear any existing Run result
     const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     garden.events.eventLog = []
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })
@@ -88,7 +88,7 @@ describe("kubernetes-type pod Run", () => {
     // Clear any existing Run result
     const provider = await garden.resolveProvider({ log: garden.log, name: "local-kubernetes" })
     const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    await clearRunResult({ ctx, log: garden.log, action })
+    await runResultCache.clear({ ctx, log: garden.log, action })
 
     await garden.processTasks({ tasks: [testTask], throwOnError: true })
 

--- a/core/test/integ/src/plugins/kubernetes/task-results.ts
+++ b/core/test/integ/src/plugins/kubernetes/task-results.ts
@@ -15,7 +15,7 @@ import { expect } from "chai"
 import {
   composeCacheableRunResult,
   k8sGetRunResult,
-  storeRunResult,
+  runResultCache,
 } from "../../../../../src/plugins/kubernetes/run-results.js"
 import { MAX_RUN_RESULT_LOG_LENGTH } from "../../../../../src/plugins/kubernetes/constants.js"
 import { createActionLog } from "../../../../../src/logger/log-entry.js"
@@ -37,7 +37,7 @@ describe("kubernetes Run results", () => {
     garden.close()
   })
 
-  describe("storeRunResult", () => {
+  describe("RunResultCache", () => {
     it("should trim logs when necessary", async () => {
       const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
@@ -62,10 +62,9 @@ describe("kubernetes Run results", () => {
         },
         // version: task.version,
       })
-      const trimmed = await storeRunResult({
+      const trimmed = await runResultCache.store({
         ctx,
         log: garden.log,
-        // module: task.module,
         action,
         result,
       })

--- a/core/test/integ/src/plugins/kubernetes/test-results.ts
+++ b/core/test/integ/src/plugins/kubernetes/test-results.ts
@@ -17,7 +17,7 @@ import { createActionLog } from "../../../../../src/logger/log-entry.js"
 import {
   composeCacheableTestResult,
   k8sGetTestResult,
-  storeTestResult,
+  testResultCache,
 } from "../../../../../src/plugins/kubernetes/test-results.js"
 
 describe("kubernetes Test results", () => {
@@ -37,7 +37,7 @@ describe("kubernetes Test results", () => {
     garden.close()
   })
 
-  describe("storeTestResult", () => {
+  describe("TestResultCache", () => {
     it("should trim logs when necessary", async () => {
       const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
@@ -62,10 +62,9 @@ describe("kubernetes Test results", () => {
         },
         // version: task.version,
       })
-      const trimmed = await storeTestResult({
+      const trimmed = await testResultCache.store({
         ctx,
         log: garden.log,
-        // module: task.module,
         action,
         result,
       })


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick #6938 to 0.13 branch.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
