### PR TITLE
fix: improve reliability by removing config store file lock

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -122,7 +122,6 @@
     "path-is-inside": "^1.0.2",
     "pluralize": "^8.0.0",
     "prop-types": "^15.8.1",
-    "proper-lockfile": "^4.1.2",
     "proper-url-join": "^2.1.2",
     "proxy-agent": "^6.5.0",
     "qs": "^6.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,7 +1111,6 @@
         "path-is-inside": "^1.0.2",
         "pluralize": "^8.0.0",
         "prop-types": "^15.8.1",
-        "proper-lockfile": "^4.1.2",
         "proper-url-join": "^2.1.2",
         "proxy-agent": "^6.5.0",
         "qs": "^6.13.1",
@@ -6479,30 +6478,6 @@
     "core/node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "core/node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "core/node_modules/proper-lockfile/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "license": "ISC"
-    },
-    "core/node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "core/node_modules/proper-lockfile/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
     },
     "core/node_modules/ps-tree": {
       "version": "1.2.0",


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:
We've seen some users encountering error messages when Garden couldn't
acquire the config store lock.

We're already preventing data corruption on concurrent modification by
relying on atomically writing by creating a new file and moving it.

This commit changes the lock mechanism to only protect concurrent writes
from the same garden process, but we accept data loss in the unlikely
event another garden process also updates the config store at the same
time (one of the writes will win).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
