### PR TITLE
(0.13) fix: reduce scope of the `build` deprecation to the `container` type

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -23,8 +23,8 @@ import {
   parseActionReference,
   unusedApiVersionSchema,
 } from "../config/common.js"
-import { DOCS_BASE_URL, GardenApiVersion } from "../constants.js"
-import { dedent, deline, naturalList, stableStringify } from "../util/string.js"
+import { DOCS_BASE_URL } from "../constants.js"
+import { dedent, naturalList, stableStringify } from "../util/string.js"
 import type { ActionVersion, ModuleVersion, TreeVersion } from "../vcs/vcs.js"
 import { getActionSourcePath, hashStrings, versionStringPrefix } from "../vcs/vcs.js"
 import type { BuildAction, ResolvedBuildAction } from "./build.js"
@@ -70,8 +70,6 @@ import type { ResolvedTemplate } from "../template/types.js"
 import type { WorkflowConfig } from "../config/workflow.js"
 import type { VariablesContext } from "../config/template-contexts/variables.js"
 import { deepMap } from "../util/objects.js"
-import { makeDeprecationMessage, reportDeprecatedFeatureUsage } from "../util/deprecations.js"
-import { RootLogger } from "../logger/logger.js"
 
 // TODO: split this file
 

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -287,7 +287,6 @@ export const baseRuntimeActionConfigSchema = createSchema({
       )
       .meta({
         templateContext: ActionConfigContext,
-        deprecated: makeDeprecationMessage({ deprecation: "buildConfigFieldOnRuntimeActions" }),
       }),
   }),
   extend: baseActionConfigSchema,
@@ -701,30 +700,6 @@ export abstract class RuntimeAction<
   StaticOutputs extends Record<string, unknown> = any,
   RuntimeOutputs extends Record<string, unknown> = any,
 > extends BaseAction<C, StaticOutputs, RuntimeOutputs> {
-  constructor(params: ActionWrapperParams<C>) {
-    super(params)
-
-    const buildName = this.getConfig("build")
-    if (buildName) {
-      const log = RootLogger.getInstance().createLog()
-      const config = params.config
-      // Report concrete action name for better UX
-      log.warn(
-        deline`Action ${styles.highlight(this.key())}
-        of type ${styles.highlight(config.type)}
-        defined in ${styles.highlight(config.internal.configFilePath || config.internal.basePath)}
-        declares deprecated config field ${styles.highlight("build")}.`
-      )
-      // Report general deprecation warning
-      reportDeprecatedFeatureUsage({
-        // TODO(0.14): change this to v2
-        apiVersion: GardenApiVersion.v1,
-        log,
-        deprecation: "buildConfigFieldOnRuntimeActions",
-      })
-    }
-  }
-
   /**
    * Return the Build action specified on the `build` field if defined, otherwise null
    */

--- a/core/src/cloud/auth.ts
+++ b/core/src/cloud/auth.ts
@@ -67,11 +67,11 @@ export function enforceLogin({
       throw new LoginRequiredWhenConnected()
     }
 
-    reportDeprecatedFeatureUsage({ apiVersion, log, deprecation: "loginRequirement" })
+    reportDeprecatedFeatureUsage({ log, deprecation: "loginRequirement" })
   }
 
   if (!isConnectedToCloud && apiVersion !== GardenApiVersion.v2) {
-    reportDeprecatedFeatureUsage({ apiVersion, log, deprecation: "configMapBasedCache" })
+    reportDeprecatedFeatureUsage({ log, deprecation: "configMapBasedCache" })
 
     // TODO(0.14): Nudge the user with a message at the end of the command, instead of a warning in the middle of the logs somewhere.
   }

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -175,7 +175,6 @@ export class DeployCommand extends Command<Args, Opts> {
 
     if (opts["local-mode"] !== undefined) {
       reportDeprecatedFeatureUsage({
-        apiVersion: garden.projectApiVersion,
         log,
         deprecation: "localMode",
       })

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -100,7 +100,6 @@ export class ServeCommand<
 
     if (opts["local-mode"] !== undefined) {
       reportDeprecatedFeatureUsage({
-        apiVersion: garden.projectApiVersion,
         log,
         deprecation: "localMode",
       })

--- a/core/src/commands/sync/sync-restart.ts
+++ b/core/src/commands/sync/sync-restart.ts
@@ -60,7 +60,6 @@ export class SyncRestartCommand extends Command<Args, Opts> {
   async action({ garden, log, args, parentCommand }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     if (!parentCommand) {
       reportDeprecatedSyncCommandUsage({
-        apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncRestartCommand",
         syncCommandName: this.name,

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -103,7 +103,6 @@ export class SyncStartCommand extends Command<Args, Opts> {
   }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     if (!parentCommand) {
       reportDeprecatedSyncCommandUsage({
-        apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncStartCommand",
         syncCommandName: this.name,

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -103,7 +103,6 @@ export class SyncStatusCommand extends Command<Args, Opts> {
   }: CommandParams<Args, Opts>): Promise<SyncStatusCommandResult> {
     if (!parentCommand) {
       reportDeprecatedSyncCommandUsage({
-        apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncStatusCommand",
         syncCommandName: this.name,

--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -61,7 +61,6 @@ export class SyncStopCommand extends Command<Args, Opts> {
   async action({ garden, log, args, parentCommand }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     if (!parentCommand) {
       reportDeprecatedSyncCommandUsage({
-        apiVersion: garden.projectApiVersion,
         log,
         deprecation: "syncStopCommand",
         syncCommandName: this.name,

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -371,7 +371,6 @@ function handleDotIgnoreFiles(log: Log, projectSpec: ProjectConfig) {
   }
 
   reportDeprecatedFeatureUsage({
-    apiVersion: projectSpec.apiVersion,
     log,
     deprecation: "dotIgnoreFiles",
   })
@@ -396,7 +395,6 @@ function handleProjectModules(log: Log, projectSpec: ProjectConfig): ProjectConf
   // but it still can be presented in the runtime if the old config format is used.
   if (projectSpec["modules"]) {
     reportDeprecatedFeatureUsage({
-      apiVersion: projectSpec.apiVersion,
       log,
       deprecation: "projectConfigModules",
     })

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -39,10 +39,6 @@ export enum GardenApiVersion {
   v2 = "garden.io/v2",
 }
 
-// TODO(0.14): bump this to v1 (or v2?)
-//  Update the comments and log messages in the placed where it's used.
-export const defaultGardenApiVersion = GardenApiVersion.v0
-
 export const supportedApiVersions: string[] = Object.values(GardenApiVersion).map((v) => v as string)
 
 export function gardenApiSupportsActions(apiVersion: GardenApiVersion): boolean {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -182,7 +182,7 @@ import type { ResolvedTemplate } from "./template/types.js"
 import { serialiseUnresolvedTemplates } from "./template/types.js"
 import type { VariablesContext } from "./config/template-contexts/variables.js"
 import { reportDeprecatedFeatureUsage } from "./util/deprecations.js"
-import { getProjectApiVersion, setProjectApiVersion } from "./project-api-version.js"
+import { getGlobalProjectApiVersion, resolveApiVersion } from "./project-api-version.js"
 
 const defaultLocalAddress = "localhost"
 
@@ -429,7 +429,6 @@ export class Garden {
       params.opts.legacyBuildSync === undefined ? gardenEnv.GARDEN_LEGACY_BUILD_STAGE : params.opts.legacyBuildSync
     if (legacyBuildSync) {
       reportDeprecatedFeatureUsage({
-        apiVersion: params.projectApiVersion,
         log: params.log,
         deprecation: "rsyncBuildStaging",
       })
@@ -1919,7 +1918,8 @@ export async function resolveGardenParamsPartial(currentDirectory: string, opts:
     }
   }
 
-  setProjectApiVersion(config, log)
+  const apiVersion = resolveApiVersion(config, log)
+  config.apiVersion = apiVersion
 
   gardenDirPath = resolve(config.path, gardenDirPath || DEFAULT_GARDEN_DIR_NAME)
   const artifactsPath = resolve(gardenDirPath, "artifacts")
@@ -2225,7 +2225,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       username: _username,
       forceRefresh: opts.forceRefresh,
       cache: treeCache,
-      projectApiVersion: getProjectApiVersion(),
+      projectApiVersion: getGlobalProjectApiVersion(),
     }
   })
 })

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -367,14 +367,12 @@ function isContainerBuilderEnabled({
   ctx: PluginContext
   containerProviderConfig: ContainerProviderConfig
 }) {
-  const apiVersion = ctx.projectApiVersion
-
   if (containerProviderConfig.gardenCloudBuilder !== undefined) {
-    reportDeprecatedFeatureUsage({ apiVersion, log: ctx.log, deprecation: "gardenCloudBuilder" })
+    reportDeprecatedFeatureUsage({ log: ctx.log, deprecation: "gardenCloudBuilder" })
   }
 
   if (gardenEnv.GARDEN_CLOUD_BUILDER !== undefined) {
-    reportDeprecatedFeatureUsage({ apiVersion, log: ctx.log, deprecation: "gardenCloudBuilderEnvVar" })
+    reportDeprecatedFeatureUsage({ log: ctx.log, deprecation: "gardenCloudBuilderEnvVar" })
   }
 
   if (!!containerProviderConfig.gardenContainerBuilder && !!containerProviderConfig.gardenCloudBuilder) {

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -56,7 +56,7 @@ import { actionReferenceToString } from "../../actions/base.js"
 import { RootLogger } from "../../logger/logger.js"
 import { styles } from "../../logger/styles.js"
 import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
-import { getProjectApiVersion } from "../../project-api-version.js"
+import { getGlobalProjectApiVersion } from "../../project-api-version.js"
 
 export const CONTAINER_STATUS_CONCURRENCY_LIMIT = gardenEnv.GARDEN_HARD_CONCURRENCY_LIMIT
 export const CONTAINER_BUILD_CONCURRENCY_LIMIT_LOCAL = 5
@@ -730,14 +730,13 @@ function validateRuntimeCommon(action: Resolved<ContainerRuntimeAction>) {
     )
     // Report general deprecation warning
     reportDeprecatedFeatureUsage({
-      apiVersion: getProjectApiVersion(),
       log,
       deprecation: "buildConfigFieldOnRuntimeActions",
     })
   }
 
   // TODO(0.14): Make spec.image required in the schema, and remove this if statement.
-  if (getProjectApiVersion() === GardenApiVersion.v2 && !image) {
+  if (getGlobalProjectApiVersion() === GardenApiVersion.v2 && !image) {
     throw new ConfigurationError({
       message: `${action.longDescription()} must specify \`spec.image\`.`,
     })

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -26,7 +26,7 @@ import {
   validateContainerBuild,
 } from "./build.js"
 import type { ConfigureModuleParams } from "../../plugin/handlers/Module/configure.js"
-import { dedent, naturalList } from "../../util/string.js"
+import { dedent, deline, naturalList } from "../../util/string.js"
 import type { Provider, BaseProviderConfig } from "../../config/provider.js"
 import { providerConfigBaseSchema } from "../../config/provider.js"
 import type { GetModuleOutputsParams } from "../../plugin/handlers/Module/get-outputs.js"
@@ -48,11 +48,15 @@ import type { Resolved } from "../../actions/types.js"
 import { getDeployedImageId } from "../kubernetes/container/util.js"
 import type { DeepPrimitiveMap } from "../../config/common.js"
 import { joi } from "../../config/common.js"
-import { DEFAULT_DEPLOY_TIMEOUT_SEC, gardenEnv } from "../../constants.js"
+import { DEFAULT_DEPLOY_TIMEOUT_SEC, GardenApiVersion, gardenEnv } from "../../constants.js"
 import type { ExecBuildConfig } from "../exec/build.js"
 import type { PluginToolSpec } from "../../plugin/tools.js"
 import type { PluginContext } from "../../plugin-context.js"
 import { actionReferenceToString } from "../../actions/base.js"
+import { RootLogger } from "../../logger/logger.js"
+import { styles } from "../../logger/styles.js"
+import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
+import { getProjectApiVersion } from "../../project-api-version.js"
 
 export const CONTAINER_STATUS_CONCURRENCY_LIMIT = gardenEnv.GARDEN_HARD_CONCURRENCY_LIMIT
 export const CONTAINER_BUILD_CONCURRENCY_LIMIT_LOCAL = 5
@@ -715,6 +719,31 @@ function validateRuntimeCommon(action: Resolved<ContainerRuntimeAction>) {
   const { build } = action.getConfig()
   const { image, volumes } = action.getSpec()
 
+  if (build) {
+    const log = RootLogger.getInstance().createLog()
+    const configPath = action.configPath()
+    // Report concrete action name for better UX
+    log.warn(
+      deline`Action ${styles.highlight(action.longDescription())}
+          ${configPath ? `- defined in ${styles.highlight(configPath)} -` : ""}
+          specifies deprecated config field ${styles.highlight("build")}.`
+    )
+    // Report general deprecation warning
+    reportDeprecatedFeatureUsage({
+      apiVersion: getProjectApiVersion(),
+      log,
+      deprecation: "buildConfigFieldOnRuntimeActions",
+    })
+  }
+
+  // TODO(0.14): Make spec.image required in the schema, and remove this if statement.
+  if (getProjectApiVersion() === GardenApiVersion.v2 && !image) {
+    throw new ConfigurationError({
+      message: `${action.longDescription()} must specify \`spec.image\`.`,
+    })
+  }
+
+  // TODO(0.14): The entire if/else if/else if block can be removed
   if (!build && !image) {
     throw new ConfigurationError({
       message: `${action.longDescription()} must specify one of \`build\` or \`spec.image\``,

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -265,7 +265,6 @@ const hadolintTest = provider.createActionType({
 
 hadolintTest.addHandler("configure", async ({ ctx, config, log }) => {
   reportDeprecatedFeatureUsage({
-    apiVersion: ctx.projectApiVersion,
     log,
     deprecation: "hadolintPlugin",
   })

--- a/core/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/core/src/plugins/kubernetes/commands/cluster-init.ts
@@ -24,7 +24,6 @@ export const clusterInit: PluginCommand = {
 
   handler: async ({ ctx, log }) => {
     reportDeprecatedFeatureUsage({
-      apiVersion: ctx.projectApiVersion,
       log,
       deprecation: "kubernetesClusterInitCommand",
     })

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -81,7 +81,6 @@ export const k8sContainerDeploy: DeployActionHandler<"deploy", ContainerDeployAc
 
   if (deploymentStrategy) {
     reportDeprecatedFeatureUsage({
-      apiVersion: ctx.projectApiVersion,
       log,
       deprecation: "containerDeploymentStrategy",
     })

--- a/core/src/plugins/kubernetes/ephemeral/config.ts
+++ b/core/src/plugins/kubernetes/ephemeral/config.ts
@@ -50,7 +50,7 @@ export const configSchema = () =>
 export async function configureProvider(params: ConfigureProviderParams<KubernetesConfig>) {
   const { base, log, ctx, config: baseConfig } = params
 
-  reportDeprecatedFeatureUsage({ apiVersion: ctx.projectApiVersion, log, deprecation: "ephemeralKubernetesProvider" })
+  reportDeprecatedFeatureUsage({ log, deprecation: "ephemeralKubernetesProvider" })
 
   if (!ctx.cloudApi) {
     throw new ConfigurationError({

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -31,7 +31,6 @@ import pFilter from "p-filter"
 import { kubectl } from "../kubectl.js"
 import { loadAndValidateYaml } from "../../../config/base.js"
 import { reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
-import { getProjectApiVersion } from "../../../project-api-version.js"
 import type { ActionReference } from "../../../config/common.js"
 
 const { pathExists, readFile } = fsExtra
@@ -409,7 +408,7 @@ export function getSpecFiles({
   fileSources: KubernetesDeployActionSpecFileSources
 }): { files: string[]; manifestFiles: string[]; manifestTemplates: string[] } {
   if (files.length > 0) {
-    reportDeprecatedFeatureUsage({ apiVersion: getProjectApiVersion(), log, deprecation: "kubernetesActionSpecFiles" })
+    reportDeprecatedFeatureUsage({ log, deprecation: "kubernetesActionSpecFiles" })
   }
 
   return { files, manifestTemplates, manifestFiles }

--- a/core/src/plugins/kubernetes/volumes/configmap.ts
+++ b/core/src/plugins/kubernetes/volumes/configmap.ts
@@ -60,9 +60,8 @@ export const configmapDeployDefinition = (): DeployActionDefinition<ConfigmapAct
   docs: getDocs(),
   schema: joi.object().keys(commonSpecKeys()),
   handlers: {
-    configure: async ({ config, ctx, log }) => {
+    configure: async ({ config, log }) => {
       reportDeprecatedFeatureUsage({
-        apiVersion: ctx.projectApiVersion,
         log,
         deprecation: "configmapDeployAction",
       })

--- a/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
+++ b/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
@@ -83,9 +83,8 @@ export const persistentvolumeclaimDeployDefinition = (): DeployActionDefinition<
   `,
   schema: joi.object().keys(commonSpecKeys()),
   handlers: {
-    configure: async ({ config, ctx, log }) => {
+    configure: async ({ config, log }) => {
       reportDeprecatedFeatureUsage({
-        apiVersion: ctx.projectApiVersion,
         log,
         deprecation: "persistentvolumeclaimDeployAction",
       })

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -38,7 +38,6 @@ export const gardenPlugin = () =>
     handlers: {
       async getDashboardPage({ ctx, log }: GetDashboardPageParams) {
         reportDeprecatedFeatureUsage({
-          apiVersion: ctx.projectApiVersion,
           log,
           deprecation: "octantPlugin",
         })

--- a/core/src/project-api-version.ts
+++ b/core/src/project-api-version.ts
@@ -5,8 +5,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { defaultGardenApiVersion, GardenApiVersion } from "./constants.js"
-import { RuntimeError } from "./exceptions.js"
+import { GardenApiVersion } from "./constants.js"
+import { InternalError } from "./exceptions.js"
 import type { ProjectConfig } from "./config/project.js"
 import type { Log } from "./logger/log-entry.js"
 import { emitNonRepeatableWarning } from "./warnings.js"
@@ -15,40 +15,44 @@ import { reportDeprecatedFeatureUsage } from "./util/deprecations.js"
 
 let projectApiVersionGlobal: GardenApiVersion | undefined
 
-export function getProjectApiVersion(): GardenApiVersion {
+export function getGlobalProjectApiVersion(): GardenApiVersion {
   if (!projectApiVersionGlobal) {
-    throw new RuntimeError({ message: "apiVersion is not defined" })
+    throw new InternalError({ message: "apiVersion is not defined" })
   }
   return projectApiVersionGlobal
 }
 
-export function setProjectApiVersion(projectConfig: Partial<ProjectConfig>, log: Log) {
-  projectApiVersionGlobal = resolveApiVersion(projectConfig, log)
+export function setGloablProjectApiVersion(apiVersion: GardenApiVersion) {
+  projectApiVersionGlobal = apiVersion
 }
 
-export function resolveApiVersion(projectSpec: Partial<ProjectConfig>, log: Log): GardenApiVersion {
-  const projectApiVersion = projectSpec.apiVersion
+export function resolveApiVersion(projectSpec: ProjectConfig, log: Log): GardenApiVersion {
+  const declaredApiVersion = projectSpec.apiVersion
+
+  const resolvedApiVersion = declaredApiVersion || GardenApiVersion.v0
 
   // We conservatively set the apiVersion to be compatible with 0.12.
   // TODO(0.14): Throw an error if the apiVersion field is not defined.
-  if (projectApiVersion === undefined) {
+  if (declaredApiVersion === undefined) {
     emitNonRepeatableWarning(
       log,
       `"apiVersion" is missing in the Project config. Assuming "${
-        defaultGardenApiVersion
+        resolvedApiVersion
       }" for backwards compatibility with 0.12. The "apiVersion"-field is mandatory when using the new action Kind-configs. A detailed migration guide is available at ${makeDocsLinkStyled("guides/migrating-to-bonsai")}`
     )
-
-    return defaultGardenApiVersion
   }
 
-  if (projectApiVersion !== GardenApiVersion.v2) {
+  // HACK: Set project API version globally.
+  // This makes it easier to use `reportDeprecatedFeatureUsage`, as it can be difficult at times to pass down the apiVersion
+  setGloablProjectApiVersion(resolvedApiVersion)
+
+  if (declaredApiVersion !== GardenApiVersion.v2) {
+    // Print the deprecation warning that 0.14 will only support apiVersion v2
     reportDeprecatedFeatureUsage({
-      apiVersion: projectApiVersion,
       log,
       deprecation: "apiVersion",
     })
   }
 
-  return projectApiVersion
+  return resolvedApiVersion
 }

--- a/core/src/template/ast.ts
+++ b/core/src/template/ast.ts
@@ -19,7 +19,7 @@ import type { Branch } from "./analysis.js"
 import { TemplateStringError, truncateRawTemplateString } from "./errors.js"
 import { styles } from "../logger/styles.js"
 import { GardenApiVersion } from "../constants.js"
-import { getProjectApiVersion } from "../project-api-version.js"
+import { getGlobalProjectApiVersion } from "../project-api-version.js"
 import { reportDeprecatedFeatureUsage } from "../util/deprecations.js"
 import { RootLogger } from "../logger/logger.js"
 import { emitNonRepeatableWarning } from "../warnings.js"
@@ -527,14 +527,13 @@ export class FormatStringExpression extends TemplateExpression {
   }
 
   override evaluate(args: ASTEvaluateArgs): ASTEvaluationResult<CollectionOrValue<TemplatePrimitive>> {
-    const apiVersion = getProjectApiVersion()
+    const apiVersion = getGlobalProjectApiVersion()
     const isOptional = this.isOptional(apiVersion)
 
     if (apiVersion === GardenApiVersion.v1 && isOptional) {
       const log = RootLogger.getInstance().createLog()
 
       reportDeprecatedFeatureUsage({
-        apiVersion: GardenApiVersion.v1,
         log,
         deprecation: "optionalTemplateValueSyntax",
       })

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -345,10 +345,16 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     buildConfigFieldOnRuntimeActions: {
       docsSection: "Action configs",
-      docsHeadline: `The ${style("build")} config field in runtime action configs`,
-      warnHint: `Use the ${style("dependencies")} config to define the build dependencies. Using the ${style("build")} config field in runtime actions will not be supported anymore in Garden 0.14.`,
+      docsHeadline: `The ${style("build")} config field in \`container\` actions`,
+      warnHint: `Using the ${style("build")} config field in ${style("container")} actions will not be supported anymore in Garden 0.14.`,
       docs: dedent`
-        Please replace all root-level configuration entries like \`build: my-app\` with the \`dependencies: [build.my-app]\`.
+        Instead of usin g \`build\`, please reference the \`deploymentImageId\` output explicitly in each affected \`Deploy\`, \`Run\` and \`Test\` action spec of the \`container\` action type.
+
+        Other action types, like the \`exec\`, \`kubernetes\` and \`helm\` action types, are not affected and \`build\` can still be used to control the build staging directory of the action.
+
+        Referring to a container image via the \`build\` config field was confusing to some of our users, as it does not work for all action types that can reference containers, for example in \`kubernetes\` and \`helm\` actions configs.
+
+        That's why we decided to drop support for referencing container images via the \`build\` config field.
 
         For example, a configuration like
 
@@ -363,11 +369,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         name: backend
         description: Backend service container
         type: container
-        build: backend # <-- old config style uses \`build\` field
-
-        spec:
-          image: \${actions.build.backend.outputs.deploymentImageId}
-        ...
+        build: backend # <-- old config style uses \`build\` field. The \`spec.image\` did not need to be specified.
         \`\`\`
 
         should be replaced with
@@ -383,15 +385,11 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         name: backend
         description: Backend service container
         type: container
-
-        # use \`dependencies\` field instead of the \`build\`
-        dependencies:
-        - build.backend
-
         spec:
-          image: \${actions.build.backend.outputs.deploymentImageId}
-        ...
+          image: \${actions.build.backend.outputs.deploymentImageId} # <--- the new config style is more explicit.
         \`\`\`
+
+        Garden automatically determines the execution order of actions (First building the backend container, then deploying the backend) based on the output references.
       `,
     },
     rsyncBuildStaging: {

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -14,6 +14,7 @@ import type { Log } from "../logger/log-entry.js"
 import dedent from "dedent"
 import { deline } from "./string.js"
 import type { SyncCommandName } from "../commands/sync/sync.js"
+import { getGlobalProjectApiVersion } from "../project-api-version.js"
 
 const deprecatedPluginNames = ["conftest", "conftest-container", "conftest-kubernetes", "hadolint", "octant"] as const
 export type DeprecatedPluginName = (typeof deprecatedPluginNames)[number]
@@ -550,12 +551,13 @@ class FeatureNotAvailable extends GardenError {
 }
 
 type DeprecationWarningParams = {
-  apiVersion: GardenApiVersion
   log: Log
   deprecation: Deprecation
 }
 
-export function reportDeprecatedFeatureUsage({ apiVersion, log, deprecation }: DeprecationWarningParams) {
+export function reportDeprecatedFeatureUsage({ log, deprecation }: DeprecationWarningParams) {
+  const apiVersion = getGlobalProjectApiVersion()
+
   if (apiVersion === GardenApiVersion.v2) {
     throw new FeatureNotAvailable({ deprecation })
   }
@@ -565,16 +567,16 @@ export function reportDeprecatedFeatureUsage({ apiVersion, log, deprecation }: D
 }
 
 export function reportDeprecatedSyncCommandUsage({
-  apiVersion,
   log,
   deprecation,
   syncCommandName,
 }: {
-  apiVersion: GardenApiVersion
   log: Log
   deprecation: Deprecation
   syncCommandName: SyncCommandName
 }) {
+  const apiVersion = getGlobalProjectApiVersion()
+
   if (apiVersion === GardenApiVersion.v2) {
     const message = deline`
     Command ${styles.command(`sync ${syncCommandName}`)} can only be executed in the dev console.
@@ -584,17 +586,7 @@ export function reportDeprecatedSyncCommandUsage({
   }
 
   reportDeprecatedFeatureUsage({
-    apiVersion,
     log,
     deprecation,
   })
-}
-
-export function reportDefaultConfigValueChange({ apiVersion, log, deprecation }: DeprecationWarningParams) {
-  // Avoids throwing an error in `reportDeprecatedFeatureUsage`
-  if (apiVersion === GardenApiVersion.v2) {
-    return
-  }
-
-  reportDeprecatedFeatureUsage({ apiVersion, log, deprecation })
 }

--- a/core/test/setup.ts
+++ b/core/test/setup.ts
@@ -16,8 +16,7 @@ import { initTestLogger, testProjectTempDirs } from "./helpers.js"
 import mocha from "mocha"
 import sourceMapSupport from "source-map-support"
 import { UnresolvedTemplateValue } from "../src/template/types.js"
-import { setProjectApiVersion } from "../src/project-api-version.js"
-import { RootLogger } from "../src/logger/logger.js"
+import { setGloablProjectApiVersion } from "../src/project-api-version.js"
 
 sourceMapSupport.install()
 
@@ -48,8 +47,6 @@ mocha.utils.canonicalize = function (value, stack, typeHint) {
   return origCanonicalize(value, stack, typeHint)
 }
 
-const log = RootLogger.getInstance().createLog()
-
 // Global hooks
 export const mochaHooks = {
   async beforeAll() {
@@ -68,8 +65,7 @@ export const mochaHooks = {
 
   beforeEach() {
     // Init globally stored project-level apiVersion, assuming garden.io/v1 for 0.13.
-    // TODO(0.14): Remove global project apiVersion?
-    setProjectApiVersion({ apiVersion: GardenApiVersion.v1 }, log)
+    setGloablProjectApiVersion(GardenApiVersion.v1)
   },
 
   afterEach() {

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -133,8 +133,10 @@ describe("prepareProjectResource", () => {
     }
     expect(returnedProjectResource).to.eql(expectedProjectResource)
 
-    const logEntry = log.getLatestEntry()
-    expect(logEntry.msg).to.include(`"apiVersion" is missing in the Project config`)
+    const acornLogEntry = log.entries.slice(-2)[0]
+    expect(acornLogEntry.msg).to.include(`"apiVersion" is missing in the Project config`)
+    const cedarLogEntry = log.getLatestEntry()
+    expect(cedarLogEntry.msg).to.include(`Garden 0.14 will introduce breaking changes.`)
   })
 
   it("should log a warning if the apiVersion is garden.io/v0", async () => {

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -31,9 +31,8 @@ import { TestContext } from "./config/template-contexts/base.js"
 import type { Collection } from "../../../src/util/objects.js"
 import type { ParsedTemplate } from "../../../src/template/types.js"
 import type { ConfigContext } from "../../../src/config/template-contexts/base.js"
-import { setProjectApiVersion } from "../../../src/project-api-version.js"
+import { setGloablProjectApiVersion } from "../../../src/project-api-version.js"
 import { GardenApiVersion } from "../../../src/constants.js"
-import { RootLogger } from "../../../src/logger/logger.js"
 
 describe("template string access protection", () => {
   it("should crash when an unresolved value is accidentally treated as resolved", () => {
@@ -55,10 +54,8 @@ describe("template string access protection", () => {
 })
 
 describe("parse and evaluate template strings with apiVersion: garden.io/v2", () => {
-  const log = RootLogger.getInstance().createLog()
-
   beforeEach(() => {
-    setProjectApiVersion({ apiVersion: GardenApiVersion.v2 }, log)
+    setGloablProjectApiVersion(GardenApiVersion.v2)
   })
 
   describe("should resolve ? suffix as a regular character", () => {

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -245,10 +245,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -249,10 +249,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -251,10 +251,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -249,10 +249,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -253,10 +253,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -245,10 +245,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -251,10 +251,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -249,10 +249,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -245,10 +245,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -251,10 +251,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -247,10 +247,6 @@ Whether the varfile is optional.
 
 ### `build`
 
-{% hint style="warning" %}
-**Deprecated**: Use the `dependencies` config to define the build dependencies. Using the `build` config field in runtime actions will not be supported anymore in Garden 0.14.
-{% endhint %}
-
 Specify a _Build_ action, and resolve this action from the context of that Build.
 
 For example, you might create an `exec` Build which prepares some manifests, and then reference that in a `kubernetes` _Deploy_ action, and the resulting manifests from the Build.

--- a/plugins/conftest/src/index.ts
+++ b/plugins/conftest/src/index.ts
@@ -283,7 +283,6 @@ export const gardenPlugin = () =>
           handlers: <TestActionHandlers<TestAction<ConftestHelmTestConfig>>>{
             configure: async ({ ctx, config, log }) => {
               reportDeprecatedFeatureUsage({
-                apiVersion: ctx.projectApiVersion,
                 log,
                 deprecation: "conftestPlugin",
               })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
- fix: reduce scope of the \`build\` deprecation to the \`container\` action type
- chore: clean up the apiVersion and deprecation code
- test: fix test failure in prepareProjectResource

**Which issue(s) this PR fixes**:
Fixes the module backwards-compatibility when using `apiVersion: garden.io/v2` in the project-level configuration.

**Special notes for your reviewer**:
Best to review the two commits separately.