### PR TITLE
chore: fix `deprecated` and `internal` flags propagation in reference docs 

### DIFF
--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -76,7 +76,7 @@ export const includeGuideLink = makeDocsLinkPlain(
 export const enumToArray = (Enum: any) => Object.values(Enum).filter((k) => typeof k === "string") as string[]
 
 // Extend the Joi module with our custom rules
-interface MetadataKeys {
+export interface MetadataKeys {
   // Unique name to identify in error messages etc
   name?: string
   // Flag as an advanced feature, to be advised in generated docs
@@ -113,9 +113,7 @@ export interface JoiDescription extends Joi.Description {
     presence?: string
     only?: boolean
   }
-  metas?: {
-    [key: string]: object
-  }[]
+  metas?: MetadataKeys[]
 }
 
 // Unfortunately we need to explicitly extend each type (just extending the AnySchema doesn't work).

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -21,6 +21,13 @@ import type { VariablesContext } from "./variables.js"
 import { getBackendType, getCloudDistributionName } from "../../cloud/util.js"
 import { getSecretsUnavailableInNewBackendMessage } from "../../cloud/secrets.js"
 
+const secretsSchema = joiStringMap(joi.string().description("The secret's value."))
+  .description("A map of all secrets for this project in the current environment.")
+  .meta({
+    internal: true,
+    keyPlaceholder: "<secret-name>",
+  })
+
 class LocalContext extends ContextWithSchema {
   @schema(
     joi
@@ -297,14 +304,7 @@ export interface ProjectConfigContextParams extends DefaultEnvironmentContextPar
  * `secrets`.
  */
 export class ProjectConfigContext extends DefaultEnvironmentContext {
-  @schema(
-    joiStringMap(joi.string().description("The secret's value."))
-      .description("A map of all secrets for this project in the current environment.")
-      .meta({
-        internal: true,
-        keyPlaceholder: "<secret-name>",
-      })
-  )
+  @schema(secretsSchema)
   public readonly secrets: PrimitiveMap
   private readonly _cloudBackendDomain: string
   private readonly _backendType: "v1" | "v2"
@@ -371,14 +371,7 @@ export class EnvironmentConfigContext extends ProjectConfigContext {
   @schema(joiIdentifierMap(joiPrimitive()).description("Alias for the variables field."))
   public var: VariablesContext
 
-  @schema(
-    joiStringMap(joi.string().description("The secret's value."))
-      .description("A map of all secrets for this project in the current environment.")
-      .meta({
-        internal: true,
-        keyPlaceholder: "<secret-name>",
-      })
-  )
+  @schema(secretsSchema)
   public override secrets: PrimitiveMap
 
   constructor(params: EnvironmentConfigContextParams) {

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -24,7 +24,6 @@ import { getSecretsUnavailableInNewBackendMessage } from "../../cloud/secrets.js
 const secretsSchema = joiStringMap(joi.string().description("The secret's value."))
   .description("A map of all secrets for this project in the current environment.")
   .meta({
-    internal: true,
     keyPlaceholder: "<secret-name>",
   })
 

--- a/core/src/docs/common.ts
+++ b/core/src/docs/common.ts
@@ -21,7 +21,7 @@ export abstract class BaseKeyDescription<T = any> {
   abstract experimental: boolean
   abstract required: boolean
 
-  constructor(
+  protected constructor(
     public name: string | undefined,
     public level: number,
     public parent?: BaseKeyDescription

--- a/core/src/docs/joi-schema.ts
+++ b/core/src/docs/joi-schema.ts
@@ -16,7 +16,7 @@ import { safeDumpYaml } from "../util/serialization.js"
 import { zodToJsonSchema } from "zod-to-json-schema"
 
 export class JoiKeyDescription extends BaseKeyDescription {
-  private joiDescription: JoiDescription
+  private readonly joiDescription: JoiDescription
 
   override deprecated: boolean
   override deprecationMessage: string | undefined
@@ -53,7 +53,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
 
     const metas: MetadataKeys = extend({}, ...(joiDescription.metas || []))
 
-    this.deprecated = joiDescription.parent?.deprecated || !!metas.deprecated
+    this.deprecated = parent?.deprecated || !!metas.deprecated
     if (typeof metas.deprecated === "string") {
       this.deprecationMessage = metas.deprecated
     }

--- a/core/src/docs/joi-schema.ts
+++ b/core/src/docs/joi-schema.ts
@@ -10,7 +10,7 @@ import { uniq, isFunction, extend, isArray, isPlainObject } from "lodash-es"
 import { BaseKeyDescription, isArrayType } from "./common.js"
 import { findByName } from "../util/util.js"
 import { JsonKeyDescription } from "./json-schema.js"
-import type { JoiDescription } from "../config/common.js"
+import type { JoiDescription, MetadataKeys } from "../config/common.js"
 import { metadataFromDescription } from "../config/common.js"
 import { safeDumpYaml } from "../util/serialization.js"
 import { zodToJsonSchema } from "zod-to-json-schema"
@@ -51,7 +51,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
     const presenceRequired = joiDescription.flags?.presence === "required"
     this.required = presenceRequired || this.allowedValuesOnly
 
-    const metas: any = extend({}, ...(joiDescription.metas || []))
+    const metas: MetadataKeys = extend({}, ...(joiDescription.metas || []))
 
     this.deprecated = joiDescription.parent?.deprecated || !!metas.deprecated
     if (typeof metas.deprecated === "string") {
@@ -123,7 +123,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
       )
 
       if (renderPatternKeys && objSchema.patterns && objSchema.patterns.length > 0) {
-        const metas: any = extend({}, ...(objSchema.metas || []))
+        const metas: MetadataKeys = extend({}, ...(objSchema.metas || []))
         childDescriptions.push(
           new JoiKeyDescription({
             joiDescription: objSchema.patterns[0].rule as JoiDescription as JoiDescription,
@@ -194,7 +194,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
  * Returns an object schema description if applicable for the field, that is if the provided schema is an
  * object schema _or_ if it's an "alternatives" schema where one alternative is an object schema.
  */
-function getObjectSchema(d: JoiDescription) {
+function getObjectSchema(d: JoiDescription): JoiDescription | undefined {
   const { type } = d
 
   if (type === "alternatives") {
@@ -204,8 +204,11 @@ function getObjectSchema(d: JoiDescription) {
         return nestedObjSchema
       }
     }
+    return undefined
   } else if (type === "object" || type === "customObject") {
     return d
+  } else {
+    return undefined
   }
 }
 

--- a/core/src/docs/joi-schema.ts
+++ b/core/src/docs/joi-schema.ts
@@ -59,7 +59,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
     }
     this.description = joiDescription.flags?.description
     this.experimental = joiDescription.parent?.experimental || !!metas.experimental
-    this.internal = joiDescription.parent?.internal || !!metas.internal
+    this.internal = parent?.internal || !!metas.internal
   }
 
   override formatType() {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1724,24 +1724,6 @@ providers:
         # The module spec, as defined by the provider plugin.
         spec:
 
-            # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
-            # directory (for remote modules this means the root of the module repository, otherwise the directory of
-            # the module configuration).
-            #
-            # Note that any existing file with the same name will be overwritten. If the path contains one or more
-            # directories, they will be automatically created if missing.
-            targetPath:
-
-            # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to
-            # false to skip resolving template strings. Note that this does not apply when setting the `value` field,
-            # since that's resolved earlier when parsing the configuration.
-            resolveTemplates:
-
-            # The desired file contents as a string.
-            value:
-
-            sourcePath:
-
         # The name of the parent module (e.g. a templated module that generated this module), if applicable.
         parentName:
 
@@ -2676,24 +2658,6 @@ moduleConfigs:
     # The module spec, as defined by the provider plugin.
     spec:
 
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
-        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
-        # module configuration).
-        #
-        # Note that any existing file with the same name will be overwritten. If the path contains one or more
-        # directories, they will be automatically created if missing.
-        targetPath:
-
-        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
-        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
-        # resolved earlier when parsing the configuration.
-        resolveTemplates:
-
-        # The desired file contents as a string.
-        value:
-
-        sourcePath:
-
     # The name of the parent module (e.g. a templated module that generated this module), if applicable.
     parentName:
 
@@ -3245,24 +3209,6 @@ modules:
 
     # The module spec, as defined by the provider plugin.
     spec:
-
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
-        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
-        # module configuration).
-        #
-        # Note that any existing file with the same name will be overwritten. If the path contains one or more
-        # directories, they will be automatically created if missing.
-        targetPath:
-
-        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
-        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
-        # resolved earlier when parsing the configuration.
-        resolveTemplates:
-
-        # The desired file contents as a string.
-        value:
-
-        sourcePath:
 
     # The name of the parent module (e.g. a templated module that generated this module), if applicable.
     parentName:

--- a/docs/reference/template-strings/action-all-fields.md
+++ b/docs/reference/template-strings/action-all-fields.md
@@ -293,6 +293,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/action-all-fields.md
+++ b/docs/reference/template-strings/action-all-fields.md
@@ -293,14 +293,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -295,14 +295,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -295,6 +295,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/environments.md
+++ b/docs/reference/template-strings/environments.md
@@ -289,6 +289,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration.

--- a/docs/reference/template-strings/environments.md
+++ b/docs/reference/template-strings/environments.md
@@ -289,14 +289,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration.

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -295,14 +295,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -295,6 +295,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -295,14 +295,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -295,6 +295,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/projects.md
+++ b/docs/reference/template-strings/projects.md
@@ -289,11 +289,3 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-

--- a/docs/reference/template-strings/projects.md
+++ b/docs/reference/template-strings/projects.md
@@ -289,3 +289,19 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -291,14 +291,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -291,6 +291,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/remote-sources.md
+++ b/docs/reference/template-strings/remote-sources.md
@@ -289,6 +289,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/remote-sources.md
+++ b/docs/reference/template-strings/remote-sources.md
@@ -289,14 +289,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/workflows.md
+++ b/docs/reference/template-strings/workflows.md
@@ -291,14 +291,6 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
-### `${secrets.<secret-name>}`
-
-The secret's value.
-
-| Type     |
-| -------- |
-| `string` |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/template-strings/workflows.md
+++ b/docs/reference/template-strings/workflows.md
@@ -291,6 +291,22 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -351,6 +351,10 @@ The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 
 
 [limits](#limits) > cpu
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 CPU).
 
 | Type     | Required |
@@ -360,6 +364,10 @@ The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 
 ### `limits.memory`
 
 [limits](#limits) > memory
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 GB).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the propagation of `deprecated` and `internal` meta flags of joi objects to their children.

Now we don't need to explicitly set `.meta({ internal: true })` on every child of an already internal joi schema to hide it from the generated docs.
The same fix applies to the `deprecated` meta flag.

There are also some type-safety improvements.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
