### PR TITLE
chore: cleanup in joi schema definitions

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -78,9 +78,9 @@ const actionInternalFieldsSchema = createSchema({
   name: "action-config-internal-fields",
   extend: baseInternalFieldsSchema,
   keys: () => ({
-    groupName: joi.string().optional().meta({ internal: true }),
-    moduleName: joi.string().optional().meta({ internal: true }),
-    resolved: joi.boolean().optional().meta({ internal: true }),
+    groupName: joi.string().optional(),
+    moduleName: joi.string().optional(),
+    resolved: joi.boolean().optional(),
   }),
   allowUnknown: true,
   meta: { internal: true },

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -98,12 +98,12 @@ export interface BaseGardenResource {
 export const baseInternalFieldsSchema = createSchema({
   name: "base-internal-fields",
   keys: () => ({
-    basePath: joi.string().required().meta({ internal: true }),
-    configFilePath: joi.string().optional().meta({ internal: true }),
-    inputs: joi.object().optional().meta({ internal: true }),
-    parentName: joi.string().optional().meta({ internal: true }),
-    templateName: joi.string().optional().meta({ internal: true }),
-    yamlDoc: joi.any().optional().meta({ internal: true }),
+    basePath: joi.string().required(),
+    configFilePath: joi.string().optional(),
+    inputs: joi.object().optional(),
+    parentName: joi.string().optional(),
+    templateName: joi.string().optional(),
+    yamlDoc: joi.any().optional(),
   }),
   allowUnknown: true,
   meta: { internal: true },

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -465,14 +465,14 @@ const limitsSchema = createSchema({
     cpu: joi
       .number()
       .min(10)
-      .description("The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)")
-      .meta({ deprecated: true }), // TODO(deprecation): deprecate in 0.14
+      .description("The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)"),
     memory: joi
       .number()
       .min(64)
-      .description("The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)")
-      .meta({ deprecated: true }), // TODO(deprecation): deprecate in 0.14
+      .description("The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)"),
   }),
+  description: "Specify resource limits for the service.",
+  meta: { deprecated: "Please use the `cpu` and `memory` fields instead." }, // TODO(deprecation): deprecate in 0.14
 })
 
 export const containerCpuSchema = () =>
@@ -716,9 +716,7 @@ export const containerDeploySchemaKeys = memoize(() => ({
   // TODO(deprecation): deprecate in 0.14
   hotReload: joi.any().meta({ internal: true }),
   timeout: k8sDeploymentTimeoutSchema(),
-  limits: limitsSchema()
-    .description("Specify resource limits for the service.")
-    .meta({ deprecated: "Please use the `cpu` and `memory` fields instead." }), // TODO(deprecation): deprecate in 0.14
+  limits: limitsSchema(),
   ports: joiSparseArray(portSchema()).unique("name").description("List of ports that the service container exposes."),
   replicas: joi.number().integer().description(deline`
     The number of instances of the service to deploy.

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -33,7 +33,6 @@ import { templateStringLiteral } from "../../docs/common.js"
 import { syncGuideLink } from "../kubernetes/constants.js"
 import { makeSecret, type Secret } from "../../util/secrets.js"
 import type { ActionKind } from "../../plugin/action-types.js"
-import { makeDeprecationMessage } from "../../util/deprecations.js"
 
 export const defaultDockerfileName = "Dockerfile"
 
@@ -347,10 +346,7 @@ export const containerLocalModeSchema = createSchema({
     command: joi.sparseArray().optional().items(joi.string()),
     restart: localModeRestartSchema(),
   }),
-  meta: {
-    deprecated: makeDeprecationMessage({ deprecation: "localMode" }),
-    internal: true,
-  },
+  meta: { internal: true },
 })
 
 const annotationsSchema = memoize(() =>

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -323,8 +323,8 @@ export const containerSyncPathSchema = createSchema({
 export const localModeRestartSchema = createSchema({
   name: "local-mode-restart",
   keys: () => ({
-    delayMsec: joi.number().integer().optional().meta({ internal: true }),
-    max: joi.number().integer().optional().meta({ internal: true }),
+    delayMsec: joi.number().integer().optional(),
+    max: joi.number().integer().optional(),
   }),
   options: { presence: "optional" },
   meta: { internal: true },
@@ -333,8 +333,8 @@ export const localModeRestartSchema = createSchema({
 export const localModePortsSchema = createSchema({
   name: "local-mode-port",
   keys: () => ({
-    local: joi.number().integer().optional().meta({ internal: true }),
-    remote: joi.number().integer().optional().meta({ internal: true }),
+    local: joi.number().integer().optional(),
+    remote: joi.number().integer().optional(),
   }),
   meta: { internal: true },
 })
@@ -343,8 +343,8 @@ export const containerLocalModeSchema = createSchema({
   name: "container-local-mode",
   description: `This feature has been deleted.`,
   keys: () => ({
-    ports: joi.array().optional().items(localModePortsSchema()).meta({ internal: true }),
-    command: joi.sparseArray().optional().items(joi.string()).meta({ internal: true }),
+    ports: joi.array().optional().items(localModePortsSchema()),
+    command: joi.sparseArray().optional().items(joi.string()),
     restart: localModeRestartSchema(),
   }),
   meta: {

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -211,25 +211,21 @@ const resourceSchema = (defaults: KubernetesResourceSpec, deprecated: boolean) =
             .integer()
             .default(defaults.limits.cpu)
             .description("CPU limit in millicpu.")
-            .example(defaults.limits.cpu)
-            .meta({ deprecated }),
+            .example(defaults.limits.cpu),
           memory: joi
             .number()
             .integer()
             .default(defaults.limits.memory)
             .description("Memory limit in megabytes.")
-            .example(defaults.limits.memory)
-            .meta({ deprecated }),
+            .example(defaults.limits.memory),
           ephemeralStorage: joi
             .number()
             .integer()
             .optional()
             .description("Ephemeral storage limit in megabytes.")
-            .example(8192)
-            .meta({ deprecated }),
+            .example(8192),
         })
-        .default(defaults.limits)
-        .meta({ deprecated }),
+        .default(defaults.limits),
       requests: joi
         .object()
         .keys({
@@ -238,22 +234,19 @@ const resourceSchema = (defaults: KubernetesResourceSpec, deprecated: boolean) =
             .integer()
             .default(defaults.requests.cpu)
             .description("CPU request in millicpu.")
-            .example(defaults.requests.cpu)
-            .meta({ deprecated }),
+            .example(defaults.requests.cpu),
           memory: joi
             .number()
             .integer()
             .default(defaults.requests.memory)
             .description("Memory request in megabytes.")
-            .example(defaults.requests.memory)
-            .meta({ deprecated }),
+            .example(defaults.requests.memory),
           ephemeralStorage: joi
             .number()
             .integer()
             .optional()
             .description("Ephemeral storage request in megabytes.")
-            .example(8192)
-            .meta({ deprecated }),
+            .example(8192),
         })
         .default(defaults.requests)
         .meta({ deprecated }),

--- a/core/src/plugins/kubernetes/kubernetes-type/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/config.ts
@@ -128,7 +128,7 @@ type KubernetesCommonDeployKeyDeprecations = { deprecateFiles: boolean }
 
 export const kubernetesCommonDeploySpecKeys = (deprecations: KubernetesCommonDeployKeyDeprecations) => {
   const keys = {
-    files: kubernetesManifestTemplatesSchema().meta({ deprecated: deprecations.deprecateFiles }),
+    files: kubernetesManifestTemplatesSchema(),
     kustomize: kustomizeSpecSchema(),
     manifests: kubernetesManifestsSchema(),
     patchResources: kubernetesPatchResourcesSchema(),

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -15,10 +15,10 @@ export const kubernetesLocalModeSchema = () =>
     target: joi
       .object()
       .keys({
-        kind: joi.string().optional().meta({ internal: true }),
-        name: joi.string().optional().meta({ internal: true }),
-        podSelector: joi.string().optional().meta({ internal: true }),
-        containerName: joi.string().optional().meta({ internal: true }),
+        kind: joi.string().optional(),
+        name: joi.string().optional(),
+        podSelector: joi.string().optional(),
+        containerName: joi.string().optional(),
       })
       .meta({ internal: true }),
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

The behavior of `deprecated` and `internal` metadata flags of joi schemas was fixed in #7174.
Now both of the flags are propagated to the child-objects recursively.

The presense of both flags makes no sense on the joi-schema level, because internal fields are never rendered in the reference documentation.

This PR removes the unnecessary manual flag declarations, and minimized the usage of `deprecated: true` flag with a `boolean` value. The goal is to get rid of the boolean values at all, and use type-safe deprecation flags which will be implemented in #7143.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The code joi-schema code changes made in this PR did not cause any changes in the generated reference docs.