### PR TITLE
(cherry pick #6979) feat(framework): automatically infer action dependencies from references of Build actions outputs

### DIFF
--- a/core/src/project-api-version.ts
+++ b/core/src/project-api-version.ts
@@ -22,7 +22,7 @@ export function getGlobalProjectApiVersion(): GardenApiVersion {
   return projectApiVersionGlobal
 }
 
-export function setGloablProjectApiVersion(apiVersion: GardenApiVersion) {
+export function setGlobalProjectApiVersion(apiVersion: GardenApiVersion) {
   projectApiVersionGlobal = apiVersion
 }
 
@@ -44,7 +44,7 @@ export function resolveApiVersion(projectSpec: ProjectConfig, log: Log): GardenA
 
   // HACK: Set project API version globally.
   // This makes it easier to use `reportDeprecatedFeatureUsage`, as it can be difficult at times to pass down the apiVersion
-  setGloablProjectApiVersion(resolvedApiVersion)
+  setGlobalProjectApiVersion(resolvedApiVersion)
 
   if (declaredApiVersion !== GardenApiVersion.v2) {
     // Print the deprecation warning that 0.14 will only support apiVersion v2

--- a/core/test/setup.ts
+++ b/core/test/setup.ts
@@ -16,7 +16,7 @@ import { initTestLogger, testProjectTempDirs } from "./helpers.js"
 import mocha from "mocha"
 import sourceMapSupport from "source-map-support"
 import { UnresolvedTemplateValue } from "../src/template/types.js"
-import { setGloablProjectApiVersion } from "../src/project-api-version.js"
+import { setGlobalProjectApiVersion } from "../src/project-api-version.js"
 
 sourceMapSupport.install()
 
@@ -65,7 +65,7 @@ export const mochaHooks = {
 
   beforeEach() {
     // Init globally stored project-level apiVersion, assuming garden.io/v1 for 0.13.
-    setGloablProjectApiVersion(GardenApiVersion.v1)
+    setGlobalProjectApiVersion(GardenApiVersion.v1)
   },
 
   afterEach() {

--- a/core/test/unit/src/graph/actions.ts
+++ b/core/test/unit/src/graph/actions.ts
@@ -7,13 +7,16 @@
  */
 
 import type { TestGarden } from "../../../helpers.js"
-import { expectError, makeGarden, makeTempDir, noOpTestPlugin } from "../../../helpers.js"
+import { customizedTestPlugin, expectError, makeGarden, makeTempDir, noOpTestPlugin } from "../../../helpers.js"
 import { preprocessActionConfig } from "../../../../src/graph/actions.js"
 import type { RunActionConfig } from "../../../../src/actions/run.js"
-import { DEFAULT_RUN_TIMEOUT_SEC } from "../../../../src/constants.js"
+import { DEFAULT_RUN_TIMEOUT_SEC, GardenApiVersion } from "../../../../src/constants.js"
 import type tmp from "tmp-promise"
 import { expect } from "chai"
 import { parseTemplateCollection } from "../../../../src/template/templated-collections.js"
+import type { BuildActionConfig } from "../../../../src/actions/build.js"
+import { joi } from "../../../../src/config/common.js"
+import { getGlobalProjectApiVersion, setGlobalProjectApiVersion } from "../../../../src/project-api-version.js"
 
 describe("preprocessActionConfig", () => {
   let tmpDir: tmp.DirectoryResult
@@ -21,6 +24,9 @@ describe("preprocessActionConfig", () => {
 
   before(async () => {
     tmpDir = await makeTempDir({ git: true, initialCommit: false })
+  })
+
+  beforeEach(async () => {
     garden = await makeGarden(tmpDir, noOpTestPlugin())
   })
 
@@ -69,6 +75,314 @@ describe("preprocessActionConfig", () => {
   })
 
   context("template strings", () => {
+    context("implicit dependencies inferred from actoin output references", () => {
+      context("a static output is referenced in API version v2", () => {
+        it("should inject an executed=true dependency when the ref is a Build", async () => {
+          garden = await makeGarden(
+            tmpDir,
+            customizedTestPlugin({
+              name: "test",
+              createActionTypes: {
+                Build: [
+                  {
+                    name: "test",
+                    docs: "Test Build action with static output",
+                    schema: joi.object(),
+                    handlers: {},
+                    staticOutputsSchema: joi.object().keys({ someOutput: joi.string() }),
+                  },
+                ],
+              },
+            })
+          )
+
+          setGlobalProjectApiVersion(GardenApiVersion.v2)
+
+          const depBuildConfig: BuildActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Build" as const,
+              type: "test",
+              name: "build-dep",
+              variables: {},
+              spec: { command: ["echo", "build-dep"] },
+            },
+            source: { path: [] },
+          })
+          const runConfig: RunActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Run" as const,
+              type: "exec",
+              name: "with-refs",
+              variables: {},
+              spec: { command: ["echo", "${actions.build.build-dep.outputs.someOutput}"] },
+            },
+            source: { path: [] },
+          })
+
+          const router = await garden.getActionRouter()
+          const actionTypes = await garden.getActionTypes()
+          const definition = actionTypes[runConfig.kind][runConfig.type]?.spec
+
+          const res = await preprocessActionConfig({
+            garden,
+            config: runConfig,
+            configsByKey: { "run.with-refs": runConfig, "build.build-dep": depBuildConfig },
+            actionTypes,
+            definition,
+            router,
+            linkedSources: {},
+            mode: "default",
+            log: garden.log,
+          })
+
+          expect(res.dependencies).to.eql([
+            {
+              explicit: false,
+              kind: "Build",
+              name: "build-dep",
+              needsExecutedOutputs: true, // <-----
+              needsStaticOutputs: false, // <-----
+              type: "test",
+            },
+          ])
+        })
+        it("should not inject an executed=true dependency when the ref is a Run", async () => {
+          garden = await makeGarden(
+            tmpDir,
+            customizedTestPlugin({
+              name: "test",
+              createActionTypes: {
+                Run: [
+                  {
+                    name: "test",
+                    docs: "Run action with static output",
+                    schema: joi.object(),
+                    handlers: {},
+                    staticOutputsSchema: joi.object().keys({ someOutput: joi.string() }),
+                  },
+                ],
+              },
+            })
+          )
+
+          setGlobalProjectApiVersion(GardenApiVersion.v2)
+
+          const depRunConfig: RunActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Run" as const,
+              type: "test",
+              name: "run-dep",
+              variables: {},
+              spec: { command: ["echo", "run-dep"] },
+            },
+            source: { path: [] },
+          })
+          const runConfig: RunActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Run" as const,
+              type: "exec",
+              name: "with-refs",
+              variables: {},
+              spec: { command: ["echo", "${actions.run.run-dep.outputs.someOutput}"] },
+            },
+            source: { path: [] },
+          })
+
+          const router = await garden.getActionRouter()
+          const actionTypes = await garden.getActionTypes()
+          const definition = actionTypes[runConfig.kind][runConfig.type]?.spec
+
+          const res = await preprocessActionConfig({
+            garden,
+            config: runConfig,
+            configsByKey: { "run.with-refs": runConfig, "run.run-dep": depRunConfig },
+            actionTypes,
+            definition,
+            router,
+            linkedSources: {},
+            mode: "default",
+            log: garden.log,
+          })
+
+          expect(res.dependencies).to.eql([
+            {
+              explicit: false,
+              kind: "Run",
+              name: "run-dep",
+              needsExecutedOutputs: false, // <-----
+              needsStaticOutputs: true, // <-----
+              type: "test",
+            },
+          ])
+        })
+      })
+      context("a static output is referenced in API version v1", () => {
+        let globalApiVersionBackup: GardenApiVersion | undefined = undefined
+        try {
+          globalApiVersionBackup = getGlobalProjectApiVersion()
+        } catch (_err) {}
+        before(() => {
+          setGlobalProjectApiVersion(GardenApiVersion.v1)
+        })
+        after(() => {
+          globalApiVersionBackup && setGlobalProjectApiVersion(globalApiVersionBackup)
+        })
+        it("should not inject an executed=true dependency when the ref is a Build", async () => {
+          garden = await makeGarden(
+            tmpDir,
+            customizedTestPlugin({
+              name: "test",
+              createActionTypes: {
+                Build: [
+                  {
+                    name: "test",
+                    docs: "Test Build action with static output",
+                    schema: joi.object(),
+                    handlers: {},
+                    staticOutputsSchema: joi.object().keys({ someOutput: joi.string() }),
+                  },
+                ],
+              },
+            })
+          )
+
+          setGlobalProjectApiVersion(GardenApiVersion.v1)
+
+          const depBuildConfig: BuildActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Build" as const,
+              type: "test",
+              name: "build-dep",
+              variables: {},
+              spec: { command: ["echo", "build-dep"] },
+            },
+            source: { path: [] },
+          })
+          const runConfig: RunActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Run" as const,
+              type: "exec",
+              name: "with-refs",
+              variables: {},
+              spec: { command: ["echo", "${actions.build.build-dep.outputs.someOutput}"] },
+            },
+            source: { path: [] },
+          })
+
+          const router = await garden.getActionRouter()
+          const actionTypes = await garden.getActionTypes()
+          const definition = actionTypes[runConfig.kind][runConfig.type]?.spec
+
+          const res = await preprocessActionConfig({
+            garden,
+            config: runConfig,
+            configsByKey: { "run.with-refs": runConfig, "build.build-dep": depBuildConfig },
+            actionTypes,
+            definition,
+            router,
+            linkedSources: {},
+            mode: "default",
+            log: garden.log,
+          })
+
+          expect(res.dependencies).to.eql([
+            {
+              explicit: false,
+              kind: "Build",
+              name: "build-dep",
+              needsExecutedOutputs: false, // <-----
+              needsStaticOutputs: true, // <-----
+              type: "test",
+            },
+          ])
+        })
+        it("should not inject an executed=true dependency when the ref is a Run", async () => {
+          garden = await makeGarden(
+            tmpDir,
+            customizedTestPlugin({
+              name: "test",
+              createActionTypes: {
+                Run: [
+                  {
+                    name: "test",
+                    docs: "Run action with static output",
+                    schema: joi.object(),
+                    handlers: {},
+                    staticOutputsSchema: joi.object().keys({ someOutput: joi.string() }),
+                  },
+                ],
+              },
+            })
+          )
+
+          setGlobalProjectApiVersion(GardenApiVersion.v1)
+
+          const depRunConfig: RunActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Run" as const,
+              type: "test",
+              name: "run-dep",
+              variables: {},
+              spec: { command: ["echo", "run-dep"] },
+            },
+            source: { path: [] },
+          })
+          const runConfig: RunActionConfig = parseTemplateCollection({
+            value: {
+              internal: { basePath: tmpDir.path },
+              timeout: DEFAULT_RUN_TIMEOUT_SEC,
+              kind: "Run" as const,
+              type: "exec",
+              name: "with-refs",
+              variables: {},
+              spec: { command: ["echo", "${actions.run.run-dep.outputs.someOutput}"] },
+            },
+            source: { path: [] },
+          })
+
+          const router = await garden.getActionRouter()
+          const actionTypes = await garden.getActionTypes()
+          const definition = actionTypes[runConfig.kind][runConfig.type]?.spec
+
+          const res = await preprocessActionConfig({
+            garden,
+            config: runConfig,
+            configsByKey: { "run.with-refs": runConfig, "run.run-dep": depRunConfig },
+            actionTypes,
+            definition,
+            router,
+            linkedSources: {},
+            mode: "default",
+            log: garden.log,
+          })
+
+          expect(res.dependencies).to.eql([
+            {
+              explicit: false,
+              kind: "Run",
+              name: "run-dep",
+              needsExecutedOutputs: false, // <-----
+              needsStaticOutputs: true, // <-----
+              type: "test",
+            },
+          ])
+        })
+      })
+    })
     context("include/exclude configs", () => {
       it("should resolve variables in 'exclude' config", async () => {
         const config: RunActionConfig = parseTemplateCollection({

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -31,7 +31,7 @@ import { TestContext } from "./config/template-contexts/base.js"
 import type { Collection } from "../../../src/util/objects.js"
 import type { ParsedTemplate } from "../../../src/template/types.js"
 import type { ConfigContext } from "../../../src/config/template-contexts/base.js"
-import { setGloablProjectApiVersion } from "../../../src/project-api-version.js"
+import { setGlobalProjectApiVersion } from "../../../src/project-api-version.js"
 import { GardenApiVersion } from "../../../src/constants.js"
 
 describe("template string access protection", () => {
@@ -55,7 +55,7 @@ describe("template string access protection", () => {
 
 describe("parse and evaluate template strings with apiVersion: garden.io/v2", () => {
   beforeEach(() => {
-    setGloablProjectApiVersion(GardenApiVersion.v2)
+    setGlobalProjectApiVersion(GardenApiVersion.v2)
   })
 
   describe("should resolve ? suffix as a regular character", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

improvement(core): fixes to output reference logic

We now infer an `executed: true`  dependency for action output references when the referenced action is a Build, regardless of whether the output is a static or a runtime output.

We only do this for API version v2 (and keep the old behavior for v1 and v0).

This improves the user experience for the common use-case of referencing a container image in a runtime resource (like a `helm` Deploy), where the user intent is almost always that the referenced build should exist (i.e. the dependency should be processed) before the runtime resource is processed (i.e. deployed or run).

This is because Builds generally don't have side-effects other than producing artifacts, whereas Deploys and Runs often do.

Note: We could also always execute Test actions that are referenced, but we'll stick with only Builds for now.