### PR TITLE
fix(template): coerce `null` and empty strings to `undefined` in config fields of type optional-string

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -719,6 +719,7 @@ export const containerRegistryConfigSchema = createSchema({
     namespace: joi
       .string()
       .optional()
+      .empty(["", null])
       .description(
         "The registry namespace. Will be placed between hostname and image name, like so: <hostname>/<namespace>/<image name>"
       )

--- a/core/src/plugins/kubernetes/kubernetes-type/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/config.ts
@@ -77,7 +77,7 @@ const kubernetesPatchResourceSchema = () =>
     strategy: joi
       .string()
       .allow("json", "merge", "strategic")
-      .required()
+      .optional()
       .description(
         dedent`
         The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
@@ -86,8 +86,7 @@ const kubernetesPatchResourceSchema = () =>
         https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
         `
       )
-      .default("strategic")
-      .optional(),
+      .default("strategic"),
     patch: joi.object().required().description("The patch to apply.").unknown(true),
   })
 

--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -40,7 +40,7 @@ export const configSchema = () =>
   kubernetesConfigBase()
     .keys({
       name: joiProviderName("local-kubernetes"),
-      context: k8sContextSchema().optional().allow(null),
+      context: k8sContextSchema().optional().empty(["", null]),
       namespace: namespaceSchema().description(
         "Specify which namespace to deploy services to (defaults to the project name). " +
           "Note that the framework generates other namespaces as well with this name as a prefix."

--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -40,7 +40,7 @@ export const configSchema = () =>
   kubernetesConfigBase()
     .keys({
       name: joiProviderName("local-kubernetes"),
-      context: k8sContextSchema().optional(),
+      context: k8sContextSchema().optional().allow(null),
       namespace: namespaceSchema().description(
         "Specify which namespace to deploy services to (defaults to the project name). " +
           "Note that the framework generates other namespaces as well with this name as a prefix."

--- a/plugins/jib/src/index.ts
+++ b/plugins/jib/src/index.ts
@@ -74,6 +74,7 @@ const jibBuildSchemaKeys = () => ({
   jdkPath: joi
     .string()
     .optional()
+    .empty(["", null])
     .description(
       dedent`
             The JDK home path. This **always overrides** the JDK defined in \`jdkVersion\`.
@@ -97,7 +98,7 @@ const jibBuildSchemaKeys = () => ({
     .valid("docker", "oci")
     .default("docker")
     .description("Specify the image format in the resulting tar file. Only used if `tarOnly: true`."),
-  gradlePath: joi.string().optional().description(dedent`
+  gradlePath: joi.string().optional().empty(["", null]).description(dedent`
         Defines the location of the custom executable Gradle binary.
 
         If not provided, then the Gradle binary available in the working directory will be used.
@@ -106,7 +107,7 @@ const jibBuildSchemaKeys = () => ({
         **Note!** Either \`jdkVersion\` or \`jdkPath\` will be used to define \`JAVA_HOME\` environment variable for the custom Gradle.
         To ensure a system JDK usage, please set \`jdkPath\` to \`${systemJdkGardenEnvVar}\`.
       `),
-  mavenPath: joi.string().optional().description(dedent`
+  mavenPath: joi.string().optional().empty(["", null]).description(dedent`
         Defines the location of the custom executable Maven binary.
 
         If not provided, then Maven ${mvnVersion} will be downloaded and used.
@@ -119,7 +120,7 @@ const jibBuildSchemaKeys = () => ({
     .items(joi.string())
     .default(["compile"])
     .description("Defines the Maven phases to be executed during the Garden build step."),
-  mavendPath: joi.string().optional().description(dedent`
+  mavendPath: joi.string().optional().empty(["", null]).description(dedent`
         Defines the location of the custom executable Maven Daemon binary.
 
         If not provided, then Maven Daemon ${mvndVersion} will be downloaded and used.


### PR DESCRIPTION
**What this PR does / why we need it**:

Some templatable configuration fields have type string and are marked as optional.

Since we no longer support the optional string syntax, the default values fallback values like `null` or `""` can violate the schema definitions.

In order to overcome that, we can interpret such special values as `undefined`, so those will be compatible with `joi.string().optional()` definition.

This is done by using `joi.empty(["", null])`. The same approach was used in pulumi plugin.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
