### PR TITLE
fix(terraform): use backendConfig with plugin commands

### DIFF
--- a/plugins/terraform/src/commands.ts
+++ b/plugins/terraform/src/commands.ts
@@ -49,11 +49,13 @@ function makeRootCommand(commandName: string): PluginCommand {
       })
       await remove(cachePath)
 
+      // Use provider config
       const root = join(ctx.projectRoot, provider.config.initRoot)
       const workspace = provider.config.workspace || null
+      const backendConfig = provider.config.backendConfig
 
       await ensureWorkspace({ ctx, provider, root, log, workspace })
-      await ensureTerraformInit({ ctx, provider, root, log })
+      await ensureTerraformInit({ ctx, provider, root, log, backendConfig })
 
       args = [commandName, ...(await prepareVariables(root, provider.config.variables)), ...args]
 
@@ -93,10 +95,12 @@ function makeActionCommand(commandName: string): PluginCommand {
       const root = join(action.sourcePath(), spec.root)
 
       const provider = ctx.provider as TerraformProvider
+      // Use action spec
       const workspace = spec.workspace || null
+      const backendConfig = spec.backendConfig
 
       await ensureWorkspace({ ctx, provider, root, log, workspace })
-      await ensureTerraformInit({ ctx, provider, root, log })
+      await ensureTerraformInit({ ctx, provider, root, log, backendConfig })
 
       args = [commandName, ...(await prepareVariables(root, spec.variables)), ...args.slice(1)]
       await terraform(ctx, provider).spawnAndWait({

--- a/plugins/terraform/src/handlers.ts
+++ b/plugins/terraform/src/handlers.ts
@@ -31,9 +31,10 @@ export const getTerraformStatus: DeployActionHandler<"getStatus", TerraformDeplo
 
   const variables = spec.variables
   const workspace = spec.workspace || null
+  const backendConfig = spec.backendConfig
 
   await ensureWorkspace({ log, ctx, provider, root, workspace })
-  await ensureTerraformInit({ log, ctx, provider, root, backendConfig: spec.backendConfig })
+  await ensureTerraformInit({ log, ctx, provider, root, backendConfig })
 
   const status = await getStackStatus({
     ctx,

--- a/plugins/terraform/src/helpers.ts
+++ b/plugins/terraform/src/helpers.ts
@@ -125,7 +125,7 @@ export async function hasBackendConfigChanged({
     throw err
   }
 
-  const currentBackendConfig = tfState?.backend?.["config"] as { [key: string]: string } | undefined
+  const currentBackendConfig = tfState?.backend?.["config"] as { [key: string]: string | null | undefined } | undefined
 
   const hasChanged =
     (currentBackendConfig &&

--- a/plugins/terraform/src/helpers.ts
+++ b/plugins/terraform/src/helpers.ts
@@ -94,7 +94,7 @@ const terraformValidateOutputSchema = s
 
 /**
  * Reads the current backend config from the `.terraform/terraform.tfstate` file and
- * compares it to the backend config supplied by the user via the Garden config (passed)
+ * compares it to the backend config supplied by the user via the Garden config passed
  * as an argument to this function.
  *
  * Returns true if the user defined backend config is different from the one in the `tfstate` file.
@@ -209,7 +209,7 @@ export async function ensureTerraformInit(params: TerraformParams & { backendCon
     // It failed when running "terraform init": in this case we only add the error from the
     // first validation try
     if (initError) {
-      const resultErrors = res.diagnostics.map((d: any) => `${startCase(d.severity)}: ${d.summary}\n${d.detail || ""}`)
+      const resultErrors = res.diagnostics.map((d) => `${startCase(d.severity)}: ${d.summary}\n${d.detail || ""}`)
       errorMsg += dedent`\n\n${resultErrors.join("\n")}
 
         Garden tried running "terraform init" but got the following error:\n


### PR DESCRIPTION
Before this fix, we weren't passing the `backendConfig` to Terraform when using plugins commands.

That is, for commands like `garden plugins terraform apply-root` the `backendConfig` specified in the Garden config would be ignored.

This commit fixes that and adds tests.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
