### PR TITLE
fix: do not throw on unknown action types for disabled actions

### DIFF
--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -443,7 +443,7 @@ export const processActionConfig = profileAsync(async function processActionConf
 
   const configPath = relative(garden.projectRoot, config.internal.configFilePath || config.internal.basePath)
 
-  if (!actionTypes[kind][type]) {
+  if (!actionTypes[kind][type] && !config.disabled) {
     const availableKinds: ActionKind[] = []
     actionKinds.forEach((actionKind) => {
       if (actionTypes[actionKind][type]) {

--- a/core/test/data/test-projects/disabled-action-without-provider/garden.yml
+++ b/core/test/data/test-projects/disabled-action-without-provider/garden.yml
@@ -1,0 +1,32 @@
+apiVersion: garden.io/v2
+kind: Project
+name: my-project
+environments:
+  - name: no-k8s
+  - name: k8s
+
+providers:
+  - name: local-kubernetes
+    namespace: env-repro
+    environments: [k8s]
+
+---
+kind: Deploy
+name: k8s-deploy
+type: kubernetes
+disabled: true
+environments: ["k8s"] # also fails with disabled: true
+spec:
+  manifests:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my-configmap
+      data:
+        foo: bar
+---
+kind: Run
+name: say-hi
+type: exec
+spec:
+  command: ["echo", "Hi ${local.username}"]

--- a/core/test/data/test-projects/disabled-action-without-provider/garden.yml
+++ b/core/test/data/test-projects/disabled-action-without-provider/garden.yml
@@ -15,7 +15,7 @@ kind: Deploy
 name: k8s-deploy
 type: kubernetes
 disabled: true
-environments: ["k8s"] # also fails with disabled: true
+environments: ["k8s"]
 spec:
   manifests:
     - apiVersion: v1

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4271,6 +4271,25 @@ describe("Garden", () => {
       expect(a.isDisabled()).to.be.false
       expect(b.isDisabled()).to.be.true
     })
+
+    it("should not throw if disabled action does not have a configured provider", async () => {
+      // The action 'k8s-deploy' is disabled and configured only in 'no-k8s' environment that does not have kubernetes provider
+      const garden = await makeTestGarden(getDataDir("test-projects", "disabled-action-without-provider"), {
+        environmentString: "no-k8s",
+      })
+
+      // The disabled action with no provider configured should not cause an error
+      const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+
+      // The enabled acton 'say-hi' should be unreachable from graph-lookups
+      void expectError(() => graph.getDeploy("k8s-deploy"), {
+        contains: "Deploy type=kubernetes name=k8s-deploy is disabled",
+      })
+
+      // The enabled acton 'say-hi' should be reachable from graph-lookups
+      const sayHiRun = graph.getRun("say-hi")
+      expect(sayHiRun.isDisabled()).to.be.false
+    })
   })
 
   context("module type has a base", () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

We can avoid throwing an error in `processActionConfig` if the action is disabled.

Disabled actions with configured provider pass the error-check defined in `processActionConfig`. So, this PR ensures that the disabled actions without configured providers also pass that check.
Anyway, the disabled actions will not be executed, so there is no harm is bypassing that error-check.

At that point we know the resolved value of the `disabled` flag on the action config, so we can use it to identify disabled actions.

**Which issue(s) this PR fixes**:

Fixes #6957

**Special notes for your reviewer**:
