### PR TITLE
fix(self-update): do not crash on missing numeric version

### DIFF
--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -113,9 +113,10 @@ export abstract class Parameter<T> {
     this._getSuggestions = getSuggestions
   }
 
-  // TODO: merge this and the parseString method?
   validate(input: T): T | undefined {
-    // TODO: make sure the error message thrown is nice and readable
+    // TODO: make sure the error is thrown,
+    //  its thrown is nice and readable,
+    //  and the output type is correct
     this.schema.validate(input)
     return input
   }

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -21,6 +21,7 @@ import { RuntimeError } from "../exceptions.js"
 import { makeTempDir } from "../util/fs.js"
 import { createReadStream, createWriteStream } from "fs"
 import fsExtra from "fs-extra"
+
 const { copy, mkdirp, move, readdir, remove } = fsExtra
 import { GotHttpError, got } from "../util/http.js"
 import { gardenEnv } from "../constants.js"
@@ -260,7 +261,12 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
   }: CommandParams<SelfUpdateArgs, SelfUpdateOpts>): Promise<CommandResult<SelfUpdateResult>> {
     const currentVersion = getPackageVersion()
 
-    let desiredVersion = args.version
+    // FIXME: StringParameter is in fact a number
+    //  The method Parameter.validate ignores the actual validation result,
+    //  and does not ensure the correct type of the output object.
+    //  This is a qick hack to unlock the release,
+    //  let's revisit the parameter validation.
+    let desiredVersion = `${args.version}`
 
     if (desiredVersion && desiredVersion[0] === "v") {
       desiredVersion = desiredVersion.slice(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the crash while running self-update command with any non-existing `number`-compatible value, like `1` or `0.13`.

All values that can be interpreted as `number` in JavaScript are not getting converted to strings. So, the original issue comes from the `Parameter` class; the `StringParameter` does not ensure the `string` type of the runtime console input.

This PR brings a quick fix. Let's revisit the CLI parameter validation after the 0.14 release.

**Which issue(s) this PR fixes**:

Fixes #6953

**Special notes for your reviewer**:
