### PR TITLE
chore: fix `deprecated` and `internal` flags propagation in reference docs

### DIFF
--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -76,7 +76,7 @@ export const includeGuideLink = makeDocsLinkPlain(
 export const enumToArray = (Enum: any) => Object.values(Enum).filter((k) => typeof k === "string") as string[]
 
 // Extend the Joi module with our custom rules
-interface MetadataKeys {
+export interface MetadataKeys {
   // Unique name to identify in error messages etc
   name?: string
   // Flag as an advanced feature, to be advised in generated docs
@@ -113,9 +113,7 @@ export interface JoiDescription extends Joi.Description {
     presence?: string
     only?: boolean
   }
-  metas?: {
-    [key: string]: object
-  }[]
+  metas?: MetadataKeys[]
 }
 
 // Unfortunately we need to explicitly extend each type (just extending the AnySchema doesn't work).

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -21,6 +21,12 @@ import type { VariablesContext } from "./variables.js"
 import { getCloudDistributionName } from "../../cloud/util.js"
 import { getSecretsUnavailableInNewBackendMessage } from "../../cloud/secrets.js"
 
+const secretsSchema = joiStringMap(joi.string().description("The secret's value."))
+  .description("A map of all secrets for this project in the current environment.")
+  .meta({
+    keyPlaceholder: "<secret-name>",
+  })
+
 class LocalContext extends ContextWithSchema {
   @schema(
     joi
@@ -296,14 +302,7 @@ export interface ProjectConfigContextParams extends DefaultEnvironmentContextPar
  * `secrets`.
  */
 export class ProjectConfigContext extends DefaultEnvironmentContext {
-  @schema(
-    joiStringMap(joi.string().description("The secret's value."))
-      .description("A map of all secrets for this project in the current environment.")
-      .meta({
-        internal: true,
-        keyPlaceholder: "<secret-name>",
-      })
-  )
+  @schema(secretsSchema)
   public readonly secrets: PrimitiveMap
   private readonly _cloudBackendDomain: string
   private readonly _loggedIn: boolean
@@ -371,14 +370,7 @@ export class EnvironmentConfigContext extends ProjectConfigContext {
   @schema(joiIdentifierMap(joiPrimitive()).description("Alias for the variables field."))
   public var: VariablesContext
 
-  @schema(
-    joiStringMap(joi.string().description("The secret's value."))
-      .description("A map of all secrets for this project in the current environment.")
-      .meta({
-        internal: true,
-        keyPlaceholder: "<secret-name>",
-      })
-  )
+  @schema(secretsSchema)
   public override secrets: PrimitiveMap
 
   constructor(params: EnvironmentConfigContextParams) {

--- a/core/src/docs/common.ts
+++ b/core/src/docs/common.ts
@@ -21,7 +21,7 @@ export abstract class BaseKeyDescription<T = any> {
   abstract experimental: boolean
   abstract required: boolean
 
-  constructor(
+  protected constructor(
     public name: string | undefined,
     public level: number,
     public parent?: BaseKeyDescription

--- a/core/src/docs/joi-schema.ts
+++ b/core/src/docs/joi-schema.ts
@@ -10,13 +10,13 @@ import { uniq, isFunction, extend, isArray, isPlainObject } from "lodash-es"
 import { BaseKeyDescription, isArrayType } from "./common.js"
 import { findByName } from "../util/util.js"
 import { JsonKeyDescription } from "./json-schema.js"
-import type { JoiDescription } from "../config/common.js"
+import type { JoiDescription, MetadataKeys } from "../config/common.js"
 import { metadataFromDescription } from "../config/common.js"
 import { safeDumpYaml } from "../util/serialization.js"
 import { zodToJsonSchema } from "zod-to-json-schema"
 
 export class JoiKeyDescription extends BaseKeyDescription {
-  private joiDescription: JoiDescription
+  private readonly joiDescription: JoiDescription
 
   override deprecated: boolean
   override deprecationMessage: string | undefined
@@ -51,15 +51,15 @@ export class JoiKeyDescription extends BaseKeyDescription {
     const presenceRequired = joiDescription.flags?.presence === "required"
     this.required = presenceRequired || this.allowedValuesOnly
 
-    const metas: any = extend({}, ...(joiDescription.metas || []))
+    const metas: MetadataKeys = extend({}, ...(joiDescription.metas || []))
 
-    this.deprecated = joiDescription.parent?.deprecated || !!metas.deprecated
+    this.deprecated = parent?.deprecated || !!metas.deprecated
     if (typeof metas.deprecated === "string") {
       this.deprecationMessage = metas.deprecated
     }
     this.description = joiDescription.flags?.description
     this.experimental = joiDescription.parent?.experimental || !!metas.experimental
-    this.internal = joiDescription.parent?.internal || !!metas.internal
+    this.internal = parent?.internal || !!metas.internal
   }
 
   override formatType() {
@@ -123,7 +123,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
       )
 
       if (renderPatternKeys && objSchema.patterns && objSchema.patterns.length > 0) {
-        const metas: any = extend({}, ...(objSchema.metas || []))
+        const metas: MetadataKeys = extend({}, ...(objSchema.metas || []))
         childDescriptions.push(
           new JoiKeyDescription({
             joiDescription: objSchema.patterns[0].rule as JoiDescription as JoiDescription,
@@ -194,7 +194,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
  * Returns an object schema description if applicable for the field, that is if the provided schema is an
  * object schema _or_ if it's an "alternatives" schema where one alternative is an object schema.
  */
-function getObjectSchema(d: JoiDescription) {
+function getObjectSchema(d: JoiDescription): JoiDescription | undefined {
   const { type } = d
 
   if (type === "alternatives") {
@@ -204,8 +204,11 @@ function getObjectSchema(d: JoiDescription) {
         return nestedObjSchema
       }
     }
+    return undefined
   } else if (type === "object" || type === "customObject") {
     return d
+  } else {
+    return undefined
   }
 }
 

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -742,6 +742,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [spec](#spec) > [localMode](#speclocalmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -751,6 +755,10 @@ The reverse port-forwards configuration for the local application.
 ### `spec.localMode.ports[].local`
 
 [spec](#spec) > [localMode](#speclocalmode) > [ports](#speclocalmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -762,6 +770,10 @@ The local port to be used for reverse port-forward.
 
 [spec](#spec) > [localMode](#speclocalmode) > [ports](#speclocalmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -771,6 +783,10 @@ The remote port to be used for reverse port-forward.
 ### `spec.localMode.command[]`
 
 [spec](#spec) > [localMode](#speclocalmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -782,6 +798,10 @@ The command to run the local application. If not present, then the local applica
 
 [spec](#spec) > [localMode](#speclocalmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -792,6 +812,10 @@ Specifies restarting policy for the local application. By default, the local app
 
 [spec](#spec) > [localMode](#speclocalmode) > [restart](#speclocalmoderestart) > delayMsec
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
 | Type     | Default | Required |
@@ -801,6 +825,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 ### `spec.localMode.restart.max`
 
 [spec](#spec) > [localMode](#speclocalmode) > [restart](#speclocalmoderestart) > max
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Max number of the local application restarts. Unlimited by default.
 

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -944,6 +944,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [spec](#spec) > [localMode](#speclocalmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -953,6 +957,10 @@ The reverse port-forwards configuration for the local application.
 ### `spec.localMode.ports[].local`
 
 [spec](#spec) > [localMode](#speclocalmode) > [ports](#speclocalmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -964,6 +972,10 @@ The local port to be used for reverse port-forward.
 
 [spec](#spec) > [localMode](#speclocalmode) > [ports](#speclocalmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -973,6 +985,10 @@ The remote port to be used for reverse port-forward.
 ### `spec.localMode.command[]`
 
 [spec](#spec) > [localMode](#speclocalmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -984,6 +1000,10 @@ The command to run the local application. If not present, then the local applica
 
 [spec](#spec) > [localMode](#speclocalmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -993,6 +1013,10 @@ Specifies restarting policy for the local application. By default, the local app
 ### `spec.localMode.restart.delayMsec`
 
 [spec](#spec) > [localMode](#speclocalmode) > [restart](#speclocalmoderestart) > delayMsec
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
@@ -1004,6 +1028,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 
 [spec](#spec) > [localMode](#speclocalmode) > [restart](#speclocalmoderestart) > max
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Max number of the local application restarts. Unlimited by default.
 
 | Type     | Default | Required |
@@ -1013,6 +1041,10 @@ Max number of the local application restarts. Unlimited by default.
 ### `spec.localMode.target`
 
 [spec](#spec) > [localMode](#speclocalmode) > target
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The remote Kubernetes resource to proxy traffic from. If specified, this is used instead of `defaultTarget`.
 
@@ -1024,6 +1056,10 @@ The remote Kubernetes resource to proxy traffic from. If specified, this is used
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > kind
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The kind of Kubernetes resource to find.
 
 | Type     | Allowed Values                           | Required |
@@ -1033,6 +1069,10 @@ The kind of Kubernetes resource to find.
 ### `spec.localMode.target.name`
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > name
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
 
@@ -1044,6 +1084,10 @@ The name of the resource, of the specified `kind`. If specified, you must also s
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > podSelector
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
 
 | Type     | Required |
@@ -1053,6 +1097,10 @@ A map of string key/value labels to match on any Pods in the namespace. When spe
 ### `spec.localMode.target.containerName`
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > containerName
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
 

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -980,6 +980,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [spec](#spec) > [localMode](#speclocalmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -989,6 +993,10 @@ The reverse port-forwards configuration for the local application.
 ### `spec.localMode.ports[].local`
 
 [spec](#spec) > [localMode](#speclocalmode) > [ports](#speclocalmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -1000,6 +1008,10 @@ The local port to be used for reverse port-forward.
 
 [spec](#spec) > [localMode](#speclocalmode) > [ports](#speclocalmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -1009,6 +1021,10 @@ The remote port to be used for reverse port-forward.
 ### `spec.localMode.command[]`
 
 [spec](#spec) > [localMode](#speclocalmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -1020,6 +1036,10 @@ The command to run the local application. If not present, then the local applica
 
 [spec](#spec) > [localMode](#speclocalmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -1029,6 +1049,10 @@ Specifies restarting policy for the local application. By default, the local app
 ### `spec.localMode.restart.delayMsec`
 
 [spec](#spec) > [localMode](#speclocalmode) > [restart](#speclocalmoderestart) > delayMsec
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
@@ -1040,6 +1064,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 
 [spec](#spec) > [localMode](#speclocalmode) > [restart](#speclocalmoderestart) > max
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Max number of the local application restarts. Unlimited by default.
 
 | Type     | Default | Required |
@@ -1049,6 +1077,10 @@ Max number of the local application restarts. Unlimited by default.
 ### `spec.localMode.target`
 
 [spec](#spec) > [localMode](#speclocalmode) > target
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The remote Kubernetes resource to proxy traffic from. If specified, this is used instead of `defaultTarget`.
 
@@ -1060,6 +1092,10 @@ The remote Kubernetes resource to proxy traffic from. If specified, this is used
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > kind
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The kind of Kubernetes resource to find.
 
 | Type     | Allowed Values                           | Required |
@@ -1069,6 +1105,10 @@ The kind of Kubernetes resource to find.
 ### `spec.localMode.target.name`
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > name
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
 
@@ -1080,6 +1120,10 @@ The name of the resource, of the specified `kind`. If specified, you must also s
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > podSelector
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
 
 | Type     | Required |
@@ -1089,6 +1133,10 @@ A map of string key/value labels to match on any Pods in the namespace. When spe
 ### `spec.localMode.target.containerName`
 
 [spec](#spec) > [localMode](#speclocalmode) > [target](#speclocalmodetarget) > containerName
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1730,24 +1730,6 @@ providers:
         # The module spec, as defined by the provider plugin.
         spec:
 
-            # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
-            # directory (for remote modules this means the root of the module repository, otherwise the directory of
-            # the module configuration).
-            #
-            # Note that any existing file with the same name will be overwritten. If the path contains one or more
-            # directories, they will be automatically created if missing.
-            targetPath:
-
-            # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to
-            # false to skip resolving template strings. Note that this does not apply when setting the `value` field,
-            # since that's resolved earlier when parsing the configuration.
-            resolveTemplates:
-
-            # The desired file contents as a string.
-            value:
-
-            sourcePath:
-
         # The name of the parent module (e.g. a templated module that generated this module), if applicable.
         parentName:
 
@@ -2682,24 +2664,6 @@ moduleConfigs:
     # The module spec, as defined by the provider plugin.
     spec:
 
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
-        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
-        # module configuration).
-        #
-        # Note that any existing file with the same name will be overwritten. If the path contains one or more
-        # directories, they will be automatically created if missing.
-        targetPath:
-
-        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
-        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
-        # resolved earlier when parsing the configuration.
-        resolveTemplates:
-
-        # The desired file contents as a string.
-        value:
-
-        sourcePath:
-
     # The name of the parent module (e.g. a templated module that generated this module), if applicable.
     parentName:
 
@@ -3251,24 +3215,6 @@ modules:
 
     # The module spec, as defined by the provider plugin.
     spec:
-
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
-        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
-        # module configuration).
-        #
-        # Note that any existing file with the same name will be overwritten. If the path contains one or more
-        # directories, they will be automatically created if missing.
-        targetPath:
-
-        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
-        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
-        # resolved earlier when parsing the configuration.
-        resolveTemplates:
-
-        # The desired file contents as a string.
-        value:
-
-        sourcePath:
 
     # The name of the parent module (e.g. a templated module that generated this module), if applicable.
     parentName:

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1656,6 +1656,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [services](#services) > [localMode](#serviceslocalmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -1665,6 +1669,10 @@ The reverse port-forwards configuration for the local application.
 ### `services[].localMode.ports[].local`
 
 [services](#services) > [localMode](#serviceslocalmode) > [ports](#serviceslocalmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -1676,6 +1684,10 @@ The local port to be used for reverse port-forward.
 
 [services](#services) > [localMode](#serviceslocalmode) > [ports](#serviceslocalmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -1685,6 +1697,10 @@ The remote port to be used for reverse port-forward.
 ### `services[].localMode.command[]`
 
 [services](#services) > [localMode](#serviceslocalmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -1696,6 +1712,10 @@ The command to run the local application. If not present, then the local applica
 
 [services](#services) > [localMode](#serviceslocalmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -1706,6 +1726,10 @@ Specifies restarting policy for the local application. By default, the local app
 
 [services](#services) > [localMode](#serviceslocalmode) > [restart](#serviceslocalmoderestart) > delayMsec
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
 | Type     | Default | Required |
@@ -1715,6 +1739,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 ### `services[].localMode.restart.max`
 
 [services](#services) > [localMode](#serviceslocalmode) > [restart](#serviceslocalmoderestart) > max
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Max number of the local application restarts. Unlimited by default.
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -1299,6 +1299,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [localMode](#localmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -1308,6 +1312,10 @@ The reverse port-forwards configuration for the local application.
 ### `localMode.ports[].local`
 
 [localMode](#localmode) > [ports](#localmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -1319,6 +1327,10 @@ The local port to be used for reverse port-forward.
 
 [localMode](#localmode) > [ports](#localmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -1328,6 +1340,10 @@ The remote port to be used for reverse port-forward.
 ### `localMode.command[]`
 
 [localMode](#localmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -1339,6 +1355,10 @@ The command to run the local application. If not present, then the local applica
 
 [localMode](#localmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -1348,6 +1368,10 @@ Specifies restarting policy for the local application. By default, the local app
 ### `localMode.restart.delayMsec`
 
 [localMode](#localmode) > [restart](#localmoderestart) > delayMsec
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
@@ -1359,6 +1383,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 
 [localMode](#localmode) > [restart](#localmoderestart) > max
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Max number of the local application restarts. Unlimited by default.
 
 | Type     | Default | Required |
@@ -1368,6 +1396,10 @@ Max number of the local application restarts. Unlimited by default.
 ### `localMode.target`
 
 [localMode](#localmode) > target
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The remote Kubernetes resource to proxy traffic from. If specified, this is used instead of `defaultTarget`.
 
@@ -1379,6 +1411,10 @@ The remote Kubernetes resource to proxy traffic from. If specified, this is used
 
 [localMode](#localmode) > [target](#localmodetarget) > kind
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The kind of Kubernetes resource to find.
 
 | Type     | Allowed Values                           | Required |
@@ -1388,6 +1424,10 @@ The kind of Kubernetes resource to find.
 ### `localMode.target.name`
 
 [localMode](#localmode) > [target](#localmodetarget) > name
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
 
@@ -1399,6 +1439,10 @@ The name of the resource, of the specified `kind`. If specified, you must also s
 
 [localMode](#localmode) > [target](#localmodetarget) > podSelector
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
 
 | Type     | Required |
@@ -1408,6 +1452,10 @@ A map of string key/value labels to match on any Pods in the namespace. When spe
 ### `localMode.target.containerName`
 
 [localMode](#localmode) > [target](#localmodetarget) > containerName
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -1871,6 +1871,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [services](#services) > [localMode](#serviceslocalmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -1880,6 +1884,10 @@ The reverse port-forwards configuration for the local application.
 ### `services[].localMode.ports[].local`
 
 [services](#services) > [localMode](#serviceslocalmode) > [ports](#serviceslocalmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -1891,6 +1899,10 @@ The local port to be used for reverse port-forward.
 
 [services](#services) > [localMode](#serviceslocalmode) > [ports](#serviceslocalmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -1900,6 +1912,10 @@ The remote port to be used for reverse port-forward.
 ### `services[].localMode.command[]`
 
 [services](#services) > [localMode](#serviceslocalmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -1911,6 +1927,10 @@ The command to run the local application. If not present, then the local applica
 
 [services](#services) > [localMode](#serviceslocalmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -1921,6 +1941,10 @@ Specifies restarting policy for the local application. By default, the local app
 
 [services](#services) > [localMode](#serviceslocalmode) > [restart](#serviceslocalmoderestart) > delayMsec
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
 | Type     | Default | Required |
@@ -1930,6 +1954,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 ### `services[].localMode.restart.max`
 
 [services](#services) > [localMode](#serviceslocalmode) > [restart](#serviceslocalmoderestart) > max
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Max number of the local application restarts. Unlimited by default.
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -1365,6 +1365,10 @@ Note! This feature is still experimental. Some incompatible changes can be made 
 
 [localMode](#localmode) > ports
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The reverse port-forwards configuration for the local application.
 
 | Type            | Required |
@@ -1374,6 +1378,10 @@ The reverse port-forwards configuration for the local application.
 ### `localMode.ports[].local`
 
 [localMode](#localmode) > [ports](#localmodeports) > local
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The local port to be used for reverse port-forward.
 
@@ -1385,6 +1393,10 @@ The local port to be used for reverse port-forward.
 
 [localMode](#localmode) > [ports](#localmodeports) > remote
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The remote port to be used for reverse port-forward.
 
 | Type     | Required |
@@ -1394,6 +1406,10 @@ The remote port to be used for reverse port-forward.
 ### `localMode.command[]`
 
 [localMode](#localmode) > command
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The command to run the local application. If not present, then the local application should be started manually.
 
@@ -1405,6 +1421,10 @@ The command to run the local application. If not present, then the local applica
 
 [localMode](#localmode) > restart
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specifies restarting policy for the local application. By default, the local application will be restarting infinitely with 1000ms between attempts.
 
 | Type     | Default                         | Required |
@@ -1414,6 +1434,10 @@ Specifies restarting policy for the local application. By default, the local app
 ### `localMode.restart.delayMsec`
 
 [localMode](#localmode) > [restart](#localmoderestart) > delayMsec
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Delay in milliseconds between the local application restart attempts. The default value is 1000ms.
 
@@ -1425,6 +1449,10 @@ Delay in milliseconds between the local application restart attempts. The defaul
 
 [localMode](#localmode) > [restart](#localmoderestart) > max
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Max number of the local application restarts. Unlimited by default.
 
 | Type     | Default | Required |
@@ -1434,6 +1462,10 @@ Max number of the local application restarts. Unlimited by default.
 ### `localMode.target`
 
 [localMode](#localmode) > target
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The remote Kubernetes resource to proxy traffic from. If specified, this is used instead of `defaultTarget`.
 
@@ -1445,6 +1477,10 @@ The remote Kubernetes resource to proxy traffic from. If specified, this is used
 
 [localMode](#localmode) > [target](#localmodetarget) > kind
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The kind of Kubernetes resource to find.
 
 | Type     | Allowed Values                           | Required |
@@ -1454,6 +1490,10 @@ The kind of Kubernetes resource to find.
 ### `localMode.target.name`
 
 [localMode](#localmode) > [target](#localmodetarget) > name
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
 
@@ -1465,6 +1505,10 @@ The name of the resource, of the specified `kind`. If specified, you must also s
 
 [localMode](#localmode) > [target](#localmodetarget) > podSelector
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
 
 | Type     | Required |
@@ -1474,6 +1518,10 @@ A map of string key/value labels to match on any Pods in the namespace. When spe
 ### `localMode.target.containerName`
 
 [localMode](#localmode) > [target](#localmodetarget) > containerName
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
 

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -166,6 +166,10 @@ Extra flags to pass to the `docker build` command. Will extend the `spec.extraFl
 
 [providers](#providers) > [gardenCloudBuilder](#providersgardencloudbuilder) > enabled
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Enable Garden Container Builder, which can speed up builds significantly using fast machines and extremely fast caching.
 
 By running `GARDEN_CONTAINER_BUILDER=1 garden build` you can try Garden Container Builder temporarily without any changes to your Garden configuration.

--- a/docs/reference/template-strings/action-all-fields.md
+++ b/docs/reference/template-strings/action-all-fields.md
@@ -293,6 +293,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -295,6 +295,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/environments.md
+++ b/docs/reference/template-strings/environments.md
@@ -289,6 +289,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -295,6 +295,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -295,6 +295,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/projects.md
+++ b/docs/reference/template-strings/projects.md
@@ -289,6 +289,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -291,6 +291,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/remote-sources.md
+++ b/docs/reference/template-strings/remote-sources.md
@@ -289,6 +289,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/template-strings/workflows.md
+++ b/docs/reference/template-strings/workflows.md
@@ -291,6 +291,14 @@ Example:
 my-variable: ${git.originUrl}
 ```
 
+### `${secrets.*}`
+
+A map of all secrets for this project in the current environment.
+
+| Type     |
+| -------- |
+| `object` |
+
 ### `${secrets.<secret-name>}`
 
 The secret's value.

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -351,6 +351,10 @@ The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 
 
 [limits](#limits) > cpu
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 CPU).
 
 | Type     | Required |
@@ -360,6 +364,10 @@ The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 
 ### `limits.memory`
 
 [limits](#limits) > memory
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 GB).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Back-ports  #7142 to 0.13.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
