### PR TITLE
ci: update `circleci/path-filtering` orb version to 1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@0.0.2
+  path-filtering: circleci/path-filtering@1.2.0
 
 # We are using a setup workflow here to filter based on the path of changed resources
 # and then continue the workflow with continue-config.yml based on the filters.


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the `circleci/path-filtering` orb version to the latest available.

That update was also done in 0.13 branch to make it possible to use path filtering, see #7181. Otherwise, the filtering step was failing.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
