### PR TITLE
fix(graph): use a special helper to check if an action is disabled

### DIFF
--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -443,7 +443,7 @@ export const processActionConfig = profileAsync(async function processActionConf
 
   const configPath = relative(garden.projectRoot, config.internal.configFilePath || config.internal.basePath)
 
-  if (!actionTypes[kind][type] && !config.disabled) {
+  if (!actionTypes[kind][type] && !actionIsDisabled(config, garden.environmentName)) {
     const availableKinds: ActionKind[] = []
     actionKinds.forEach((actionKind) => {
       if (actionTypes[actionKind][type]) {

--- a/core/test/data/test-projects/disabled-action-without-provider/garden.yml
+++ b/core/test/data/test-projects/disabled-action-without-provider/garden.yml
@@ -12,9 +12,9 @@ providers:
 
 ---
 kind: Deploy
-name: k8s-deploy
+name: k8s-deploy-disabled-via-flag
 type: kubernetes
-disabled: true
+disabled: true # the action is disabled explicitly in all envs
 environments: ["k8s"]
 spec:
   manifests:
@@ -24,6 +24,7 @@ spec:
         name: my-configmap
       data:
         foo: bar
+
 ---
 kind: Run
 name: say-hi

--- a/core/test/data/test-projects/disabled-action-without-provider/garden.yml
+++ b/core/test/data/test-projects/disabled-action-without-provider/garden.yml
@@ -26,6 +26,20 @@ spec:
         foo: bar
 
 ---
+kind: Deploy
+name: k8s-deploy-disabled-via-env-config
+type: kubernetes
+environments: ["k8s"] # the action is only enabled in k8s environment
+spec:
+  manifests:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my-configmap
+      data:
+        foo: bar
+
+---
 kind: Run
 name: say-hi
 type: exec

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4294,6 +4294,27 @@ describe("Garden", () => {
           const sayHiRun = graph.getRun("say-hi")
           expect(sayHiRun.isDisabled()).to.be.false
         })
+
+        it("when action is disabled implicitly via environment config", async () => {
+          // The action 'k8s-deploy' is disabled and configured only in 'no-k8s' environment that does not have kubernetes provider
+          const garden = await makeTestGarden(getDataDir("test-projects", "disabled-action-without-provider"), {
+            environmentString: "no-k8s",
+          })
+
+          // The disabled action with no provider configured should not cause an error
+          const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+
+          // The action 'k8s-deploy-disabled-via-env-config' is disabled via the environment config,
+          // and should be unreachable from graph-lookups.
+          const actionName = "k8s-deploy-disabled-via-env-config"
+          void expectError(() => graph.getDeploy(actionName), {
+            contains: `Deploy type=kubernetes name=${actionName} is disabled`,
+          })
+
+          // The enabled acton 'say-hi' should be reachable from graph-lookups
+          const sayHiRun = graph.getRun("say-hi")
+          expect(sayHiRun.isDisabled()).to.be.false
+        })
       })
     })
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

The helper ensures the correct and consistent behavior, because the action can be disabled not only explicitly by `disabled: true` flag, but also implicitly over the environment configuration.

**Which issue(s) this PR fixes**:

Follow-up fix for #7062.

**Special notes for your reviewer**:
