### PR TITLE
fix: prevent unnecessary execution of builds referenced in runtime actions

### DIFF
--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -962,6 +962,7 @@ function dependenciesFromActionConfig({
 
   for (const ref of getActionTemplateReferences(config, templateContext)) {
     let needsExecuted = false
+    let isExplicit = false
 
     const outputType = ref.keyPath[0]
 
@@ -988,30 +989,33 @@ function dependenciesFromActionConfig({
 
       const apiVersion = getGlobalProjectApiVersion()
 
-      let alwaysExecuteCondition: boolean
       if (apiVersion === GardenApiVersion.v2) {
-        // In API version v2:
-        // Avoid execution when referencing the static output keys of the ref's action type if it's not a Build.
-        // This is because Builds generally don't have side-effects other than producing artifacts, whereas Deploys
-        // and Runs often do.
-        // This improves the user experience for the common use-case of referencing a container image in a runtime
-        // resource (like a `helm` Deploy), where the user intent is almost always that the referenced build should exist
-        // (i.e. the dependency should be processed) before the runtime resource is processed (i.e. deployed or run).
-        // Note: We could also always execute Test actions that are referenced, but we'll stick with only Builds for now.
-        alwaysExecuteCondition = !isString(outputKey) || refActionKind === "Build"
-      } else {
-        // Otherwise:
-        // Avoid execution when referencing the static output keys of the ref action type.
-        // e.g. a helm deploy referencing container build static output deploymentImageName
-        // ${actions.build.my-container.outputs.deploymentImageName}
-        alwaysExecuteCondition = !isString(outputKey)
+        /*
+        If a referenced dependency is a Build, then we re-mark it as explicit dependency.
+        It will have the same effect as if it was explicitly referenced in the configuration.
+
+        This is safe, because Builds generally don't have side-effects other than producing artifacts,
+        whereas Deploys and Runs often do.
+
+        This improves the user experience for the common use-case of referencing a container image in a runtime
+        resource (like a `helm` Deploy), where the user intent is almost always that the referenced build should exist
+        (i.e. the dependency should be processed) before the runtime resource is processed (i.e. deployed or run).
+
+        Note: We could also always execute Test actions that are referenced, but we'll stick with only Builds for now.
+       */
+        if (refActionKind === "Build") {
+          isExplicit = true
+        }
       }
 
-      if (alwaysExecuteCondition) {
+      if (!isString(outputKey)) {
+        // If the output key is not resolved yet, we just mark at as needing execution.
         needsExecuted = true
       } else {
-        needsExecuted =
-          isString(outputKey) && !staticOutputKeys.includes(outputKey) && !refStaticOutputKeys.includes(outputKey)
+        // Otherwise, we avoid execution when referencing the static output keys of the ref's action type.
+        // e.g. a helm deploy referencing container build static output deploymentImageName
+        // ${actions.build.my-container.outputs.deploymentImageName}
+        needsExecuted = !staticOutputKeys.includes(outputKey) && !refStaticOutputKeys.includes(outputKey)
       }
     }
 
@@ -1021,7 +1025,7 @@ function dependenciesFromActionConfig({
     }
 
     addDep(omit(refWithType, ["keyPath"]), {
-      explicit: false,
+      explicit: isExplicit,
       needsExecutedOutputs: needsExecuted,
       needsStaticOutputs: !needsExecuted,
     })

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -26,7 +26,7 @@ import { clearVarfileCache } from "../../../../src/config/base.js"
 import { parseTemplateCollection } from "../../../../src/template/templated-collections.js"
 import { deepResolveContext } from "../../../../src/config/template-contexts/base.js"
 import { setGlobalProjectApiVersion } from "../../../../src/project-api-version.js"
-import { ActionDependencyAttributes } from "../../../../src/actions/types.js"
+import type { ActionDependencyAttributes } from "../../../../src/actions/types.js"
 
 describe("actionConfigsToGraph", () => {
   let tmpDir: TempDirectory

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -396,7 +396,7 @@ describe("actionConfigsToGraph", () => {
 
     expect(deps).to.eql([
       {
-        explicit: true,
+        explicit: true, // <--- referenced builds are treated as if they were explicit dependencies
         kind: "Build",
         type: "test",
         name: "foo",

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -354,7 +354,7 @@ describe("actionConfigsToGraph", () => {
     ])
   })
 
-  it("flags implicit dependency as needing execution if a non-static output is referenced", async () => {
+  it("flags implicit dependency as needing execution and explicit if a non-static output is referenced", async () => {
     const graph = await actionConfigsToGraph({
       garden,
       log,
@@ -396,7 +396,7 @@ describe("actionConfigsToGraph", () => {
 
     expect(deps).to.eql([
       {
-        explicit: false,
+        explicit: true,
         kind: "Build",
         type: "test",
         name: "foo",

--- a/core/test/unit/src/graph/actions.ts
+++ b/core/test/unit/src/graph/actions.ts
@@ -75,9 +75,9 @@ describe("preprocessActionConfig", () => {
   })
 
   context("template strings", () => {
-    context("implicit dependencies inferred from actoin output references", () => {
+    context("implicit dependencies inferred from action output references", () => {
       context("a static output is referenced in API version v2", () => {
-        it("should inject an executed=true dependency when the ref is a Build", async () => {
+        it("should inject an explicit=true dependency when the ref is a Build", async () => {
           garden = await makeGarden(
             tmpDir,
             customizedTestPlugin({
@@ -141,16 +141,17 @@ describe("preprocessActionConfig", () => {
 
           expect(res.dependencies).to.eql([
             {
-              explicit: false,
+              explicit: true, // <-----
               kind: "Build",
               name: "build-dep",
-              needsExecutedOutputs: true, // <-----
-              needsStaticOutputs: false, // <-----
+              needsExecutedOutputs: false, // <-----
+              needsStaticOutputs: true, // <-----
               type: "test",
             },
           ])
         })
-        it("should not inject an executed=true dependency when the ref is a Run", async () => {
+
+        it("should not inject an explicit=true dependency when the ref is a Run", async () => {
           garden = await makeGarden(
             tmpDir,
             customizedTestPlugin({
@@ -372,7 +373,7 @@ describe("preprocessActionConfig", () => {
 
           expect(res.dependencies).to.eql([
             {
-              explicit: false,
+              explicit: false, // <-----
               kind: "Run",
               name: "run-dep",
               needsExecutedOutputs: false, // <-----


### PR DESCRIPTION
**What this PR does / why we need it**:

Back-port #7171 to 0.13.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
