### PR TITLE
chore: update Remote Container logging

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -793,7 +793,7 @@ export class GardenCloudApi {
           version: "v2",
           availability: {
             available: false,
-            reason: `Failed to determine Garden Container Builder availability: ${extractErrorMessageBodyFromGotError(err) ?? err}`,
+            reason: `Failed to determine Remote Container Builder availability: ${extractErrorMessageBodyFromGotError(err) ?? err}`,
           },
         },
       }

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -318,7 +318,7 @@ async function buildContainerInCloudBuilder(params: {
     name: `build.${params.action.name}`,
   })
   if (res.timeSaved > 0) {
-    log.success(`${styles.bold("Accelerated by Garden Container Builder - saved", formatDurationMs(res.timeSaved))}`)
+    log.success(`${styles.bold("Accelerated by Remote Container Builder - saved", formatDurationMs(res.timeSaved))}`)
   }
   return res
 }

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -37,7 +37,6 @@ import { join } from "path"
 import { mkdtemp, readFile } from "fs/promises"
 import type { DockerBuildReport } from "../../cloud/grow/trpc.js"
 import type { ActionRuntime } from "../../plugin/base.js"
-import { formatDuration, intervalToDuration } from "date-fns"
 
 export const validateContainerBuild: BuildActionHandler<"validate", ContainerBuildAction> = async ({ action }) => {
   // configure concurrency limit for build status task nodes.
@@ -324,20 +323,8 @@ async function buildContainerInCloudBuilder(params: {
 }
 
 function renderSavedTime(timeMs: number): string {
-  const renderedDuration = timeMs === 0 ? "" : formatDurationMs(timeMs)
+  const renderedDuration = timeMs === 0 ? "" : renderTimeDurationMs(timeMs)
   return renderedDuration.length === 0 ? "" : `(saved ${renderedDuration})`
-}
-
-function formatDurationMs(durationMs: number) {
-  if (durationMs < 1000) {
-    return `${durationMs} ms`
-  }
-
-  const duration = intervalToDuration({
-    start: new Date(0, 0, 0, 0, 0, 0, 0),
-    end: new Date(0, 0, 0, 0, 0, 0, durationMs),
-  })
-  return formatDuration(duration, { format: ["hours", "minutes", "seconds"] })
 }
 
 async function getDockerMetadata(filePath: string, log: ActionLog) {

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -30,7 +30,7 @@ import type { PluginContext } from "../../plugin-context.js"
 import { cloudBuilder } from "./cloudbuilder.js"
 import { styles } from "../../logger/styles.js"
 import type { CloudBuilderAvailableV2 } from "../../cloud/api.js"
-import { spawn, type SpawnOutput } from "../../util/util.js"
+import { renderTimeDurationMs, spawn, type SpawnOutput } from "../../util/util.js"
 import { isSecret, type Secret } from "../../util/secrets.js"
 import { tmpdir } from "os"
 import { join } from "path"
@@ -318,15 +318,21 @@ async function buildContainerInCloudBuilder(params: {
     name: `build.${params.action.name}`,
   })
   if (res.timeSaved > 0) {
-    log.success(`${styles.bold("Accelerated by Remote Container Builder - saved", formatDurationMs(res.timeSaved))}`)
+    log.success(styles.bold(`Accelerated by Remote Container Builder ${renderSavedTime(res.timeSaved)}`))
   }
   return res
+}
+
+function renderSavedTime(timeMs: number): string {
+  const renderedDuration = timeMs === 0 ? "" : formatDurationMs(timeMs)
+  return renderedDuration.length === 0 ? "" : `(saved ${renderedDuration})`
 }
 
 function formatDurationMs(durationMs: number) {
   if (durationMs < 1000) {
     return `${durationMs} ms`
   }
+
   const duration = intervalToDuration({
     start: new Date(0, 0, 0, 0, 0, 0, 0),
     end: new Date(0, 0, 0, 0, 0, 0, durationMs),

--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -86,17 +86,17 @@ function makeNotLoggedInError({ isInClusterBuildingConfigured }: CloudBuilderCon
 
   return new ConfigurationError({
     message: dedent`
-        You are not logged in. Run ${styles.command("garden login")} so Garden Container Builder can speed up your container builds.
+        You are not logged in. Run ${styles.command("garden login")} so Remote Container Builder can speed up your container builds.
 
-        If you can't log in right now, disable Garden Container Builder using the environment variable ${styles.bold("GARDEN_CONTAINER_BUILDER=0")}. ${fallbackDescription}`,
+        If you can't log in right now, disable Remote Container Builder using the environment variable ${styles.bold("GARDEN_CONTAINER_BUILDER=0")}. ${fallbackDescription}`,
   })
 }
 
 function makeVersionMismatchWarning({ isInClusterBuildingConfigured }: CloudBuilderConfiguration) {
   return dedent`
-    ${styles.bold("Update Garden to continue to benefit from Garden Container Builder.")}
+    ${styles.bold("Update Garden to continue to benefit from Remote Container Builder.")}
 
-    Your current Garden version is not supported anymore by Garden Container Builder. Please update Garden to the latest version.
+    Your current Garden version is not supported anymore by Remote Container Builder. Please update Garden to the latest version.
 
     Falling back to ${isInClusterBuildingConfigured ? "in-cluster building" : "building the image locally"}, which may be slower.
 
@@ -234,7 +234,7 @@ class CloudBuilder {
       emitNonRepeatableWarning(
         ctx.log,
         dedent`
-          ${styles.bold("Garden Container Builder is not available.")}
+          ${styles.bold("Remote Container Builder is not available.")}
 
           Falling back to ${isInClusterBuildingConfigured ? "in-cluster building" : "building the image locally"}, which may be slower.
 

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -73,14 +73,14 @@ export const gardenContainerBuilderSchema = () =>
     .optional()
     .keys({
       enabled: joi.boolean().default(false).description(dedent`
-            Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
+            Enable Remote Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
 
-            by running \`GARDEN_CONTAINER_BUILDER=1 garden build\` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
-            The environment variable \`GARDEN_CONTAINER_BUILDER\` can also be used to override this setting, if enabled in the configuration. Set it to \`false\` or \`0\` to temporarily disable Garden Container Builder.
+            by running \`GARDEN_CONTAINER_BUILDER=1 garden build\` you can try Remote Container Builder temporarily without any changes to your Garden configuration.
+            The environment variable \`GARDEN_CONTAINER_BUILDER\` can also be used to override this setting, if enabled in the configuration. Set it to \`false\` or \`0\` to temporarily disable Remote Container Builder.
 
             Under the hood, enabling this option means that Garden will install a remote buildx driver on your local Docker daemon, and use that for builds. See also https://docs.docker.com/build/drivers/remote/
 
-            If service limits are reached, or Garden Container Builder is not available, Garden will fall back to building images locally, or it falls back to building in your Kubernetes cluster in case in-cluster building is configured in the Kubernetes provider configuration.
+            If service limits are reached, or Remote Container Builder is not available, Garden will fall back to building images locally, or it falls back to building in your Kubernetes cluster in case in-cluster building is configured in the Kubernetes provider configuration.
 
             Please note that when enabling Container Builder together with in-cluster building, you need to authenticate to your \`deploymentRegistry\` from the local machine (e.g. by running \`docker login\`).
             `),
@@ -92,7 +92,7 @@ export const configSchema = () =>
       dockerBuildExtraFlags: joi.sparseArray().items(joi.string()).description(dedent`
         Extra flags to pass to the \`docker build\` command. Will extend the \`spec.extraFlags\` specified in each container Build action.
         `),
-      // Garden Container builder
+      // Remote Container Builder
       gardenContainerBuilder: gardenContainerBuilderSchema(),
     })
     .unknown(false)

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -96,7 +96,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
     throw new ConfigurationError({
       message: dedent`
         Unfortunately Kaniko does not support secret build arguments.
-        Garden Container Builder and the Kubernetes BuildKit in-cluster builder both support secrets.
+        Remote Container Builder and the Kubernetes BuildKit in-cluster builder both support secrets.
 
         See also https://github.com/GoogleContainerTools/kaniko/issues/3028
       `,

--- a/core/src/plugins/kubernetes/container/build/local.ts
+++ b/core/src/plugins/kubernetes/container/build/local.ts
@@ -91,7 +91,7 @@ export const localBuild: BuildHandler = async (params) => {
       : // container provider will add --load when using Container Builder automatically, if --push is not present.
         provider.dependencies.container
 
-  // TODO: How can we pass additional information like Garden Container Builder availability to the base handler?
+  // TODO: How can we pass additional information like Remote Container Builder availability to the base handler?
   // In this particular case the problem is neglegible because we are using an LRU cache and the base handler is will
   // call cloudBuilder.getAvailability very soon; But that is not a beautiful solution.
   const buildResult = await base({ ...params, ctx: { ...ctx, provider: containerProvider } })

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -801,8 +801,16 @@ export function renderTimeUnit(amount: number, unit: "hour" | "minute" | "second
 
 export function renderTimeDuration(start: Date, end: Date): string {
   const durationMs = end.getTime() - start.getTime()
+  return renderTimeDurationMs(durationMs)
+}
+
+export function renderTimeDurationMs(durationMs: number): string {
   if (durationMs === 0) {
     return ""
+  }
+
+  if (durationMs < 1000) {
+    return `${durationMs} ms`
   }
 
   const durationSec = round(durationMs / 1000, 2)

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -35,18 +35,18 @@ providers:
     dockerBuildExtraFlags:
 
     gardenContainerBuilder:
-      # Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely
+      # Enable Remote Container Builder, which can speed up builds significantly using fast machines and extremely
       # fast caching.
       #
-      # by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without
+      # by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Remote Container Builder temporarily without
       # any changes to your Garden configuration.
       # The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in
-      # the configuration. Set it to `false` or `0` to temporarily disable Garden Container Builder.
+      # the configuration. Set it to `false` or `0` to temporarily disable Remote Container Builder.
       #
       # Under the hood, enabling this option means that Garden will install a remote buildx driver on your local
       # Docker daemon, and use that for builds. See also https://docs.docker.com/build/drivers/remote/
       #
-      # If service limits are reached, or Garden Container Builder is not available, Garden will fall back to building
+      # If service limits are reached, or Remote Container Builder is not available, Garden will fall back to building
       # images locally, or it falls back to building in your Kubernetes cluster in case in-cluster building is
       # configured in the Kubernetes provider configuration.
       #
@@ -138,14 +138,14 @@ Extra flags to pass to the `docker build` command. Will extend the `spec.extraFl
 
 [providers](#providers) > [gardenContainerBuilder](#providersgardencontainerbuilder) > enabled
 
-Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
+Enable Remote Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
 
-by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
-The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in the configuration. Set it to `false` or `0` to temporarily disable Garden Container Builder.
+by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Remote Container Builder temporarily without any changes to your Garden configuration.
+The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in the configuration. Set it to `false` or `0` to temporarily disable Remote Container Builder.
 
 Under the hood, enabling this option means that Garden will install a remote buildx driver on your local Docker daemon, and use that for builds. See also https://docs.docker.com/build/drivers/remote/
 
-If service limits are reached, or Garden Container Builder is not available, Garden will fall back to building images locally, or it falls back to building in your Kubernetes cluster in case in-cluster building is configured in the Kubernetes provider configuration.
+If service limits are reached, or Remote Container Builder is not available, Garden will fall back to building images locally, or it falls back to building in your Kubernetes cluster in case in-cluster building is configured in the Kubernetes provider configuration.
 
 Please note that when enabling Container Builder together with in-cluster building, you need to authenticate to your `deploymentRegistry` from the local machine (e.g. by running `docker login`).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Rename "Garden Container Builder" to "Remote Container Builder"
* Align the saved time log message shape between Team Cache and Remote Container Builder

Now both logs have the logs like `${feature message} (saved ${rendered time})`.

**Special notes for your reviewer**:

~We still use separate helper functions to render saved time in Team Cache and Remote Container features.~

~The difference is that the former renders the values less than 1 second in the form of `{ddd}ms` and the latter one as `{0.dd} seconds`.~

~Do we want to align that formatting too? Which one is preferred? We can do it in a follow-up PR.~

Aligned the part above my always rendering actual ms for time spans less that 1 second. Zero-length time spans are rendered to empty strings.