### PR TITLE
fix(k8s): update to nginx ingress controller 1.12.1 that is not affected by RCE vulnerability

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -90,7 +90,8 @@ export function getDefaultGardenIngressControllerDefaultBackendImagePath(
 
 export const defaultKanikoImageName: DockerImageWithDigest =
   "gcr.io/kaniko-project/executor:v1.11.0-debug@sha256:32ba2214921892c2fa7b5f9c4ae6f8f026538ce6b2105a93a36a8b5ee50fe517"
+// The sha256 hashes can be found in https://explore.ggcr.dev/?repo=registry.k8s.io
 export const defaultGardenIngressControllerImage: DockerImageWithDigest =
-  "registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:e6b8de175acda6ca913891f0f727bca4527e797d52688cbe9fec9040d6f6b6fa"
+  "registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b"
 export const defaultGardenIngressControllerKubeWebhookCertGenImage: DockerImageWithDigest =
   "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1@sha256:0de05718b59dc33b57ddfb4d8ad5f637cefd13eafdec0e1579d782b3483c27c3"

--- a/core/src/plugins/kubernetes/nginx/nginx-helm.ts
+++ b/core/src/plugins/kubernetes/nginx/nginx-helm.ts
@@ -21,7 +21,7 @@ import { GardenIngressComponent } from "./ingress-controller-base.js"
 import { styles } from "../../../logger/styles.js"
 
 const HELM_INGRESS_NGINX_REPO = "https://kubernetes.github.io/ingress-nginx"
-const HELM_INGRESS_NGINX_VERSION = "4.12.0"
+const HELM_INGRESS_NGINX_VERSION = "4.12.1"
 const HELM_INGRESS_NGINX_CHART = "ingress-nginx"
 const HELM_INGRESS_NGINX_RELEASE_NAME = "garden-nginx"
 const HELM_INGRESS_NGINX_DEPLOYMENT_TIMEOUT = "300s"

--- a/core/src/plugins/kubernetes/nginx/nginx-kind-manifests.ts
+++ b/core/src/plugins/kubernetes/nginx/nginx-kind-manifests.ts
@@ -12,7 +12,7 @@ import {
   defaultGardenIngressControllerKubeWebhookCertGenImage,
 } from "../constants.js"
 
-const INGRESS_NGINX_CONTROLLER_VERSION = "1.12.0"
+const INGRESS_NGINX_CONTROLLER_VERSION = "1.12.1"
 
 export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
   return [


### PR DESCRIPTION
**What this PR does / why we need it**:

Back-port #7030 to 0.13.
