### PR TITLE
fix: make Remote Container Builder controllable via env var

### DIFF
--- a/core/src/plugins/container/cloudbuilder.ts
+++ b/core/src/plugins/container/cloudbuilder.ts
@@ -342,21 +342,16 @@ function isContainerBuilderEnabled({
   ctx: PluginContext
   containerProviderConfig: ContainerProviderConfig
 }) {
-  // handle new config
-  if (!!containerProviderConfig.gardenContainerBuilder) {
-    let isCloudBuilderEnabled = containerProviderConfig.gardenContainerBuilder.enabled || false
+  let isCloudBuilderEnabled = containerProviderConfig.gardenContainerBuilder?.enabled || false
 
-    // The env variable GARDEN_CONTAINER_BUILDER can be used to override the gardenContainerBuilder.enabled config setting.
-    // It will be undefined, if the variable is not set and true/false if GARDEN_CONTAINER_BUILDER=1 or GARDEN_CONTAINER_BUILDER=0.
-    const overrideFromEnv = gardenEnv.GARDEN_CONTAINER_BUILDER
-    if (overrideFromEnv !== undefined) {
-      isCloudBuilderEnabled = overrideFromEnv
-    }
-
-    return isCloudBuilderEnabled
+  // The env variable GARDEN_CONTAINER_BUILDER can be used to override the gardenContainerBuilder.enabled config setting.
+  // It will be undefined, if the variable is not set and true/false if GARDEN_CONTAINER_BUILDER=1 or GARDEN_CONTAINER_BUILDER=0.
+  const overrideFromEnv = gardenEnv.GARDEN_CONTAINER_BUILDER
+  if (overrideFromEnv !== undefined) {
+    isCloudBuilderEnabled = overrideFromEnv
   }
 
-  return false
+  return isCloudBuilderEnabled
 }
 
 function getConfiguration(ctx: PluginContext): CloudBuilderConfiguration {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to this fix it was impossible to enable/disable the Remote Container Builder via the relevant env var.

That was because of the wrapper condition `if (!!containerProviderConfig.gardenContainerBuilder)` that was a left-over from the version where we supported 2 backends.

This PR removes that wrapper condition and fixes the issue.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
