### PR TITLE
fix(sync): await monitors stop on `sync stop` completion

### DIFF
--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -114,7 +114,7 @@ export class SyncStopCommand extends Command<Args, Opts> {
         await router.deploy.stopSync({ log: actionLog, action, graph })
 
         // Halt any active monitors for the sync
-        garden.monitors.find({ type: "sync", key: action.name }).map((m) => m.stop())
+        await Promise.all(garden.monitors.find({ type: "sync", key: action.name }).map((m) => m.stop()))
 
         actionLog.info("Syncing successfully stopped.")
       })


### PR DESCRIPTION
**What this PR does / why we need it**:

Back-port #7056 to 0.13 (cherry picked from commit 88f564aa50dcb24c3fa2ffa33e24e0990d78c366).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
