### PR TITLE
fix(cloud): remove unnecessary error translation inside the tRPC client

### DIFF
--- a/core/src/cloud/grow/trpc.ts
+++ b/core/src/cloud/grow/trpc.ts
@@ -6,42 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { CreateTRPCClient, TRPCClientError, TRPCClientErrorBase, TRPCLink } from "@trpc/client"
+import type { CreateTRPCClient } from "@trpc/client"
 import { createTRPCClient, httpLink, loggerLink } from "@trpc/client"
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server"
-import { observable } from "@trpc/server/observable"
 import superjson from "superjson"
-import { z } from "zod"
 import type { AppRouter } from "./trpc-schema.js"
-import { GardenError } from "../../exceptions.js"
-import { styles } from "../../logger/styles.js"
-import { getRootLogger } from "../../logger/logger.js"
-import { getCloudLogSectionName } from "../util.js"
-
-const errorMetaSchema = z.object({ response: z.object({ status: z.number() }) })
-type ErrorMeta = z.infer<typeof errorMetaSchema>
-
-class GrowCloudError extends GardenError implements TRPCClientErrorBase<never> {
-  readonly type = "garden-cloud-v2-error"
-  readonly meta: ErrorMeta | undefined
-  override readonly cause: TRPCClientError<never>
-  readonly shape = undefined as never
-  readonly data = undefined as never
-
-  constructor({ cause, meta }: { cause: TRPCClientError<never>; meta: ErrorMeta | undefined }) {
-    let message: string
-    if (meta?.response.status === 401) {
-      message = `Authentication required; please log in with ${styles.highlight("garden login")} and retry.`
-    } else {
-      message = cause.message
-    }
-    super({
-      message,
-    })
-    this.meta = meta
-    this.cause = cause
-  }
-}
 
 export type RouterOutput = inferRouterOutputs<AppRouter>
 export type RouterInput = inferRouterInputs<AppRouter>
@@ -50,34 +19,6 @@ export type DockerBuildReport = RouterInput["dockerBuild"]["create"]
 
 export type RegisterCloudBuildRequest = RouterInput["cloudBuilder"]["registerBuild"]
 export type RegisterCloudBuildResponse = RouterOutput["cloudBuilder"]["registerBuild"]
-
-export const errorLogger: TRPCLink<AppRouter> = () => {
-  return ({ next, op }) => {
-    return observable((observer) => {
-      const log = getRootLogger().createLog({ name: getCloudLogSectionName("Garden Cloud V2"), origin: "trpc" })
-      log.debug(`tRPC ${op.type}: ${op.path}`)
-      const unsubscribe = next(op).subscribe({
-        next(value) {
-          observer.next(value)
-        },
-        error(err) {
-          const meta = errorMetaSchema.safeParse(err.meta)
-          const growErr = new GrowCloudError({
-            meta: meta.data,
-            cause: err,
-          })
-          // Errors are handled by the caller, but we do log them here just in case at the debug level.
-          log.debug(growErr.message)
-          observer.error(growErr)
-        },
-        complete() {
-          observer.complete()
-        },
-      })
-      return unsubscribe
-    })
-  }
-}
 
 function cloudApiUrl(hostUrl: string): string {
   return new URL("/api", hostUrl).href
@@ -88,7 +29,6 @@ export type TrpcConfigParams = { hostUrl: string; tokenGetter: (() => string) | 
 function getTrpcConfig({ hostUrl, tokenGetter }: TrpcConfigParams) {
   return {
     links: [
-      errorLogger,
       loggerLink({
         enabled: () => false,
       }),

--- a/core/src/cloud/grow/trpc.ts
+++ b/core/src/cloud/grow/trpc.ts
@@ -48,6 +48,9 @@ export type RouterInput = inferRouterInputs<AppRouter>
 
 export type DockerBuildReport = RouterInput["dockerBuild"]["create"]
 
+export type RegisterCloudBuildRequest = RouterInput["cloudBuilder"]["registerBuild"]
+export type RegisterCloudBuildResponse = RouterOutput["cloudBuilder"]["registerBuild"]
+
 export const errorLogger: TRPCLink<AppRouter> = () => {
   return ({ next, op }) => {
     return observable((observer) => {
@@ -118,6 +121,3 @@ export function getNonAuthenticatedApiClient(trpcConfigParams: Omit<TrpcConfigPa
 }
 
 export type ApiClient = CreateTRPCClient<AppRouter>
-export type GrowCloudBuilderRegisterBuildResponse = Awaited<
-  ReturnType<ApiClient["cloudBuilder"]["registerBuild"]["mutate"]>
->

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -409,7 +409,7 @@ export async function sendBuildReport({
       return { timeSaved: 0 }
     }
 
-    return await growCloudApi.api.dockerBuild.create.mutate(dockerBuildReport)
+    return await growCloudApi.uploadDockerBuildReport(dockerBuildReport)
   } catch (err) {
     log.debug(`Failed to send build report to Garden Cloud: ${err}`)
     return { timeSaved: 0 }

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -34,8 +34,7 @@ import { hashString } from "../../util/util.js"
 import { deline, stableStringify } from "../../util/string.js"
 import { homedir } from "os"
 import { getCloudDistributionName, isGardenCommunityEdition } from "../../cloud/util.js"
-import { TRPCClientError } from "@trpc/client"
-import type { DockerBuildReport, GrowCloudBuilderRegisterBuildResponse } from "../../cloud/grow/trpc.js"
+import type { DockerBuildReport, RegisterCloudBuildResponse } from "../../cloud/grow/trpc.js"
 import type { GrowCloudApi } from "../../cloud/grow/api.js"
 import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 
@@ -199,25 +198,12 @@ class GrowCloudBuilderAvailabilityRetriever extends AbstractCloudBuilderAvailabi
     action,
     cloudApi,
     publicKeyPem,
-  }: RegisterCloudBuildParams<GrowCloudApi>): Promise<GrowCloudBuilderRegisterBuildResponse> {
-    try {
-      return await cloudApi.api.cloudBuilder.registerBuild.mutate({
-        // if platforms are not set, we default to linux/amd64
-        platforms: action.getSpec().platforms || ["linux/amd64"],
-        mtlsClientPublicKeyPEM: publicKeyPem,
-      })
-    } catch (err) {
-      if (!(err instanceof TRPCClientError)) {
-        throw err
-      }
-      return {
-        version: "v2",
-        availability: {
-          available: false,
-          reason: err.message,
-        },
-      }
-    }
+  }: RegisterCloudBuildParams<GrowCloudApi>): Promise<RegisterCloudBuildResponse> {
+    return await cloudApi.registerCloudBuild({
+      // if platforms are not set, we default to linux/amd64
+      platforms: action.getSpec().platforms || ["linux/amd64"],
+      mtlsClientPublicKeyPEM: publicKeyPem,
+    })
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unnecessary error translation inside the tRPC client.

This PR also refactors the Cloud API V2 class by making its `api` field (a reference to the underlying tRPC client) private:
* The API calls are implemented as methods of the class.
* The methods delegate to the underlying tRPC client and do the error handling.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
