### PR TITLE
chore: deprecate `cleanup-cluster-registry` command in `kubernetes` and `local-kubernetes` plugins

### DIFF
--- a/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
+++ b/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
@@ -7,8 +7,8 @@
  */
 
 import type { PluginCommand } from "../../../plugin/command.js"
+import { reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
 
-// TODO(deprecation): deprecate in 0.14 and remove in 0.15
 export const cleanupClusterRegistry: PluginCommand = {
   name: "cleanup-cluster-registry",
   description: "[NO LONGER USED]",
@@ -16,12 +16,7 @@ export const cleanupClusterRegistry: PluginCommand = {
   title: "Cleaning up caches and unused images from the in-cluster registry",
 
   handler: async ({ log }) => {
-    const result = {}
-
-    log.warn(
-      "This command no longer has any effect as of version 0.13! You probably want to remove this from any pipelines running it :)"
-    )
-
-    return { result }
+    reportDeprecatedFeatureUsage({ deprecation: "kubernetesPluginCleanupClusterRegistryCommand", log })
+    return { result: {} }
   },
 }

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -83,6 +83,16 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         The ${style("resources.sync")} config field in the ${style("kubernetes")} provider was only used for the ${style("cluster-docker")} build mode, which was removed in Garden 0.13.",
       `,
     },
+    kubernetesPluginCleanupClusterRegistryCommand: {
+      docsSection: "Unsupported commands",
+      docsHeadline: `${style("cleanup-cluster-registry")}`,
+      warnHint: deline`
+        The ${style("cleanup-cluster-registry")} command in the ${style("kubernetes")} and ${style("local-kubernetes")} plugins is not supported in Garden 0.14.
+        This command no longer has any effect as of version 0.13!
+        Please remove this from any pipelines running it.
+      `,
+      docs: null,
+    },
   } as const
 }
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -30,3 +30,9 @@ The local-mode feature was completely removed in 0.14, and the `spec.localMode` 
 The `resources.sync` config field in the `kubernetes` provider has no effect in Garden 0.13 and 0.14., Please remove it from your `kubernetes` provider configuration.
 
 The `resources.sync` config field in the `kubernetes` provider was only used for the `cluster-docker` build mode, which was removed in Garden 0.13.",
+
+# Unsupported commands
+
+<h2 id="kubernetesplugincleanupclusterregistrycommand"><code>cleanup-cluster-registry</code></h2>
+
+The `cleanup-cluster-registry` comamnd in the `kubernetes` and `local-kubernetes` plugins is not supported in Garden 0.14. This command no longer has any effect as of version 0.13! Please remove this from any pipelines running it.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
