### PR TITLE
fix(container): always respect env vars to control remote builder

### DIFF
--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -83,7 +83,7 @@ export const gardenContainerBuilderSchema = () =>
       enabled: joi.boolean().default(false).description(dedent`
             Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
 
-            by running \`GARDEN_CONTAINER_BUILDER=1 garden build\` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
+            By running \`GARDEN_CONTAINER_BUILDER=1 garden build\` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
             The environment variable \`GARDEN_CONTAINER_BUILDER\` can also be used to override this setting, if enabled in the configuration. Set it to \`false\` or \`0\` to temporarily disable Garden Container Builder.
 
             Under the hood, enabling this option means that Garden will install a remote buildx driver on your local Docker daemon, and use that for builds. See also https://docs.docker.com/build/drivers/remote/

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -40,7 +40,7 @@ providers:
       # Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely
       # fast caching.
       #
-      # by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without
+      # By running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without
       # any changes to your Garden configuration.
       # The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in
       # the configuration. Set it to `false` or `0` to temporarily disable Garden Container Builder.
@@ -60,7 +60,7 @@ providers:
       # Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely
       # fast caching.
       #
-      # by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without
+      # By running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without
       # any changes to your Garden configuration.
       # The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in
       # the configuration. Set it to `false` or `0` to temporarily disable Garden Container Builder.
@@ -168,7 +168,7 @@ Extra flags to pass to the `docker build` command. Will extend the `spec.extraFl
 
 Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
 
-by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
+By running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
 The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in the configuration. Set it to `false` or `0` to temporarily disable Garden Container Builder.
 
 Under the hood, enabling this option means that Garden will install a remote buildx driver on your local Docker daemon, and use that for builds. See also https://docs.docker.com/build/drivers/remote/
@@ -195,7 +195,7 @@ Please note that when enabling Container Builder together with in-cluster buildi
 
 Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
 
-by running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
+By running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without any changes to your Garden configuration.
 The environment variable `GARDEN_CONTAINER_BUILDER` can also be used to override this setting, if enabled in the configuration. Set it to `false` or `0` to temporarily disable Garden Container Builder.
 
 Under the hood, enabling this option means that Garden will install a remote buildx driver on your local Docker daemon, and use that for builds. See also https://docs.docker.com/build/drivers/remote/


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to this this, the env variable `GARDEN_CONTAINER_BUILDER` and its deprecated alias `GARDEN_CLOUD_BUILDER` were only taken into account when the corresponding provider level `gardenContainerBuilder` (or deprecated `gardenCloudBuilder`) configurations were explicitly defined in the `garden.yml` config file.

Now, the override via env vars still takes precedence over the file-based config, but it's also possible to avoid any configs in file and use only env vars.

**Which issue(s) this PR fixes**:

**Expected behavior:**
```console
GARDEN_CLOUDBUILDER=1 garden build 
```
The flag enables Remote Container Builder.
See the [0.13 docs](https://docs.garden.io/bonsai-0.13/reference/providers/container#providers-.gardencontainerbuilder.enabled):

> by running `GARDEN_CONTAINER_BUILDER=1` garden build you can try Garden Container Builder temporarily without any changes to your Garden configuration.

**Current behavior:**
```console
GARDEN_CLOUDBUILDER=1 garden build 
```
The flag is ignored and Remote Container Builder isn't used.

**Special notes for your reviewer**:

The flag `GARDEN_CONTAINER_BUILDER` works as expected in 0.14.