### PR TITLE
chore: deprecation for `spec.files` in `kubernetes-pod` action type

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -709,7 +709,7 @@ export const containerDeploySchemaKeys = memoize(() => ({
     .description("List of ingress endpoints that the service exposes.")
     .example([{ path: "/api", port: "http" }]),
   healthCheck: healthCheckSchema().description("Specify how the service's health should be checked after deploying."),
-  // TODO(deprecation): deprecate in 0.14
+  // TODO(0.15): remove this
   hotReload: joi.any().meta({ internal: true }),
   timeout: k8sDeploymentTimeoutSchema(),
   limits: limitsSchema(),

--- a/core/src/plugins/container/moduleConfig.ts
+++ b/core/src/plugins/container/moduleConfig.ts
@@ -144,10 +144,8 @@ export const containerModuleSpecSchema = () =>
         If neither \`include\` nor \`exclude\` is set, and the module
         specifies a remote image, Garden automatically sets \`include\` to \`[]\`.
       `),
-      hotReload: joi.any().meta({
-        internal: true,
-        // no need to compose deprecation message here, because thid field is hidden and does not appear in the reference docs
-      }),
+      // TODO(0.15): remove this
+      hotReload: joi.any().meta({ internal: true }),
       dockerfile: joi
         .posixPath()
         .subPathOnly()

--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
@@ -13,7 +13,7 @@ import { getActionNamespaceStatus } from "../namespace.js"
 import type { ActionKind, RunActionDefinition, TestActionDefinition } from "../../../plugin/action-types.js"
 import { dedent } from "../../../util/string.js"
 import type { RunAction, RunActionConfig } from "../../../actions/run.js"
-import { createSchema } from "../../../config/common.js"
+import { createSchema, joi } from "../../../config/common.js"
 import type { V1PodSpec } from "@kubernetes/client-node"
 import { runOrTestWithPod } from "./common.js"
 import type { KubernetesRunOutputs, KubernetesTestOutputs } from "./config.js"
@@ -35,6 +35,22 @@ import { getRunResultCache, getTestResultCache } from "../results-cache.js"
 import { toActionStatus } from "../util.js"
 import { InternalError } from "../../../exceptions.js"
 import type { KubernetesRunResult } from "../../../plugin/base.js"
+import { reportDeprecatedFeatureUsage } from "../../../util/deprecations.js"
+import { emitNonRepeatableWarning } from "../../../warnings.js"
+import { styles } from "../../../logger/styles.js"
+import { actionReferenceToString } from "../../../actions/base.js"
+import type { Log } from "../../../logger/log-entry.js"
+
+function examineForDeprecations(config: KubernetesPodRunActionConfig | KubernetesPodTestActionConfig, log: Log) {
+  const spec = config.spec
+  if ("files" in spec) {
+    emitNonRepeatableWarning(
+      log,
+      `Obsolete configuration field ${styles.highlight("spec.files")} found in the action ${styles.highlight(actionReferenceToString(config))} at ${styles.highlight(config.internal.configFilePath || config.internal.basePath)}`
+    )
+    reportDeprecatedFeatureUsage({ log, deprecation: "kubernetesPodSpecFiles" })
+  }
+}
 
 // RUN //
 
@@ -79,7 +95,7 @@ export const kubernetesRunPodSchema = (kind: ActionKind) => {
       manifests: kubernetesManifestsSchema().description(
         `List of Kubernetes resource manifests to be searched (using \`resource\`e for the pod spec for the ${kind}. If \`files\` is also specified, this is combined with the manifests read from the files.`
       ),
-      files: kubernetesPodManifestTemplatesSchema(kind).meta({ deprecated: true }),
+      files: joi.any().meta({ internal: true }),
       manifestFiles: kubernetesManifestFilesSchema(),
       manifestTemplates: kubernetesPodManifestTemplatesSchema(kind),
       resource: runPodResourceSchema(kind),
@@ -101,6 +117,10 @@ export const kubernetesPodRunDefinition = (): RunActionDefinition<KubernetesPodR
   schema: kubernetesRunPodSchema("Run"),
   runtimeOutputsSchema: kubernetesRunOutputsSchema(),
   handlers: {
+    configure: async ({ log, config }) => {
+      examineForDeprecations(config, log)
+      return { config, supportedModes: {} }
+    },
     run: async (params) => {
       const { ctx, log, action } = params
       const k8sCtx = <KubernetesPluginContext>ctx
@@ -155,6 +175,10 @@ export const kubernetesPodTestDefinition = (): TestActionDefinition<KubernetesPo
   schema: kubernetesRunPodSchema("Test"),
   runtimeOutputsSchema: kubernetesTestOutputsSchema(),
   handlers: {
+    configure: async ({ log, config }) => {
+      examineForDeprecations(config, log)
+      return { config, supportedModes: {} }
+    },
     run: async (params) => {
       const { ctx, log, action } = params
       const k8sCtx = <KubernetesPluginContext>ctx

--- a/core/src/plugins/kubernetes/kubernetes-type/module-config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/module-config.ts
@@ -77,10 +77,8 @@ export const kubernetesModuleSpecSchema = () =>
         )
         .keys({
           containerModule: containerModuleSchema(),
-          hotReloadArgs: joi.any().meta({
-            internal: true,
-            // no need to compose deprecation message here, because thid field is hidden and does not appear in the reference docs
-          }),
+          // TODO(0.15): remove this
+          hotReloadArgs: joi.any().meta({ internal: true }),
         }),
       tasks: joiSparseArray(kubernetesTaskSchema()),
       tests: joiSparseArray(kubernetesTestSchema()),

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -109,7 +109,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
     },
     workflowLimits: {
       docsSection: "Old configuration syntax",
-      docsHeadline: `Using ${style("limits")} configuration field in workflows`,
+      docsHeadline: `${style("limits")} configuration field in workflows`,
       warnHint: deline`
         Please use the ${style("resources.limits")} configuration field instead.
       `,

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -83,6 +83,20 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         The ${style("resources.sync")} config field in the ${style("kubernetes")} provider was only used for the ${style("cluster-docker")} build mode, which was removed in Garden 0.13.",
       `,
     },
+    kubernetesPodSpecFiles: {
+      docsSection: "Old configuration syntax",
+      docsHeadline: `${style("spec.files")} configuration field in ${style("kubernetes-pod")} action type`,
+      warnHint: deline`
+        The ${style("spec.files")} configuration field in ${style("kubernetes-pod")} action type has no effect.
+        Please remove it and use ${style("spec.manifestFiles")} or ${style("spec.manifestTemplates")} instead.
+      `,
+      docs: dedent`
+        See the reference documentation for details.
+
+        For ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles) and [${style("spec.manifestTemplates")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles).
+        For ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles) and [${style("spec.manifestTemplates")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles).
+      `,
+    },
     kubernetesPluginCleanupClusterRegistryCommand: {
       docsSection: "Unsupported commands",
       docsHeadline: `${style("cleanup-cluster-registry")}`,

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -93,8 +93,8 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       docs: dedent`
         See the reference documentation for details.
 
-        For ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles) and [${style("spec.manifestTemplates")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles).
-        For ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles) and [${style("spec.manifestTemplates")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles).
+        For ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
+        For ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
       `,
     },
     kubernetesPluginCleanupClusterRegistryCommand: {

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -93,8 +93,8 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       docs: dedent`
         See the reference documentation for details.
 
-        For the ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
-        For the ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
+        For the ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/Run/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/Run/kubernetes-pod.md#spec.manifesttemplates).
+        For the ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/Test/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/Test/kubernetes-pod.md#spec.manifesttemplates).
       `,
     },
     kubernetesPluginCleanupClusterRegistryCommand: {

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -93,8 +93,8 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       docs: dedent`
         See the reference documentation for details.
 
-        For ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
-        For ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
+        For the ${style("Run")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
+        For the ${style("Test")} action kind see [${style("spec.manifestFiles")}](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [${style("spec.manifestTemplates")}](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
       `,
     },
     kubernetesPluginCleanupClusterRegistryCommand: {

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -46,8 +46,8 @@ The `spec.files` configuration field in `kubernetes-pod` action type has no effe
 
 See the reference documentation for details.
 
-For `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles).
-For `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles).
+For `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
+For `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
 
 <h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -46,8 +46,8 @@ The `spec.files` configuration field in `kubernetes-pod` action type has no effe
 
 See the reference documentation for details.
 
-For the `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
-For the `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
+For the `Run` action kind see [`spec.manifestFiles`](../reference/action-types/Run/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/Run/kubernetes-pod.md#spec.manifesttemplates).
+For the `Test` action kind see [`spec.manifestFiles`](../reference/action-types/Test/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/Test/kubernetes-pod.md#spec.manifesttemplates).
 
 <h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -40,6 +40,15 @@ The `resources.sync` config field in the `kubernetes` provider has no effect in 
 
 The `resources.sync` config field in the `kubernetes` provider was only used for the `cluster-docker` build mode, which was removed in Garden 0.13.",
 
+<h2 id="kubernetespodspecfiles"><code>spec.files</code> configuration field in <code>kubernetes-pod</code> action type</h2>
+
+The `spec.files` configuration field in `kubernetes-pod` action type has no effect. Please remove it and use `spec.manifestFiles` or `spec.manifestTemplates` instead.
+
+See the reference documentation for details.
+
+For `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles).
+For `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles).
+
 <h2 id="workflowlimits">Using <code>limits</code> configuration field in workflows</h2>
 
 Please use the `resources.limits` configuration field instead.

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -46,8 +46,8 @@ The `spec.files` configuration field in `kubernetes-pod` action type has no effe
 
 See the reference documentation for details.
 
-For `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
-For `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
+For the `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifesttemplates).
+For the `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifesttemplates).
 
 <h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -49,7 +49,7 @@ See the reference documentation for details.
 For `Run` action kind see [`spec.manifestFiles`](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles) and [`spec.manifestTemplates`](../reference/action-types/run/kubernetes-pod.md#spec.manifestFiles).
 For `Test` action kind see [`spec.manifestFiles`](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles) and [`spec.manifestTemplates`](../reference/action-types/test/kubernetes-pod.md#spec.manifestFiles).
 
-<h2 id="workflowlimits">Using <code>limits</code> configuration field in workflows</h2>
+<h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 
 Please use the `resources.limits` configuration field instead.
 

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -558,24 +558,6 @@ The name of the resource.
 | -------- | -------- |
 | `string` | Yes      |
 
-### `spec.files[]`
-
-[spec](#spec) > files
-
-{% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
-{% endhint %}
-
-POSIX-style paths to YAML files to load manifests from. Each file may contain multiple manifests.
-
-Garden will treat each manifestTemplate file as a template string expression, resolve it and then attempt to parse the resulting string as YAML.
-
-Then it will find the resource matching the Pod spec for the Run ([See also `spec.resource`](#specresource)).
-
-| Type               | Default | Required |
-| ------------------ | ------- | -------- |
-| `array[posixPath]` | `[]`    | No       |
-
 ### `spec.manifestFiles[]`
 
 [spec](#spec) > manifestFiles

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -558,24 +558,6 @@ The name of the resource.
 | -------- | -------- |
 | `string` | Yes      |
 
-### `spec.files[]`
-
-[spec](#spec) > files
-
-{% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
-{% endhint %}
-
-POSIX-style paths to YAML files to load manifests from. Each file may contain multiple manifests.
-
-Garden will treat each manifestTemplate file as a template string expression, resolve it and then attempt to parse the resulting string as YAML.
-
-Then it will find the resource matching the Pod spec for the Test ([See also `spec.resource`](#specresource)).
-
-| Type               | Default | Required |
-| ------------------ | ------- | -------- |
-| `array[posixPath]` | `[]`    | No       |
-
 ### `spec.manifestFiles[]`
 
 [spec](#spec) > manifestFiles


### PR DESCRIPTION
**What this PR does / why we need it**:

We overlooked that in 0.14 release.

In fact, the `spec.files` field has not effect at all, but it could still be specified in the configuration file without a schema validation error.

This PR hides the reference documentation and prints warnings if the obsolete field is still defined in a configuration file.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
