### PR TITLE
ci(e2e): temporarily mute some e2e tests

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1274,18 +1274,18 @@ workflows:
       #     name: e2e-code-synchronization
       #     project: code-synchronization
       #     requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-demo-project
-          project: demo-project
-          environment: remote
-          requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-demo-project-modules
-          project: demo-project-modules
-          environment: remote
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-demo-project
+      #    project: demo-project
+      #     environment: remote
+      #     requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-demo-project-modules
+      #     project: demo-project-modules
+      #     environment: remote
+      #     requires: [build]
       - e2e-project:
           <<: *only-internal-prs
           name: e2e-gke-kaniko
@@ -1304,32 +1304,32 @@ workflows:
           project: jib-container
           environment: remote
           requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-jib-container-modules
-          project: jib-container-modules
-          environment: remote
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-jib-container-modules
+      #     project: jib-container-modules
+      #     environment: remote
+      #     requires: [build]
       - e2e-project:
           <<: *only-internal-prs
           name: e2e-kustomize
           project: kustomize
           requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-kustomize-modules
-          project: kustomize-modules
-          requires: [build]
       # - e2e-project:
       #     <<: *only-internal-prs
-      #     name: e2e-remote-sources
-      #     project: remote-sources
+      #     name: e2e-kustomize-modules
+      #     project: kustomize-modules
       #     requires: [build]
       - e2e-project:
           <<: *only-internal-prs
-          name: e2e-remote-sources-modules
-          project: remote-sources-modules
+          name: e2e-remote-sources
+          project: remote-sources
           requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-remote-sources-modules
+      #     project: remote-sources-modules
+      #     requires: [build]
       - e2e-project:
           <<: *only-internal-prs
           name: e2e-run-actions
@@ -1345,23 +1345,23 @@ workflows:
           name: e2e-templated-k8s-container
           project: templated-k8s-container
           requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-templated-k8s-container-modules
-          project: templated-k8s-container-modules
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-templated-k8s-container-modules
+      #     project: templated-k8s-container-modules
+      #     requires: [build]
       - e2e-project:
           <<: *only-internal-prs
           name: e2e-vote
           project: vote
           environment: remote
           requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-vote-modules
-          project: vote-modules
-          environment: remote
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-vote-modules
+      #     project: vote-modules
+      #     environment: remote
+      #     requires: [build]
       - e2e-project:
           <<: *only-internal-prs
           name: e2e-vote-helm

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1286,45 +1286,45 @@ workflows:
       #     project: demo-project-modules
       #     environment: remote
       #     requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-gke-kaniko
-          project: gke
-          environment: gke-kaniko
-          requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-gke-buildkit
-          project: gke
-          environment: gke-buildkit
-          requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-jib-container
-          project: jib-container
-          environment: remote
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-gke-kaniko
+      #     project: gke
+      #     environment: gke-kaniko
+      #     requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-gke-buildkit
+      #     project: gke
+      #     environment: gke-buildkit
+      #    requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-jib-container
+      #     project: jib-container
+      #     environment: remote
+      #     requires: [build]
       # - e2e-project:
       #     <<: *only-internal-prs
       #     name: e2e-jib-container-modules
       #     project: jib-container-modules
       #     environment: remote
       #     requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-kustomize
-          project: kustomize
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-kustomize
+      #     project: kustomize
+      #     requires: [build]
       # - e2e-project:
       #     <<: *only-internal-prs
       #     name: e2e-kustomize-modules
       #     project: kustomize-modules
       #     requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-remote-sources
-          project: remote-sources
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-remote-sources
+      #     project: remote-sources
+      #     requires: [build]
       # - e2e-project:
       #     <<: *only-internal-prs
       #     name: e2e-remote-sources-modules
@@ -1367,11 +1367,11 @@ workflows:
           name: e2e-vote-helm
           project: vote-helm
           requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
-          name: e2e-open-telemetry
-          project: open-telemetry
-          requires: [build]
+      # - e2e-project:
+      #     <<: *only-internal-prs
+      #     name: e2e-open-telemetry
+      #     project: open-telemetry
+      #     requires: [build]
       # - e2e-project:
       #     <<: *only-internal-prs
       #     name: e2e-vote-helm-modules


### PR DESCRIPTION
**What this PR does / why we need it**:

Otherwise, e2e tests fail randomly with the errors complaining about the GCR deprecation. It looks like this error starts occurring after a certain number of requests.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
