### PR TITLE
fix: log "accelerated by remote container builder" even when timeSaved is 0

### DIFF
--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -316,9 +316,9 @@ async function buildContainerInCloudBuilder(params: {
   const log = params.ctx.log.createLog({
     name: `build.${params.action.name}`,
   })
-  if (res.timeSaved > 0) {
-    log.success(styles.bold(`Accelerated by Remote Container Builder ${renderSavedTime(res.timeSaved)}`))
-  }
+
+  log.success(styles.bold(`Accelerated by Remote Container Builder ${renderSavedTime(res.timeSaved)}`))
+
   return res
 }
 


### PR DESCRIPTION
If time saved is zero, we want to still let the user know that the remote container builder has been utilised. We just won't display the time we saved