### PR TITLE
docs: change docs baseurl to latest version

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -53,7 +53,7 @@ export const SUPPORTED_ARCHITECTURES: NodeJS.Architecture[] = ["x64", "arm64"]
 export const SEGMENT_DEV_API_KEY = "D3DUZ3lBSDO3krnuIO7eYDdtlDAjooKW" // ggignore
 export const SEGMENT_PROD_API_KEY = "b6ovUD9A0YjQqT3ZWetWUbuZ9OmGxKMa" // ggignore
 
-export const DOCS_BASE_URL = "https://docs.garden.io"
+export const DOCS_BASE_URL = "https://docs.garden.io/cedar-0.14"
 
 export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://beta.app.garden.io"
 

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -53,7 +53,7 @@ export const SUPPORTED_ARCHITECTURES: NodeJS.Architecture[] = ["x64", "arm64"]
 export const SEGMENT_DEV_API_KEY = "D3DUZ3lBSDO3krnuIO7eYDdtlDAjooKW" // ggignore
 export const SEGMENT_PROD_API_KEY = "b6ovUD9A0YjQqT3ZWetWUbuZ9OmGxKMa" // ggignore
 
-export const DOCS_BASE_URL = "https://docs.garden.io/bonsai-0.13"
+export const DOCS_BASE_URL = "https://docs.garden.io"
 
 export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://beta.app.garden.io"
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -74,10 +74,6 @@ For projects that aren't connected to Garden Cloud/Enterprise, or when you're us
 
 Garden will skip `Test` and `Run` actions that already ran from your local machine, but team members and CI workflows won't be able to benefit from the cache entries on your local machine.
 
-<h2 id="kubernetesclusterinitcommand"><code>garden kubernetes cluster-init</code></h2>
-
-This command will be removed in 0.14. Do not use this command. It has no effect.
-
 <h2 id="syncstartcommand"><code>garden sync start</code></h2>
 
 The command `garden sync start` will only be available inside the dev console (`garden dev`) in the next major version of Garden, 0.14. Do not use it as a standalone Garden command.

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -275,7 +275,7 @@ Specify a list of POSIX-style paths or globs that should be included as the buil
 
 If nothing is specified here, the whole directory may be assumed to be included in the build. Providers are sometimes able to infer the list of paths, e.g. from a Dockerfile, but often this is inaccurate (say, if a Dockerfile has an `ADD .` statement) so it may be important to set `include` and/or `exclude` to define the build context. Otherwise you may find unrelated files being included in the build context and the build version, which may result in unnecessarily repeated builds.
 
-You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -275,7 +275,7 @@ Specify a list of POSIX-style paths or globs that should be included as the buil
 
 If nothing is specified here, the whole directory may be assumed to be included in the build. Providers are sometimes able to infer the list of paths, e.g. from a Dockerfile, but often this is inaccurate (say, if a Dockerfile has an `ADD .` statement) so it may be important to set `include` and/or `exclude` to define the build context. Otherwise you may find unrelated files being included in the build context and the build version, which may result in unnecessarily repeated builds.
 
-You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -275,7 +275,7 @@ Specify a list of POSIX-style paths or globs that should be included as the buil
 
 If nothing is specified here, the whole directory may be assumed to be included in the build. Providers are sometimes able to infer the list of paths, e.g. from a Dockerfile, but often this is inaccurate (say, if a Dockerfile has an `ADD .` statement) so it may be important to set `include` and/or `exclude` to define the build context. Otherwise you may find unrelated files being included in the build context and the build version, which may result in unnecessarily repeated builds.
 
-You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -275,7 +275,7 @@ Specify a list of POSIX-style paths or globs that should be included as the buil
 
 If nothing is specified here, the whole directory may be assumed to be included in the build. Providers are sometimes able to infer the list of paths, e.g. from a Dockerfile, but often this is inaccurate (say, if a Dockerfile has an `ADD .` statement) so it may be important to set `include` and/or `exclude` to define the build context. Otherwise you may find unrelated files being included in the build context and the build version, which may result in unnecessarily repeated builds.
 
-You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -57,7 +57,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -287,7 +287,7 @@ Specify a list of POSIX-style paths or globs that should be included as the buil
 
 If nothing is specified here, the whole directory may be assumed to be included in the build. Providers are sometimes able to infer the list of paths, e.g. from a Dockerfile, but often this is inaccurate (say, if a Dockerfile has an `ADD .` statement) so it may be important to set `include` and/or `exclude` to define the build context. Otherwise you may find unrelated files being included in the build context and the build version, which may result in unnecessarily repeated builds.
 
-You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -57,7 +57,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -287,7 +287,7 @@ Specify a list of POSIX-style paths or globs that should be included as the buil
 
 If nothing is specified here, the whole directory may be assumed to be included in the build. Providers are sometimes able to infer the list of paths, e.g. from a Dockerfile, but often this is inaccurate (say, if a Dockerfile has an `ADD .` statement) so it may be important to set `include` and/or `exclude` to define the build context. Otherwise you may find unrelated files being included in the build context and the build version, which may result in unnecessarily repeated builds.
 
-You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -539,7 +539,7 @@ Specifies which files or directories to sync to which paths inside the running c
 
 Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -649,7 +649,7 @@ spec:
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
@@ -713,7 +713,7 @@ Local mode always takes the precedence over sync mode if there are any conflicti
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+See the [Local Mode guide](https://docs.garden.io/cedar-0.14/guides/running-service-in-local-mode) for more information.
 
 Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -539,7 +539,7 @@ Specifies which files or directories to sync to which paths inside the running c
 
 Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -649,7 +649,7 @@ spec:
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
@@ -713,7 +713,7 @@ Local mode always takes the precedence over sync mode if there are any conflicti
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://docs.garden.io/bonsai-0.13/guides/running-service-in-local-mode) for more information.
+See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
 
 Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -145,7 +145,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -163,7 +163,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -145,7 +145,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -163,7 +163,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -49,7 +49,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -149,7 +149,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -167,7 +167,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -777,7 +777,7 @@ spec:
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -49,7 +49,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -149,7 +149,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -167,7 +167,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -777,7 +777,7 @@ spec:
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -11,7 +11,7 @@ Specify one or more Kubernetes manifests to deploy.
 
 You can either (or both) specify the manifests as part of the `garden.yml` configuration, or you can refer to one or more files with existing manifests.
 
-Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/bonsai-0.13/config-guides/variables-and-templating) to interpolate values into the manifests.
+Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/config-guides/variables-and-templating) to interpolate values into the manifests.
 
 If you need more advanced templating features you can use the [helm](./helm.md) Deploy type.
 
@@ -51,7 +51,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -151,7 +151,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -169,7 +169,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -799,7 +799,7 @@ spec:
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -11,7 +11,7 @@ Specify one or more Kubernetes manifests to deploy.
 
 You can either (or both) specify the manifests as part of the `garden.yml` configuration, or you can refer to one or more files with existing manifests.
 
-Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/config-guides/variables-and-templating) to interpolate values into the manifests.
+Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/cedar-0.14/config-guides/variables-and-templating) to interpolate values into the manifests.
 
 If you need more advanced templating features you can use the [helm](./helm.md) Deploy type.
 
@@ -51,7 +51,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -151,7 +151,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -169,7 +169,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -799,7 +799,7 @@ spec:
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -49,7 +49,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -149,7 +149,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -167,7 +167,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -49,7 +49,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -149,7 +149,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -167,7 +167,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -15,7 +15,7 @@ Stack outputs are made available as service outputs, that can be referenced by o
 
 Note that you can also declare a Terraform root in the `terraform` provider configuration by setting the `initRoot` parameter. This may be preferable if you need the outputs of the Terraform stack to be available to other provider configurations, e.g. if you spin up an environment with the Terraform provider, and then use outputs from that to configure another provider or other actions via `${providers.terraform.outputs.<key>}` template strings.
 
-See the [Terraform guide](https://docs.garden.io/advanced/terraform) for a high-level introduction to the `terraform` provider.
+See the [Terraform guide](https://docs.garden.io/cedar-0.14/advanced/terraform) for a high-level introduction to the `terraform` provider.
 
 Below is the full schema reference for the action.
 
@@ -53,7 +53,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -153,7 +153,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -171,7 +171,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -15,7 +15,7 @@ Stack outputs are made available as service outputs, that can be referenced by o
 
 Note that you can also declare a Terraform root in the `terraform` provider configuration by setting the `initRoot` parameter. This may be preferable if you need the outputs of the Terraform stack to be available to other provider configurations, e.g. if you spin up an environment with the Terraform provider, and then use outputs from that to configure another provider or other actions via `${providers.terraform.outputs.<key>}` template strings.
 
-See the [Terraform guide](https://docs.garden.io/bonsai-0.13/advanced/terraform) for a high-level introduction to the `terraform` provider.
+See the [Terraform guide](https://docs.garden.io/advanced/terraform) for a high-level introduction to the `terraform` provider.
 
 Below is the full schema reference for the action.
 
@@ -53,7 +53,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -153,7 +153,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -171,7 +171,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -145,7 +145,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -163,7 +163,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -145,7 +145,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -163,7 +163,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -145,7 +145,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -163,7 +163,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -45,7 +45,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -145,7 +145,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -163,7 +163,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -47,7 +47,7 @@ By default, the directory where the action is defined is used as the source for 
 
 You can override the directory that is used for the build context by setting `source.path`.
 
-You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+You can use `source.repository` to get the source from an external repository. For more information on remote actions, please refer to the [Remote Sources guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ For actions other than _Build_ actions, this is usually not necessary to specify
 
 _Build_ actions have a different behavior, since they generally are based on some files in the source tree, so please reference the docs for more information on those.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -165,7 +165,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be explicitly excluded from the action's version.
 
-For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred. For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set `include` paths, or such paths inferred by providers. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes when watching is enabled. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1565,7 +1565,7 @@ providers:
         #
         # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
         # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-        # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+        # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
         # for details.
         #
         # Also note that specifying an empty list here means _no sources_ should be included.
@@ -1578,7 +1578,7 @@ providers:
         # Note that you can also explicitly _include_ files using the `include` field. If you also specify the
         # `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
         # [Configuration Files
-        # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+        # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
         # for details.
         #
         # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -1819,7 +1819,8 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources
+      # guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -1966,7 +1967,7 @@ actionConfigs:
       #
       # You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree,
       # which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2004,7 +2005,8 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources
+      # guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -2065,7 +2067,7 @@ actionConfigs:
       #
       # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
       # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2075,7 +2077,7 @@ actionConfigs:
       # For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred.
       # For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set
       # `include` paths, or such paths inferred by providers. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       #
       # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -2159,7 +2161,8 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources
+      # guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -2220,7 +2223,7 @@ actionConfigs:
       #
       # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
       # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2230,7 +2233,7 @@ actionConfigs:
       # For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred.
       # For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set
       # `include` paths, or such paths inferred by providers. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       #
       # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -2314,7 +2317,8 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources
+      # guide](https://docs.garden.io/cedar-0.14/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -2375,7 +2379,7 @@ actionConfigs:
       #
       # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
       # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2385,7 +2389,7 @@ actionConfigs:
       # For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred.
       # For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set
       # `include` paths, or such paths inferred by providers. See the [Configuration Files
-      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       #
       # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -2515,8 +2519,8 @@ moduleConfigs:
     #
     # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
     # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-    # details.
+    # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+    # for details.
     #
     # Also note that specifying an empty list here means _no sources_ should be included.
     include:
@@ -2528,8 +2532,8 @@ moduleConfigs:
     # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
     # field, the files/patterns specified here are filtered from the files matched by `include`. See the
     # [Configuration Files
-    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-    # details.
+    # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+    # for details.
     #
     # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
     # directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large
@@ -2823,8 +2827,8 @@ workflowConfigs:
         #
         # `never`: This step will always be ignored.
         #
-        # See the [workflows guide](https://docs.garden.io/config-guides/workflows#the-skip-and-when-options) for
-        # details
+        # See the [workflows
+        # guide](https://docs.garden.io/cedar-0.14/config-guides/workflows#the-skip-and-when-options) for details
         # and examples.
         when:
 
@@ -3088,8 +3092,8 @@ modules:
     #
     # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
     # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-    # details.
+    # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+    # for details.
     #
     # Also note that specifying an empty list here means _no sources_ should be included.
     include:
@@ -3101,8 +3105,8 @@ modules:
     # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
     # field, the files/patterns specified here are filtered from the files matched by `include`. See the
     # [Configuration Files
-    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-    # details.
+    # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+    # for details.
     #
     # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
     # directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1565,7 +1565,7 @@ providers:
         #
         # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
         # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-        # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+        # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
         # for details.
         #
         # Also note that specifying an empty list here means _no sources_ should be included.
@@ -1578,7 +1578,7 @@ providers:
         # Note that you can also explicitly _include_ files using the `include` field. If you also specify the
         # `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
         # [Configuration Files
-        # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+        # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
         # for details.
         #
         # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -1819,8 +1819,7 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -1967,7 +1966,7 @@ actionConfigs:
       #
       # You can _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree,
       # which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2005,8 +2004,7 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -2067,7 +2065,7 @@ actionConfigs:
       #
       # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
       # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2077,7 +2075,7 @@ actionConfigs:
       # For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred.
       # For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set
       # `include` paths, or such paths inferred by providers. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       #
       # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -2161,8 +2159,7 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -2223,7 +2220,7 @@ actionConfigs:
       #
       # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
       # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2233,7 +2230,7 @@ actionConfigs:
       # For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred.
       # For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set
       # `include` paths, or such paths inferred by providers. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       #
       # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -2317,8 +2314,7 @@ actionConfigs:
       # You can override the directory that is used for the build context by setting `source.path`.
       #
       # You can use `source.repository` to get the source from an external repository. For more information on remote
-      # actions, please refer to the [Remote Sources
-      # guide](https://docs.garden.io/bonsai-0.13/advanced/using-remote-sources).
+      # actions, please refer to the [Remote Sources guide](https://docs.garden.io/advanced/using-remote-sources).
       source:
         # A relative POSIX-style path to the source directory for this action.
         #
@@ -2379,7 +2375,7 @@ actionConfigs:
       #
       # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
       # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       include:
 
@@ -2389,7 +2385,7 @@ actionConfigs:
       # For actions other than _Build_ actions, this is usually not necessary to specify, or is implicitly inferred.
       # For _Deploy_, _Run_ and _Test_ actions, the exclusions specified here only applied on top of explicitly set
       # `include` paths, or such paths inferred by providers. See the [Configuration Files
-      # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+      # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
       # for details.
       #
       # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -2519,8 +2515,8 @@ moduleConfigs:
     #
     # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
     # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-    # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-    # for details.
+    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+    # details.
     #
     # Also note that specifying an empty list here means _no sources_ should be included.
     include:
@@ -2532,8 +2528,8 @@ moduleConfigs:
     # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
     # field, the files/patterns specified here are filtered from the files matched by `include`. See the
     # [Configuration Files
-    # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-    # for details.
+    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+    # details.
     #
     # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
     # directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large
@@ -2827,8 +2823,8 @@ workflowConfigs:
         #
         # `never`: This step will always be ignored.
         #
-        # See the [workflows
-        # guide](https://docs.garden.io/bonsai-0.13/config-guides/workflows#the-skip-and-when-options) for details
+        # See the [workflows guide](https://docs.garden.io/config-guides/workflows#the-skip-and-when-options) for
+        # details
         # and examples.
         when:
 
@@ -3092,8 +3088,8 @@ modules:
     #
     # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
     # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-    # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-    # for details.
+    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+    # details.
     #
     # Also note that specifying an empty list here means _no sources_ should be included.
     include:
@@ -3105,8 +3101,8 @@ modules:
     # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
     # field, the files/patterns specified here are filtered from the files matched by `include`. See the
     # [Configuration Files
-    # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-    # for details.
+    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+    # details.
     #
     # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
     # directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -104,8 +104,8 @@ modules:
     #
     # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
     # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-    # details.
+    # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+    # for details.
     #
     # Also note that specifying an empty list here means _no sources_ should be included.
     include:
@@ -117,8 +117,8 @@ modules:
     # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
     # field, the files/patterns specified here are filtered from the files matched by `include`. See the
     # [Configuration Files
-    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-    # details.
+    # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+    # for details.
     #
     # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
     # directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large
@@ -426,7 +426,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -449,7 +449,7 @@ modules:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -104,8 +104,8 @@ modules:
     #
     # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
     # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
-    # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-    # for details.
+    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+    # details.
     #
     # Also note that specifying an empty list here means _no sources_ should be included.
     include:
@@ -117,8 +117,8 @@ modules:
     # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
     # field, the files/patterns specified here are filtered from the files matched by `include`. See the
     # [Configuration Files
-    # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-    # for details.
+    # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+    # details.
     #
     # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
     # directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large
@@ -426,7 +426,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -449,7 +449,7 @@ modules:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -95,8 +95,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -114,8 +114,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -316,8 +315,7 @@ services:
     #
     # Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
     #
-    # See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more
-    # information.
+    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
     sync:
       # Override the default container arguments when in sync mode.
       args:
@@ -345,7 +343,7 @@ services:
           exclude:
 
           # The sync mode to use for the given paths. See the [Code Synchronization
-          # guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+          # guide](https://docs.garden.io/guides/code-synchronization) for details.
           mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -381,8 +379,7 @@ services:
     #
     # Health checks are disabled for services running in local mode.
     #
-    # See the [Local Mode guide](https://docs.garden.io/bonsai-0.13/guides/running-service-in-local-mode) for more
-    # information.
+    # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
     #
     # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
     # release.
@@ -901,7 +898,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -928,7 +925,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1421,7 +1418,7 @@ Specifies which files or directories to sync to which paths inside the running c
 
 Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1528,7 +1525,7 @@ services:
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
@@ -1592,7 +1589,7 @@ Local mode always takes the precedence over sync mode if there are any conflicti
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://docs.garden.io/bonsai-0.13/guides/running-service-in-local-mode) for more information.
+See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
 
 Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -95,8 +95,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -114,7 +114,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -315,7 +316,8 @@ services:
     #
     # Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
     #
-    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+    # See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more
+    # information.
     sync:
       # Override the default container arguments when in sync mode.
       args:
@@ -343,7 +345,7 @@ services:
           exclude:
 
           # The sync mode to use for the given paths. See the [Code Synchronization
-          # guide](https://docs.garden.io/guides/code-synchronization) for details.
+          # guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
           mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -379,7 +381,8 @@ services:
     #
     # Health checks are disabled for services running in local mode.
     #
-    # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+    # See the [Local Mode guide](https://docs.garden.io/cedar-0.14/guides/running-service-in-local-mode) for more
+    # information.
     #
     # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
     # release.
@@ -898,7 +901,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -925,7 +928,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1418,7 +1421,7 @@ Specifies which files or directories to sync to which paths inside the running c
 
 Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1525,7 +1528,7 @@ services:
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
@@ -1589,7 +1592,7 @@ Local mode always takes the precedence over sync mode if there are any conflicti
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+See the [Local Mode guide](https://docs.garden.io/cedar-0.14/guides/running-service-in-local-mode) for more information.
 
 Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -99,8 +99,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -111,8 +111,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -522,7 +521,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -542,7 +541,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -99,8 +99,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -111,7 +111,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -521,7 +522,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -541,7 +542,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -89,8 +89,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -107,8 +107,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -249,8 +248,7 @@ dependencies: []
 #
 # Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 #
-# See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more
-# information.
+# See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 sync:
   # Override the default container arguments when in sync mode.
   args:
@@ -278,7 +276,7 @@ sync:
       exclude:
 
       # The sync mode to use for the given paths. See the [Code Synchronization
-      # guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+      # guide](https://docs.garden.io/guides/code-synchronization) for details.
       mode: one-way-safe
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -793,7 +791,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -819,7 +817,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1107,7 +1105,7 @@ Note that `serviceResource` must also be specified to enable sync.
 
 Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1211,7 +1209,7 @@ sync:
 
 [sync](#sync) > [paths](#syncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -89,8 +89,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -107,7 +107,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -248,7 +249,8 @@ dependencies: []
 #
 # Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 #
-# See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+# See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more
+# information.
 sync:
   # Override the default container arguments when in sync mode.
   args:
@@ -276,7 +278,7 @@ sync:
       exclude:
 
       # The sync mode to use for the given paths. See the [Code Synchronization
-      # guide](https://docs.garden.io/guides/code-synchronization) for details.
+      # guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
       mode: one-way-safe
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -791,7 +793,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -817,7 +819,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1105,7 +1107,7 @@ Note that `serviceResource` must also be specified to enable sync.
 
 Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1209,7 +1211,7 @@ sync:
 
 [sync](#sync) > [paths](#syncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -163,8 +163,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -182,8 +182,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -384,8 +383,7 @@ services:
     #
     # Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
     #
-    # See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more
-    # information.
+    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
     sync:
       # Override the default container arguments when in sync mode.
       args:
@@ -413,7 +411,7 @@ services:
           exclude:
 
           # The sync mode to use for the given paths. See the [Code Synchronization
-          # guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+          # guide](https://docs.garden.io/guides/code-synchronization) for details.
           mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -449,8 +447,7 @@ services:
     #
     # Health checks are disabled for services running in local mode.
     #
-    # See the [Local Mode guide](https://docs.garden.io/bonsai-0.13/guides/running-service-in-local-mode) for more
-    # information.
+    # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
     #
     # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
     # release.
@@ -1116,7 +1113,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -1143,7 +1140,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1636,7 +1633,7 @@ Specifies which files or directories to sync to which paths inside the running c
 
 Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1743,7 +1740,7 @@ services:
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
@@ -1807,7 +1804,7 @@ Local mode always takes the precedence over sync mode if there are any conflicti
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://docs.garden.io/bonsai-0.13/guides/running-service-in-local-mode) for more information.
+See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
 
 Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -163,8 +163,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -182,7 +182,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -383,7 +384,8 @@ services:
     #
     # Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
     #
-    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+    # See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more
+    # information.
     sync:
       # Override the default container arguments when in sync mode.
       args:
@@ -411,7 +413,7 @@ services:
           exclude:
 
           # The sync mode to use for the given paths. See the [Code Synchronization
-          # guide](https://docs.garden.io/guides/code-synchronization) for details.
+          # guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
           mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -447,7 +449,8 @@ services:
     #
     # Health checks are disabled for services running in local mode.
     #
-    # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+    # See the [Local Mode guide](https://docs.garden.io/cedar-0.14/guides/running-service-in-local-mode) for more
+    # information.
     #
     # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
     # release.
@@ -1113,7 +1116,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -1140,7 +1143,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1633,7 +1636,7 @@ Specifies which files or directories to sync to which paths inside the running c
 
 Sync is enabled e.g. by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1740,7 +1743,7 @@ services:
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
@@ -1804,7 +1807,7 @@ Local mode always takes the precedence over sync mode if there are any conflicti
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+See the [Local Mode guide](https://docs.garden.io/cedar-0.14/guides/running-service-in-local-mode) for more information.
 
 Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -15,7 +15,7 @@ Specify one or more Kubernetes manifests to deploy.
 
 You can either (or both) specify the manifests as part of the `garden.yml` configuration, or you can refer to one or more files with existing manifests.
 
-Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/config-guides/variables-and-templating) to interpolate values into the manifests.
+Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/cedar-0.14/config-guides/variables-and-templating) to interpolate values into the manifests.
 
 If you need more advanced templating features you can use the [helm](./helm.md) Deploy type.
 
@@ -91,8 +91,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -106,7 +106,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -275,7 +276,8 @@ dependencies: []
 #
 # Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 #
-# See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+# See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more
+# information.
 sync:
   # Override the default container arguments when in sync mode.
   args:
@@ -303,7 +305,7 @@ sync:
       exclude:
 
       # The sync mode to use for the given paths. See the [Code Synchronization
-      # guide](https://docs.garden.io/guides/code-synchronization) for details.
+      # guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
       mode: one-way-safe
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -775,7 +777,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -798,7 +800,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1171,7 +1173,7 @@ Note that `serviceResource` must also be specified to enable sync.
 
 Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1275,7 +1277,7 @@ sync:
 
 [sync](#sync) > [paths](#syncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -15,7 +15,7 @@ Specify one or more Kubernetes manifests to deploy.
 
 You can either (or both) specify the manifests as part of the `garden.yml` configuration, or you can refer to one or more files with existing manifests.
 
-Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/bonsai-0.13/config-guides/variables-and-templating) to interpolate values into the manifests.
+Note that if you include the manifests in the `garden.yml` file, you can use [template strings](https://docs.garden.io/config-guides/variables-and-templating) to interpolate values into the manifests.
 
 If you need more advanced templating features you can use the [helm](./helm.md) Deploy type.
 
@@ -91,8 +91,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 #
@@ -106,8 +106,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -276,8 +275,7 @@ dependencies: []
 #
 # Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 #
-# See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more
-# information.
+# See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 sync:
   # Override the default container arguments when in sync mode.
   args:
@@ -305,7 +303,7 @@ sync:
       exclude:
 
       # The sync mode to use for the given paths. See the [Code Synchronization
-      # guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+      # guide](https://docs.garden.io/guides/code-synchronization) for details.
       mode: one-way-safe
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0o644
@@ -777,7 +775,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -800,7 +798,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -1173,7 +1171,7 @@ Note that `serviceResource` must also be specified to enable sync.
 
 Sync is enabled by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1277,7 +1275,7 @@ sync:
 
 [sync](#sync) > [paths](#syncpaths) > mode
 
-The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for details.
+The sync mode to use for the given paths. See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for details.
 
 | Type     | Allowed Values                                                                                                                            | Default          | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -89,8 +89,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -101,7 +101,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -426,7 +427,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -446,7 +447,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -89,8 +89,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -101,8 +101,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -427,7 +426,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -447,7 +446,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -83,8 +83,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -95,7 +95,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -325,7 +326,7 @@ Set to true to skip rendering this template.
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -345,7 +346,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -83,8 +83,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -95,8 +95,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -326,7 +325,7 @@ Set to true to skip rendering this template.
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -346,7 +345,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -19,7 +19,7 @@ Stack outputs are made available as service outputs, that can be referenced by o
 
 Note that you can also declare a Terraform root in the `terraform` provider configuration by setting the `initRoot` parameter. This may be preferable if you need the outputs of the Terraform stack to be available to other provider configurations, e.g. if you spin up an environment with the Terraform provider, and then use outputs from that to configure another provider or other modules via `${providers.terraform.outputs.<key>}` template strings.
 
-See the [Terraform guide](https://docs.garden.io/advanced/terraform) for a high-level introduction to the `terraform` provider.
+See the [Terraform guide](https://docs.garden.io/cedar-0.14/advanced/terraform) for a high-level introduction to the `terraform` provider.
 
 Below is the full schema reference.
 
@@ -93,8 +93,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -105,7 +105,8 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -366,7 +367,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -386,7 +387,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -19,7 +19,7 @@ Stack outputs are made available as service outputs, that can be referenced by o
 
 Note that you can also declare a Terraform root in the `terraform` provider configuration by setting the `initRoot` parameter. This may be preferable if you need the outputs of the Terraform stack to be available to other provider configurations, e.g. if you spin up an environment with the Terraform provider, and then use outputs from that to configure another provider or other modules via `${providers.terraform.outputs.<key>}` template strings.
 
-See the [Terraform guide](https://docs.garden.io/bonsai-0.13/advanced/terraform) for a high-level introduction to the `terraform` provider.
+See the [Terraform guide](https://docs.garden.io/advanced/terraform) for a high-level introduction to the `terraform` provider.
 
 Below is the full schema reference.
 
@@ -93,8 +93,8 @@ disabled: false
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
 # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
@@ -105,8 +105,7 @@ include:
 #
 # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
 # field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
-# Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
 # for details.
 #
 # Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and
@@ -367,7 +366,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -387,7 +386,7 @@ include:
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `scan.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `scan.exclude` field to affect those, if you have large directories that should not be watched for changes.
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -35,7 +35,8 @@ The values in the schema below are the default values.
 # activates the breaking changes introduced in Garden 0.14.
 # The list of breaking changes is not final yet, so use this setting at your own risk.
 #
-# Please refer to [the deprecations guide](https://docs.garden.io/guides/deprecations) for more information.
+# Please refer to [the deprecations guide](https://docs.garden.io/cedar-0.14/guides/deprecations) for more
+# information.
 apiVersion:
 
 # Indicate what kind of config this is.
@@ -116,8 +117,8 @@ defaultEnvironment: ''
 # Note that this take precedence over the project `scan.include` field, and action `include` fields, so any paths
 # matched by the .ignore file will be ignored even if they are explicitly specified in those fields.
 # See the [Configuration Files
-# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-# details.
+# guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
 dotIgnoreFile: .gardenignore
 
 proxy:
@@ -132,8 +133,8 @@ scan:
   #
   # Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source
   # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-  # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-  # details.
+  # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+  # for details.
   #
   # Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories Garden
   # watches for changes. Use the `exclude` field to affect those, if you have large directories that should not be
@@ -157,8 +158,8 @@ scan:
   # The `include` field does _not_ affect which files are watched.
   #
   # See the [Configuration Files
-  # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
-  # details.
+  # guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories)
+  # for details.
   exclude:
 
   git:
@@ -239,7 +240,7 @@ EXPERIMENTAL: Configuring garden.io/v2 explicitly in your project configuration
 activates the breaking changes introduced in Garden 0.14.
 The list of breaking changes is not final yet, so use this setting at your own risk.
 
-Please refer to [the deprecations guide](https://docs.garden.io/guides/deprecations) for more information.
+Please refer to [the deprecations guide](https://docs.garden.io/cedar-0.14/guides/deprecations) for more information.
 
 | Type     | Allowed Values                                 | Required |
 | -------- | ---------------------------------------------- | -------- |
@@ -463,7 +464,7 @@ defaultEnvironment: "dev"
 
 Specify a filename that should be used as ".ignore" file across the project, using the same syntax and semantics as `.gitignore` files. By default, patterns matched in `.gardenignore` files, found anywhere in the project, are ignored when scanning for actions and action sources.
 Note that this take precedence over the project `scan.include` field, and action `include` fields, so any paths matched by the .ignore file will be ignored even if they are explicitly specified in those fields.
-See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type        | Default           | Required |
 | ----------- | ----------------- | -------- |
@@ -515,7 +516,7 @@ Control where and how to scan for configuration files in the project.
 
 Specify a list of POSIX-style paths or globs that should be scanned for Garden configuration files.
 
-Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories Garden watches for changes. Use the `exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -548,7 +549,7 @@ Note that you can also explicitly _include_ files using the `include` field. If 
 
 The `include` field does _not_ affect which files are watched.
 
-See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+See the [Configuration Files guide](https://docs.garden.io/cedar-0.14/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -35,8 +35,7 @@ The values in the schema below are the default values.
 # activates the breaking changes introduced in Garden 0.14.
 # The list of breaking changes is not final yet, so use this setting at your own risk.
 #
-# Please refer to [the deprecations guide](https://docs.garden.io/bonsai-0.13/guides/deprecations) for more
-# information.
+# Please refer to [the deprecations guide](https://docs.garden.io/guides/deprecations) for more information.
 apiVersion:
 
 # Indicate what kind of config this is.
@@ -117,8 +116,8 @@ defaultEnvironment: ''
 # Note that this take precedence over the project `scan.include` field, and action `include` fields, so any paths
 # matched by the .ignore file will be ignored even if they are explicitly specified in those fields.
 # See the [Configuration Files
-# guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-# for details.
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
 dotIgnoreFile: .gardenignore
 
 proxy:
@@ -133,8 +132,8 @@ scan:
   #
   # Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source
   # tree, which use the same format as `.gitignore` files. See the [Configuration Files
-  # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-  # for details.
+  # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+  # details.
   #
   # Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories Garden
   # watches for changes. Use the `exclude` field to affect those, if you have large directories that should not be
@@ -158,8 +157,8 @@ scan:
   # The `include` field does _not_ affect which files are watched.
   #
   # See the [Configuration Files
-  # guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories)
-  # for details.
+  # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+  # details.
   exclude:
 
   git:
@@ -240,7 +239,7 @@ EXPERIMENTAL: Configuring garden.io/v2 explicitly in your project configuration
 activates the breaking changes introduced in Garden 0.14.
 The list of breaking changes is not final yet, so use this setting at your own risk.
 
-Please refer to [the deprecations guide](https://docs.garden.io/bonsai-0.13/guides/deprecations) for more information.
+Please refer to [the deprecations guide](https://docs.garden.io/guides/deprecations) for more information.
 
 | Type     | Allowed Values                                 | Required |
 | -------- | ---------------------------------------------- | -------- |
@@ -464,7 +463,7 @@ defaultEnvironment: "dev"
 
 Specify a filename that should be used as ".ignore" file across the project, using the same syntax and semantics as `.gitignore` files. By default, patterns matched in `.gardenignore` files, found anywhere in the project, are ignored when scanning for actions and action sources.
 Note that this take precedence over the project `scan.include` field, and action `include` fields, so any paths matched by the .ignore file will be ignored even if they are explicitly specified in those fields.
-See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type        | Default           | Required |
 | ----------- | ----------------- | -------- |
@@ -516,7 +515,7 @@ Control where and how to scan for configuration files in the project.
 
 Specify a list of POSIX-style paths or globs that should be scanned for Garden configuration files.
 
-Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories Garden watches for changes. Use the `exclude` field to affect those, if you have large directories that should not be watched for changes.
 
@@ -549,7 +548,7 @@ Note that you can also explicitly _include_ files using the `include` field. If 
 
 The `include` field does _not_ affect which files are watched.
 
-See the [Configuration Files guide](https://docs.garden.io/bonsai-0.13/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -51,7 +51,7 @@ providers:
     # between multiple developers, as well as between your development and CI workflows.
     #
     # For more details on all the different options and what makes sense to use for your setup, please check out the
-    # [in-cluster building guide](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/guides/in-cluster-building).
+    # [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
     buildMode: local-docker
 
     # Configuration options for the `cluster-buildkit` build mode.
@@ -333,8 +333,7 @@ providers:
       #
       # Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
       #
-      # See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more
-      # information.
+      # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
       defaults:
         # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
         #
@@ -631,7 +630,7 @@ Otherwise the utility images are pulled directly from Docker Hub by default.
 
 Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
 
-For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/guides/in-cluster-building).
+For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
 
 | Type     | Allowed Values                               | Default          | Required |
 | -------- | -------------------------------------------- | ---------------- | -------- |
@@ -1337,7 +1336,7 @@ These are overridden/extended by the settings of any individual sync specs.
 
 Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -51,7 +51,7 @@ providers:
     # between multiple developers, as well as between your development and CI workflows.
     #
     # For more details on all the different options and what makes sense to use for your setup, please check out the
-    # [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
+    # [in-cluster building guide](https://docs.garden.io/cedar-0.14/kubernetes-plugins/guides/in-cluster-building).
     buildMode: local-docker
 
     # Configuration options for the `cluster-buildkit` build mode.
@@ -333,7 +333,8 @@ providers:
       #
       # Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
       #
-      # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+      # See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more
+      # information.
       defaults:
         # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
         #
@@ -630,7 +631,7 @@ Otherwise the utility images are pulled directly from Docker Hub by default.
 
 Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
 
-For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
+For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/cedar-0.14/kubernetes-plugins/guides/in-cluster-building).
 
 | Type     | Allowed Values                               | Default          | Required |
 | -------- | -------------------------------------------- | ---------------- | -------- |
@@ -1336,7 +1337,7 @@ These are overridden/extended by the settings of any individual sync specs.
 
 Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -9,9 +9,9 @@ tocTitle: "`local-kubernetes`"
 
 The `local-kubernetes` provider is a specialized version of the [`kubernetes` provider](./kubernetes.md) that automates and simplifies working with local Kubernetes clusters.
 
-For general Kubernetes usage information, please refer to the [Kubernetes guides](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/about). For local clusters a good place to start is the [Local Kubernetes](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/local-k8s) guide.
+For general Kubernetes usage information, please refer to the [Kubernetes guides](https://docs.garden.io/kubernetes-plugins/about). For local clusters a good place to start is the [Local Kubernetes](https://docs.garden.io/kubernetes-plugins/local-k8s) guide.
 
-If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](./kubernetes.md) docs, and the [Remote Kubernetes guide](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/remote-k8s) guide.
+If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](./kubernetes.md) docs, and the [Remote Kubernetes guide](https://docs.garden.io/kubernetes-plugins/remote-k8s) guide.
 
 Below is the full schema reference for the provider configuration..
 
@@ -45,7 +45,7 @@ providers:
     # between multiple developers, as well as between your development and CI workflows.
     #
     # For more details on all the different options and what makes sense to use for your setup, please check out the
-    # [in-cluster building guide](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/guides/in-cluster-building).
+    # [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
     buildMode: local-docker
 
     # Configuration options for the `cluster-buildkit` build mode.
@@ -327,8 +327,7 @@ providers:
       #
       # Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
       #
-      # See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more
-      # information.
+      # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
       defaults:
         # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
         #
@@ -577,7 +576,7 @@ Otherwise the utility images are pulled directly from Docker Hub by default.
 
 Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
 
-For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/bonsai-0.13/kubernetes-plugins/guides/in-cluster-building).
+For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
 
 | Type     | Allowed Values                               | Default          | Required |
 | -------- | -------------------------------------------- | ---------------- | -------- |
@@ -1283,7 +1282,7 @@ These are overridden/extended by the settings of any individual sync specs.
 
 Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/bonsai-0.13/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -9,9 +9,9 @@ tocTitle: "`local-kubernetes`"
 
 The `local-kubernetes` provider is a specialized version of the [`kubernetes` provider](./kubernetes.md) that automates and simplifies working with local Kubernetes clusters.
 
-For general Kubernetes usage information, please refer to the [Kubernetes guides](https://docs.garden.io/kubernetes-plugins/about). For local clusters a good place to start is the [Local Kubernetes](https://docs.garden.io/kubernetes-plugins/local-k8s) guide.
+For general Kubernetes usage information, please refer to the [Kubernetes guides](https://docs.garden.io/cedar-0.14/kubernetes-plugins/about). For local clusters a good place to start is the [Local Kubernetes](https://docs.garden.io/cedar-0.14/kubernetes-plugins/local-k8s) guide.
 
-If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](./kubernetes.md) docs, and the [Remote Kubernetes guide](https://docs.garden.io/kubernetes-plugins/remote-k8s) guide.
+If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](./kubernetes.md) docs, and the [Remote Kubernetes guide](https://docs.garden.io/cedar-0.14/kubernetes-plugins/remote-k8s) guide.
 
 Below is the full schema reference for the provider configuration..
 
@@ -45,7 +45,7 @@ providers:
     # between multiple developers, as well as between your development and CI workflows.
     #
     # For more details on all the different options and what makes sense to use for your setup, please check out the
-    # [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
+    # [in-cluster building guide](https://docs.garden.io/cedar-0.14/kubernetes-plugins/guides/in-cluster-building).
     buildMode: local-docker
 
     # Configuration options for the `cluster-buildkit` build mode.
@@ -327,7 +327,8 @@ providers:
       #
       # Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
       #
-      # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+      # See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more
+      # information.
       defaults:
         # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
         #
@@ -576,7 +577,7 @@ Otherwise the utility images are pulled directly from Docker Hub by default.
 
 Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
 
-For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/kubernetes-plugins/guides/in-cluster-building).
+For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/cedar-0.14/kubernetes-plugins/guides/in-cluster-building).
 
 | Type     | Allowed Values                               | Default          | Required |
 | -------- | -------------------------------------------- | ---------------- | -------- |
@@ -1282,7 +1283,7 @@ These are overridden/extended by the settings of any individual sync specs.
 
 Sync is enabled e.g by setting the `--sync` flag on the `garden deploy` command.
 
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization) for more information.
+See the [Code Synchronization guide](https://docs.garden.io/cedar-0.14/guides/code-synchronization) for more information.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -7,7 +7,7 @@ tocTitle: "`terraform`"
 
 ## Description
 
-This provider allows you to integrate Terraform stacks into your Garden project. See the [Terraform guide](https://docs.garden.io/advanced/terraform) for details and usage information.
+This provider allows you to integrate Terraform stacks into your Garden project. See the [Terraform guide](https://docs.garden.io/cedar-0.14/advanced/terraform) for details and usage information.
 
 Below is the full schema reference for the provider configuration..
 
@@ -41,7 +41,7 @@ providers:
     # Specify the path to a Terraform config directory, that should be resolved when initializing the provider. This
     # is useful when other providers need to be able to reference the outputs from the stack.
     #
-    # See the [Terraform guide](https://docs.garden.io/advanced/terraform) for more information.
+    # See the [Terraform guide](https://docs.garden.io/cedar-0.14/advanced/terraform) for more information.
     initRoot:
 
     # A map of variables to use when applying Terraform stacks. You can define these here, in individual
@@ -157,7 +157,7 @@ If set to true, Garden will automatically run `terraform apply -auto-approve` wh
 
 Specify the path to a Terraform config directory, that should be resolved when initializing the provider. This is useful when other providers need to be able to reference the outputs from the stack.
 
-See the [Terraform guide](https://docs.garden.io/advanced/terraform) for more information.
+See the [Terraform guide](https://docs.garden.io/cedar-0.14/advanced/terraform) for more information.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -7,7 +7,7 @@ tocTitle: "`terraform`"
 
 ## Description
 
-This provider allows you to integrate Terraform stacks into your Garden project. See the [Terraform guide](https://docs.garden.io/bonsai-0.13/advanced/terraform) for details and usage information.
+This provider allows you to integrate Terraform stacks into your Garden project. See the [Terraform guide](https://docs.garden.io/advanced/terraform) for details and usage information.
 
 Below is the full schema reference for the provider configuration..
 
@@ -41,7 +41,7 @@ providers:
     # Specify the path to a Terraform config directory, that should be resolved when initializing the provider. This
     # is useful when other providers need to be able to reference the outputs from the stack.
     #
-    # See the [Terraform guide](https://docs.garden.io/bonsai-0.13/advanced/terraform) for more information.
+    # See the [Terraform guide](https://docs.garden.io/advanced/terraform) for more information.
     initRoot:
 
     # A map of variables to use when applying Terraform stacks. You can define these here, in individual
@@ -157,7 +157,7 @@ If set to true, Garden will automatically run `terraform apply -auto-approve` wh
 
 Specify the path to a Terraform config directory, that should be resolved when initializing the provider. This is useful when other providers need to be able to reference the outputs from the stack.
 
-See the [Terraform guide](https://docs.garden.io/bonsai-0.13/advanced/terraform) for more information.
+See the [Terraform guide](https://docs.garden.io/advanced/terraform) for more information.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -401,7 +401,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -417,7 +417,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -469,7 +469,7 @@ my-variable: ${modules.<module-name>.path}
 
 ### `${modules.<module-name>.outputs.*}`
 
-The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -477,7 +477,7 @@ The outputs defined by the module (see individual module type [references](https
 
 ### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -609,7 +609,7 @@ The variables configured on the action.
 
 ### `${runtime.build.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -617,7 +617,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.build.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -727,7 +727,7 @@ The variables configured on the action.
 
 ### `${runtime.deploy.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -735,7 +735,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.deploy.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -845,7 +845,7 @@ The variables configured on the action.
 
 ### `${runtime.run.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -853,7 +853,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.run.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -963,7 +963,7 @@ The variables configured on the action.
 
 ### `${runtime.test.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -971,7 +971,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.test.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1081,7 +1081,7 @@ The variables configured on the action.
 
 ### `${runtime.services.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1089,7 +1089,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.services.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1199,7 +1199,7 @@ The variables configured on the action.
 
 ### `${runtime.tasks.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1207,7 +1207,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.tasks.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1325,7 +1325,7 @@ The variables configured on the action.
 
 ### `${actions.build.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1333,7 +1333,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.build.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1443,7 +1443,7 @@ The variables configured on the action.
 
 ### `${actions.deploy.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1451,7 +1451,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.deploy.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1561,7 +1561,7 @@ The variables configured on the action.
 
 ### `${actions.run.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1569,7 +1569,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.run.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1679,7 +1679,7 @@ The variables configured on the action.
 
 ### `${actions.test.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1687,7 +1687,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.test.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1797,7 +1797,7 @@ The variables configured on the action.
 
 ### `${actions.services.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1805,7 +1805,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.services.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1915,7 +1915,7 @@ The variables configured on the action.
 
 ### `${actions.tasks.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/cedar-0.14/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1923,7 +1923,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.tasks.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/cedar-0.14/reference) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -401,7 +401,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -417,7 +417,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -469,7 +469,7 @@ my-variable: ${modules.<module-name>.path}
 
 ### `${modules.<module-name>.outputs.*}`
 
-The outputs defined by the module (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -477,7 +477,7 @@ The outputs defined by the module (see individual module type [references](https
 
 ### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -609,7 +609,7 @@ The variables configured on the action.
 
 ### `${runtime.build.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -617,7 +617,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.build.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -727,7 +727,7 @@ The variables configured on the action.
 
 ### `${runtime.deploy.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -735,7 +735,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.deploy.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -845,7 +845,7 @@ The variables configured on the action.
 
 ### `${runtime.run.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -853,7 +853,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.run.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -963,7 +963,7 @@ The variables configured on the action.
 
 ### `${runtime.test.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -971,7 +971,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.test.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1081,7 +1081,7 @@ The variables configured on the action.
 
 ### `${runtime.services.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1089,7 +1089,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.services.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1199,7 +1199,7 @@ The variables configured on the action.
 
 ### `${runtime.tasks.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1207,7 +1207,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${runtime.tasks.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1325,7 +1325,7 @@ The variables configured on the action.
 
 ### `${actions.build.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1333,7 +1333,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.build.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1443,7 +1443,7 @@ The variables configured on the action.
 
 ### `${actions.deploy.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1451,7 +1451,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.deploy.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1561,7 +1561,7 @@ The variables configured on the action.
 
 ### `${actions.run.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1569,7 +1569,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.run.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1679,7 +1679,7 @@ The variables configured on the action.
 
 ### `${actions.test.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1687,7 +1687,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.test.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1797,7 +1797,7 @@ The variables configured on the action.
 
 ### `${actions.services.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1805,7 +1805,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.services.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -1915,7 +1915,7 @@ The variables configured on the action.
 
 ### `${actions.tasks.<action-name>.outputs.*}`
 
-The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/bonsai-0.13/reference) for details).
+The outputs defined by the action (see individual action/module type [references](https://docs.garden.io/reference) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -1923,7 +1923,7 @@ The outputs defined by the action (see individual action/module type [references
 
 ### `${actions.tasks.<action-name>.outputs.<output-name>}`
 
-The action output value. Refer to individual [action/module type references](https://docs.garden.io/bonsai-0.13/reference) for details.
+The action output value. Refer to individual [action/module type references](https://docs.garden.io/reference) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -401,7 +401,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -417,7 +417,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -469,7 +469,7 @@ my-variable: ${modules.<module-name>.path}
 
 ### `${modules.<module-name>.outputs.*}`
 
-The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -477,7 +477,7 @@ The outputs defined by the module (see individual module type [references](https
 
 ### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -529,7 +529,7 @@ Runtime information from the services that the service/task being run depends on
 
 ### `${runtime.services.<service-name>.outputs.*}`
 
-The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -537,7 +537,7 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 ### `${runtime.services.<service-name>.outputs.<output-name>}`
 
-The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The service output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -567,7 +567,7 @@ Runtime information from the tasks that the service/task being run depends on.
 
 ### `${runtime.tasks.<task-name>.outputs.*}`
 
-The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -575,7 +575,7 @@ The runtime outputs defined by the task (see individual module type [references]
 
 ### `${runtime.tasks.<task-name>.outputs.<output-name>}`
 
-The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The task output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -401,7 +401,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -417,7 +417,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -469,7 +469,7 @@ my-variable: ${modules.<module-name>.path}
 
 ### `${modules.<module-name>.outputs.*}`
 
-The outputs defined by the module (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -477,7 +477,7 @@ The outputs defined by the module (see individual module type [references](https
 
 ### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -529,7 +529,7 @@ Runtime information from the services that the service/task being run depends on
 
 ### `${runtime.services.<service-name>.outputs.*}`
 
-The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -537,7 +537,7 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 ### `${runtime.services.<service-name>.outputs.<output-name>}`
 
-The service output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -567,7 +567,7 @@ Runtime information from the tasks that the service/task being run depends on.
 
 ### `${runtime.tasks.<task-name>.outputs.*}`
 
-The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -575,7 +575,7 @@ The runtime outputs defined by the task (see individual module type [references]
 
 ### `${runtime.tasks.<task-name>.outputs.<output-name>}`
 
-The task output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -401,7 +401,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -417,7 +417,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -469,7 +469,7 @@ my-variable: ${modules.<module-name>.path}
 
 ### `${modules.<module-name>.outputs.*}`
 
-The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -477,7 +477,7 @@ The outputs defined by the module (see individual module type [references](https
 
 ### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -529,7 +529,7 @@ Runtime information from the services that the service/task being run depends on
 
 ### `${runtime.services.<service-name>.outputs.*}`
 
-The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -537,7 +537,7 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 ### `${runtime.services.<service-name>.outputs.<output-name>}`
 
-The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The service output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -567,7 +567,7 @@ Runtime information from the tasks that the service/task being run depends on.
 
 ### `${runtime.tasks.<task-name>.outputs.*}`
 
-The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/cedar-0.14/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -575,7 +575,7 @@ The runtime outputs defined by the task (see individual module type [references]
 
 ### `${runtime.tasks.<task-name>.outputs.<output-name>}`
 
-The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+The task output value. Refer to individual [module type references](https://docs.garden.io/cedar-0.14/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -401,7 +401,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -417,7 +417,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -469,7 +469,7 @@ my-variable: ${modules.<module-name>.path}
 
 ### `${modules.<module-name>.outputs.*}`
 
-The outputs defined by the module (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -477,7 +477,7 @@ The outputs defined by the module (see individual module type [references](https
 
 ### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -529,7 +529,7 @@ Runtime information from the services that the service/task being run depends on
 
 ### `${runtime.services.<service-name>.outputs.*}`
 
-The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -537,7 +537,7 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 ### `${runtime.services.<service-name>.outputs.<output-name>}`
 
-The service output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -567,7 +567,7 @@ Runtime information from the tasks that the service/task being run depends on.
 
 ### `${runtime.tasks.<task-name>.outputs.*}`
 
-The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details).
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
 
 | Type     | Default |
 | -------- | ------- |
@@ -575,7 +575,7 @@ The runtime outputs defined by the task (see individual module type [references]
 
 ### `${runtime.tasks.<task-name>.outputs.<output-name>}`
 
-The task output value. Refer to individual [module type references](https://docs.garden.io/bonsai-0.13/reference/module-types) for details.
+The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -397,7 +397,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -413,7 +413,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/cedar-0.14/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -397,7 +397,7 @@ The resolved configuration for the provider.
 
 ### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |
@@ -413,7 +413,7 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 ### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](https://docs.garden.io/bonsai-0.13/reference/providers) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
 | Type                          |
 | ----------------------------- |

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -126,7 +126,8 @@ steps:
     #
     # `never`: This step will always be ignored.
     #
-    # See the [workflows guide](https://docs.garden.io/config-guides/workflows#the-skip-and-when-options) for details
+    # See the [workflows guide](https://docs.garden.io/cedar-0.14/config-guides/workflows#the-skip-and-when-options)
+    # for details
     # and examples.
     when: onSuccess
 
@@ -481,7 +482,7 @@ If the next step has `when: onError`, it will also be run. Otherwise, all subseq
 
 `never`: This step will always be ignored.
 
-See the [workflows guide](https://docs.garden.io/config-guides/workflows#the-skip-and-when-options) for details
+See the [workflows guide](https://docs.garden.io/cedar-0.14/config-guides/workflows#the-skip-and-when-options) for details
 and examples.
 
 | Type     | Default       | Required |

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -126,8 +126,7 @@ steps:
     #
     # `never`: This step will always be ignored.
     #
-    # See the [workflows guide](https://docs.garden.io/bonsai-0.13/config-guides/workflows#the-skip-and-when-options)
-    # for details
+    # See the [workflows guide](https://docs.garden.io/config-guides/workflows#the-skip-and-when-options) for details
     # and examples.
     when: onSuccess
 
@@ -482,7 +481,7 @@ If the next step has `when: onError`, it will also be run. Otherwise, all subseq
 
 `never`: This step will always be ignored.
 
-See the [workflows guide](https://docs.garden.io/bonsai-0.13/config-guides/workflows#the-skip-and-when-options) for details
+See the [workflows guide](https://docs.garden.io/config-guides/workflows#the-skip-and-when-options) for details
 and examples.
 
 | Type     | Default       | Required |


### PR DESCRIPTION
I think we should consider prefixing all docs with the version number,
and forwarding from / to the latest version. @eysi do you think that's
possible?
Otherwise older versions will always link to 404 when we restructure
docs, and it's kind of a hassle to change this constant back and forth
between launches
