### PR TITLE
(0.13) fix: add deprecation for action volume references, as that's implied when deprecating persistentvolumeclaim and configmap action types

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -664,7 +664,10 @@ const volumeSchema = createSchema({
 
         Note: Make sure to pay attention to the supported \`accessModes\` of the referenced volume. Unless it supports the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple services at the same time. Refer to the documentation of the module type in question to learn more.
         `
-      ),
+      )
+      .meta({
+        deprecated: makeDeprecationMessage({ deprecation: "containerVolumeActions" }),
+      }),
   }),
   oxor: [["hostPath", "action"]],
 })

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -55,7 +55,7 @@ import type { PluginContext } from "../../plugin-context.js"
 import { actionReferenceToString } from "../../actions/base.js"
 import { RootLogger } from "../../logger/logger.js"
 import { styles } from "../../logger/styles.js"
-import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
+import { makeDeprecationMessage, reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 import { getGlobalProjectApiVersion } from "../../project-api-version.js"
 
 export const CONTAINER_STATUS_CONCURRENCY_LIMIT = gardenEnv.GARDEN_HARD_CONCURRENCY_LIMIT
@@ -103,7 +103,9 @@ export const configSchema = () =>
           Extra flags to pass to the \`docker build\` command. Will extend the \`spec.extraFlags\` specified in each container Build action.
           `),
       // Deprecate old config syntax
-      gardenCloudBuilder: gardenContainerBuilderSchema().meta({ deprecated: true }),
+      gardenCloudBuilder: gardenContainerBuilderSchema().meta({
+        deprecated: makeDeprecationMessage({ deprecation: "gardenCloudBuilder" }),
+      }),
       // Garden Container builder
       gardenContainerBuilder: gardenContainerBuilderSchema(),
     })

--- a/core/src/plugins/container/moduleConfig.ts
+++ b/core/src/plugins/container/moduleConfig.ts
@@ -35,6 +35,7 @@ import {
   volumeSchemaBase,
 } from "./config.js"
 import { kebabCase, mapKeys } from "lodash-es"
+import { makeDeprecationMessage } from "../../util/deprecations.js"
 
 /**
  * PLEASE DO NOT UPDATE THESE SCHEMAS UNLESS ABSOLUTELY NECESSARY, AND IF YOU DO, MAKE SURE
@@ -102,15 +103,19 @@ const moduleVolumesSchema = () =>
   getContainerVolumesSchema(
     volumeSchemaBase()
       .keys({
-        module: joiIdentifier().description(
-          dedent`
+        module: joiIdentifier()
+          .description(
+            dedent`
             The name of a _volume module_ that should be mounted at \`containerPath\`. The supported module types will depend on which provider you are using. The \`kubernetes\` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 
             When a \`module\` is specified, the referenced module/volume will be automatically configured as a runtime dependency of this service, as well as a build dependency of this module.
 
             Note: Make sure to pay attention to the supported \`accessModes\` of the referenced volume. Unless it supports the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple services at the same time. Refer to the documentation of the module type in question to learn more.
             `
-        ),
+          )
+          .meta({
+            deprecated: makeDeprecationMessage({ deprecation: "containerVolumeActions" }),
+          }),
       })
       .oxor("hostPath", "module")
   ).description(dedent`

--- a/core/src/plugins/kubernetes/kubernetes-type/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/config.ts
@@ -37,7 +37,7 @@ import type { ApplyParams } from "../kubectl.js"
 import { getGlobalProjectApiVersion } from "../../../project-api-version.js"
 import { GardenApiVersion } from "../../../constants.js"
 import type { Log } from "../../../logger/log-entry.js"
-import { reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
+import { makeDeprecationMessage, reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
 
 export interface KubernetesTypeCommonDeploySpec {
   // TODO(0.14): remove this field
@@ -162,7 +162,11 @@ export const kubernetesApplyArgsSchema = () =>
 type KubernetesCommonDeployKeyDeprecations = { deprecateFiles: boolean }
 
 export const kubernetesCommonDeploySpecKeys = (deprecations: KubernetesCommonDeployKeyDeprecations) => ({
-  files: kubernetesManifestTemplatesSchema().meta({ deprecated: deprecations.deprecateFiles }),
+  files: kubernetesManifestTemplatesSchema().meta({
+    deprecated: deprecations.deprecateFiles
+      ? makeDeprecationMessage({ deprecation: "kubernetesActionSpecFiles" })
+      : false,
+  }),
   kustomize: kustomizeSpecSchema(),
   manifests: kubernetesManifestsSchema(),
   patchResources: kubernetesPatchResourcesSchema(),

--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
@@ -34,6 +34,7 @@ import type { TestActionConfig, TestAction } from "../../../actions/test.js"
 import { composeCacheableTestResult, testResultCache } from "../test-results.js"
 import { k8sGetTestResult } from "../test-results.js"
 import { toActionStatus } from "../results-cache.js"
+import { makeDeprecationMessage } from "../../../util/deprecations.js"
 
 // RUN //
 
@@ -83,7 +84,9 @@ export const kubernetesRunPodSchema = (kind: ActionKind) => {
       manifests: kubernetesManifestsSchema().description(
         `List of Kubernetes resource manifests to be searched (using \`resource\`e for the pod spec for the ${kind}. If \`files\` is also specified, this is combined with the manifests read from the files.`
       ),
-      files: kubernetesPodManifestTemplatesSchema(kind).meta({ deprecated: true }),
+      files: kubernetesPodManifestTemplatesSchema(kind).meta({
+        deprecated: makeDeprecationMessage({ deprecation: "kubernetesActionSpecFiles" }),
+      }),
       manifestFiles: kubernetesManifestFilesSchema(),
       manifestTemplates: kubernetesPodManifestTemplatesSchema(kind),
       resource: runPodResourceSchema(kind),

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -442,6 +442,17 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         For more information how to use Persistent Volume Claims using Kubernetes manifests, refer to the [official Kubernetes documentation on configuring persistent volume storage](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
       `,
     },
+    containerVolumeActions: {
+      docsSection: "Garden action types",
+      docsHeadline: `Volume container action references`,
+      warnHint: `Volume container action references will be removed in Garden 0.14. Use the ${style("kubernetes")} action type instead of the ${style("container")} action type if you need persistent volume claims or mount configmaps.`,
+      docs: dedent`
+        Referencing \`persistentvolumeclaim\` and \`configmap\` action or module types from \`container\` Deploy actions will not be supported anymore in Garden 0.14.
+
+        <!-- markdown-link-check-disable-next-line -->
+        See also the deprecation notices for [the ${style("persistentvolumeclaim")} Deploy action type](#persistentvolumeclaimDeployAction)) and [the ${style("configmap")} Deploy action type](#configmapDeployAction)).
+      `,
+    },
     optionalTemplateValueSyntax: {
       docsSection: "Template Language",
       docsHeadline: `Optional template expressions`,

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -405,6 +405,15 @@ The `persistentvolumeclaim` Deploy action type will be removed in the next major
 
 For more information how to use Persistent Volume Claims using Kubernetes manifests, refer to the [official Kubernetes documentation on configuring persistent volume storage](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
 
+<h2 id="containervolumeactions">Volume container action references</h2>
+
+Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+
+Referencing `persistentvolumeclaim` and `configmap` action or module types from `container` Deploy actions will not be supported anymore in Garden 0.14.
+
+<!-- markdown-link-check-disable-next-line -->
+See also the deprecation notices for [the `persistentvolumeclaim` Deploy action type](#persistentvolumeclaimDeployAction)) and [the `configmap` Deploy action type](#configmapDeployAction)).
+
 # Template Language
 
 <h2 id="optionaltemplatevaluesyntax">Optional template expressions</h2>

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -455,6 +455,10 @@ spec:
 
 [spec](#spec) > [volumes](#specvolumes) > action
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The action reference to a _volume Deploy action_ that should be mounted at `containerPath`. The supported action types are `persistentvolumeclaim` and `configmap`.
 
 Note: Make sure to pay attention to the supported `accessModes` of the referenced volume. Unless it supports the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple services at the same time. Refer to the documentation of the module type in question to learn more.

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -286,7 +286,7 @@ Timeout for the deploy to complete, in seconds.
 [spec](#spec) > files
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: `spec.files` in `kubernetes` Deploy actions will be removed in Garden 0.14. Use `spec.manifestTemplates` and/or `spec.manifestFiles` instead.
 {% endhint %}
 
 POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests.

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -455,6 +455,10 @@ spec:
 
 [spec](#spec) > [volumes](#specvolumes) > action
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The action reference to a _volume Deploy action_ that should be mounted at `containerPath`. The supported action types are `persistentvolumeclaim` and `configmap`.
 
 Note: Make sure to pay attention to the supported `accessModes` of the referenced volume. Unless it supports the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple services at the same time. Refer to the documentation of the module type in question to learn more.

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -564,7 +564,7 @@ The name of the resource.
 [spec](#spec) > files
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: `spec.files` in `kubernetes` Deploy actions will be removed in Garden 0.14. Use `spec.manifestTemplates` and/or `spec.manifestFiles` instead.
 {% endhint %}
 
 POSIX-style paths to YAML files to load manifests from. Each file may contain multiple manifests.

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -455,6 +455,10 @@ spec:
 
 [spec](#spec) > [volumes](#specvolumes) > action
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The action reference to a _volume Deploy action_ that should be mounted at `containerPath`. The supported action types are `persistentvolumeclaim` and `configmap`.
 
 Note: Make sure to pay attention to the supported `accessModes` of the referenced volume. Unless it supports the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple services at the same time. Refer to the documentation of the module type in question to learn more.

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -564,7 +564,7 @@ The name of the resource.
 [spec](#spec) > files
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: `spec.files` in `kubernetes` Deploy actions will be removed in Garden 0.14. Use `spec.manifestTemplates` and/or `spec.manifestFiles` instead.
 {% endhint %}
 
 POSIX-style paths to YAML files to load manifests from. Each file may contain multiple manifests.

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1371,6 +1371,10 @@ services:
 
 [services](#services) > [volumes](#servicesvolumes) > module
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The name of a _volume module_ that should be mounted at `containerPath`. The supported module types will depend on which provider you are using. The `kubernetes` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 
 When a `module` is specified, the referenced module/volume will be automatically configured as a runtime dependency of this service, as well as a build dependency of this module.
@@ -2305,6 +2309,10 @@ tests:
 
 [tests](#tests) > [volumes](#testsvolumes) > module
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The name of a _volume module_ that should be mounted at `containerPath`. The supported module types will depend on which provider you are using. The `kubernetes` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 
 When a `module` is specified, the referenced module/volume will be automatically configured as a runtime dependency of this service, as well as a build dependency of this module.
@@ -2678,6 +2686,10 @@ tasks:
 ### `tasks[].volumes[].module`
 
 [tasks](#tasks) > [volumes](#tasksvolumes) > module
+
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
 
 The name of a _volume module_ that should be mounted at `containerPath`. The supported module types will depend on which provider you are using. The `kubernetes` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -1586,6 +1586,10 @@ services:
 
 [services](#services) > [volumes](#servicesvolumes) > module
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The name of a _volume module_ that should be mounted at `containerPath`. The supported module types will depend on which provider you are using. The `kubernetes` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 
 When a `module` is specified, the referenced module/volume will be automatically configured as a runtime dependency of this service, as well as a build dependency of this module.
@@ -2520,6 +2524,10 @@ tests:
 
 [tests](#tests) > [volumes](#testsvolumes) > module
 
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
+
 The name of a _volume module_ that should be mounted at `containerPath`. The supported module types will depend on which provider you are using. The `kubernetes` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 
 When a `module` is specified, the referenced module/volume will be automatically configured as a runtime dependency of this service, as well as a build dependency of this module.
@@ -2893,6 +2901,10 @@ tasks:
 ### `tasks[].volumes[].module`
 
 [tasks](#tasks) > [volumes](#tasksvolumes) > module
+
+{% hint style="warning" %}
+**Deprecated**: Volume container action references will be removed in Garden 0.14. Use the `kubernetes` action type instead of the `container` action type if you need persistent volume claims or mount configmaps.
+{% endhint %}
 
 The name of a _volume module_ that should be mounted at `containerPath`. The supported module types will depend on which provider you are using. The `kubernetes` provider supports the [persistentvolumeclaim module](./persistentvolumeclaim.md), for example.
 

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -155,7 +155,7 @@ Extra flags to pass to the `docker build` command. Will extend the `spec.extraFl
 [providers](#providers) > gardenCloudBuilder
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: The `gardenCloudBuilder` setting in the `container` provider configuration has been renamed to `gardenContainerBuilder`. Use the setting `gardenContainerBuilder` instead of `gardenCloudBuilder`.
 {% endhint %}
 
 | Type     | Required |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
