### PR TITLE
chore: deprecate legacy container limit syntax

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -9,13 +9,13 @@
 import type { Primitive, PrimitiveMap } from "../../config/common.js"
 import {
   artifactsTargetDescription,
+  createSchema,
   envVarRegex,
   joi,
   joiPrimitive,
   joiSparseArray,
   joiStringMap,
   joiUserIdentifier,
-  createSchema,
 } from "../../config/common.js"
 import type { ArtifactSpec } from "../../config/validation.js"
 import { ingressHostnameSchema, linkUrlSchema } from "../../types/service.js"
@@ -33,6 +33,7 @@ import { templateStringLiteral } from "../../docs/common.js"
 import { syncGuideLink } from "../kubernetes/constants.js"
 import { makeSecret, type Secret } from "../../util/secrets.js"
 import type { ActionKind } from "../../plugin/action-types.js"
+import { makeDeprecationMessage } from "../../util/deprecations.js"
 
 export const defaultDockerfileName = "Dockerfile"
 
@@ -468,7 +469,7 @@ const limitsSchema = createSchema({
       .description("The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)"),
   }),
   description: "Specify resource limits for the service.",
-  meta: { deprecated: "Please use the `cpu` and `memory` fields instead." }, // TODO(deprecation): deprecate in 0.14
+  meta: { deprecated: makeDeprecationMessage({ deprecation: "containerDeployActionLimits" }) },
 })
 
 export const containerCpuSchema = () =>

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -98,8 +98,8 @@ export interface ServiceHealthCheckSpec {
  * @deprecated use {@link ContainerResourcesSpec} instead.
  */
 export interface LegacyServiceLimitSpec {
-  cpu: number
-  memory: number
+  cpu: number | undefined
+  memory: number | undefined
 }
 
 export interface ContainerResourcesSpec {

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -609,6 +609,10 @@ interface ContainerCommonRuntimeSpec {
   command?: string[]
   env: PrimitiveMap
 
+  /**
+   * TODO(0.15) remove this
+   * @deprecated use {@link #cpu} and {@link #memory} instead
+   */
   limits?: LegacyServiceLimitSpec
   cpu: ContainerResourcesSpec["cpu"]
   memory: ContainerResourcesSpec["memory"]

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -31,7 +31,7 @@ import { resolve } from "path"
 import { killPortForwards } from "../port-forward.js"
 import { prepareSecrets } from "../secrets.js"
 import { configureSyncMode, convertContainerSyncSpec } from "../sync.js"
-import { getDeployedImageId, getResourceRequirements, getSecurityContext } from "./util.js"
+import { getDeployedImageId, getResourceRequirements, getSecurityContext, resolveResourceLimits } from "./util.js"
 import type { DeployActionHandler, DeployActionParams } from "../../../plugin/action-types.js"
 import type { ActionMode, Resolved } from "../../../actions/types.js"
 import { ConfigurationError, DeploymentError } from "../../../exceptions.js"
@@ -232,13 +232,14 @@ export async function createWorkloadManifest({
   })
 
   const { cpu, memory, limits } = spec
+  const resolvedResourceLimits = resolveResourceLimits({ cpu, memory }, limits)
 
   const container: V1Container = {
     name: action.name,
     image: imageId,
     env,
     ports: [],
-    resources: getResourceRequirements({ cpu, memory }, limits),
+    resources: getResourceRequirements(resolvedResourceLimits),
     imagePullPolicy: "IfNotPresent",
     securityContext: {
       allowPrivilegeEscalation: spec.privileged || false,

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -107,7 +107,7 @@ export function resolveResourceLimits(
       You have specified both ${naturalList(newConfigFields)} and ${styles.bold("deprecated")} ${naturalList(legacyConfigFields)}
       in your action config.
 
-      ${styles.bold(`Garden will use the values defined in the deprecated ${styles.highlight("spec.limits")}!!!`)}.
+      ${styles.bold(`Garden will use the values defined in the deprecated ${styles.highlight("spec.limits")}!`)}.
       Please use only ${styles.highlight("spec.cpu")} and ${styles.highlight("spec.memory")} fields in your action configuration.`
 
   return { resolvedResources, warning }

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -34,12 +34,9 @@ export function getDeployedImageId(action: Resolved<ContainerRuntimeAction>): st
   }
 }
 
-export function getResourceRequirements(
-  resources: ContainerResourcesSpec,
-  limits?: LegacyServiceLimitSpec
-): V1ResourceRequirements {
-  const maxCpu = limits?.cpu || resources.cpu.max
-  const maxMemory = limits?.memory || resources.memory.max
+export function getResourceRequirements(resources: ContainerResourcesSpec): V1ResourceRequirements {
+  const maxCpu = resources.cpu.max
+  const maxMemory = resources.memory.max
 
   const resourceReq: V1ResourceRequirements = {
     requests: {
@@ -58,6 +55,25 @@ export function getResourceRequirements(
   }
 
   return resourceReq
+}
+
+export function resolveResourceLimits(
+  resources: ContainerResourcesSpec,
+  limits?: LegacyServiceLimitSpec
+): ContainerResourcesSpec {
+  const maxCpu = limits?.cpu || resources.cpu.max
+  const maxMemory = limits?.memory || resources.memory.max
+
+  return {
+    cpu: {
+      min: resources.cpu.min,
+      max: maxCpu,
+    },
+    memory: {
+      min: resources.memory.min,
+      max: maxMemory,
+    },
+  }
 }
 
 export function getSecurityContext(

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -17,6 +17,8 @@ import type { V1ResourceRequirements, V1SecurityContext } from "@kubernetes/clie
 import { ConfigurationError } from "../../../exceptions.js"
 import type { Resolved } from "../../../actions/types.js"
 import { kilobytesToString, megabytesToString, millicpuToString } from "../util.js"
+import { deline, naturalList } from "../../../util/string.js"
+import { styles } from "../../../logger/styles.js"
 
 export function getDeployedImageId(action: Resolved<ContainerRuntimeAction>): string {
   const explicitImage = action.getSpec().image
@@ -57,14 +59,19 @@ export function getResourceRequirements(resources: ContainerResourcesSpec): V1Re
   return resourceReq
 }
 
+/**
+ * TODO(0.15): remove this
+ * @param resources the resource limits defined via new config syntax
+ * @param limits the resource limits defined via old config syntax
+ */
 export function resolveResourceLimits(
   resources: ContainerResourcesSpec,
   limits?: LegacyServiceLimitSpec
-): ContainerResourcesSpec {
+): { resolvedResources: ContainerResourcesSpec; warning: string | undefined } {
   const maxCpu = limits?.cpu || resources.cpu.max
   const maxMemory = limits?.memory || resources.memory.max
 
-  return {
+  const resolvedResources = {
     cpu: {
       min: resources.cpu.min,
       max: maxCpu,
@@ -74,6 +81,36 @@ export function resolveResourceLimits(
       max: maxMemory,
     },
   }
+
+  const conflicts: ("memory" | "cpu")[] = []
+  if (limits) {
+    if (resources.cpu.max && limits.cpu) {
+      conflicts.push("cpu")
+    }
+    if (resources.memory.max && limits.memory) {
+      conflicts.push("memory")
+    }
+  }
+
+  if (conflicts.length === 0) {
+    return { resolvedResources, warning: undefined }
+  }
+
+  const legacyConfigFields: string[] = []
+  const newConfigFields: string[] = []
+  for (const conflict of conflicts) {
+    legacyConfigFields.push(styles.highlight(`spec.limits.${conflict}`))
+    newConfigFields.push(styles.highlight(`spec.${conflict}.max`))
+  }
+
+  const warning = deline`
+      You have specified both ${naturalList(newConfigFields)} and ${styles.bold("deprecated")} ${naturalList(legacyConfigFields)}
+      in your action config.
+
+      ${styles.bold(`Garden will use the values defined in the deprecated ${styles.highlight("spec.limits")}!!!`)}.
+      Please use only ${styles.highlight("spec.cpu")} and ${styles.highlight("spec.memory")} fields in your action configuration.`
+
+  return { resolvedResources, warning }
 }
 
 export function getSecurityContext(

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -114,7 +114,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         Please use the ${style("cpu")} and ${style("memory")} configuration fields instead.
       `,
       docs: dedent`
-        Note! If the deprecated field [${style("spec.limits")}](../reference/action-types/deploy/container#spec.limits)
+        Note! If the deprecated field [${style("spec.limits")}](../reference/action-types/Deploy/container.md#spec.limits)
         is defined in the ${style("container")} Deploy action config,
         Garden 0.14 automatically copies the field's contents to the ${style("spec.cpu")} and ${style("spec.memory")},
         even if the latter are defined explicitly.
@@ -122,8 +122,8 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         Please do not use both ${style("spec.limits")} and ${style("spec.cpu")} and/or ${style("spec.memory")} simultaneously,
         and use only the latter pair of fields. Otherwise, the values from the old field ${style("spec.limits")} will be used.
 
-        See [${style("spec.cpu")}](../reference/action-types/deploy/container#spec.cpu)
-        and [${style("spec.memory")}](../reference/action-types/deploy/container#spec.memory) for the new syntax details.
+        See [${style("spec.cpu")}](../reference/action-types/Deploy/container.md#spec.cpu)
+        and [${style("spec.memory")}](../reference/action-types/Deploy/container.md#spec.memory) for the new syntax details.
       `,
     },
     workflowLimits: {
@@ -133,14 +133,14 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         Please use the ${style("resources.limits")} configuration field instead.
       `,
       docs: dedent`
-        Note! If the deprecated field [${style("limits")}](../reference/workflow-config#limits) is defined in the workflow config,
+        Note! If the deprecated field [${style("limits")}](../reference/workflow-config.md#limits) is defined in the workflow config,
         Garden 0.14 automatically copies the field's contents to the ${style("resources.limits")},
         even if the latter is defined explicitly.
 
         Please do not use both ${style("limits")} and ${style("resources.limits")} simultaneously,
         and use only ${style("resources.limits")}. Otherwise, the values from the old field ${style("limits")} will be used.
 
-        See [${style("resources.limits")}](../reference/workflow-config#resources.limits) for the new syntax details.
+        See [${style("resources.limits")}](../reference/workflow-config.md#resources.limits) for the new syntax details.
       `,
     },
   } as const

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -115,14 +115,15 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       `,
       docs: dedent`
         Note! If the deprecated field [${style("spec.limits")}](../reference/action-types/deploy/container#spec.limits)
-        explicitly defines any cpu or memory limits in the ${style("container")} Deploy action,
+        is defined in the ${style("container")} Deploy action config,
         Garden 0.14 automatically copies the field's contents to the ${style("spec.cpu")} and ${style("spec.memory")},
         even if the latter are defined explicitly.
 
         Please do not use both ${style("spec.limits")} and ${style("spec.cpu")} and/or ${style("spec.memory")} simultaneously,
         and use only the latter pair of fields. Otherwise, the values from the old field ${style("spec.limits")} will be used.
 
-        See [${style("spec.cpu")}](../reference/action-types/deploy/container#spec.cpu) and [${style("spec.memory")}](../reference/action-types/deploy/container#spec.memory)
+        See [${style("spec.cpu")}](../reference/action-types/deploy/container#spec.cpu)
+        and [${style("spec.memory")}](../reference/action-types/deploy/container#spec.memory) for the new syntax details.
       `,
     },
     workflowLimits: {
@@ -132,12 +133,14 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
         Please use the ${style("resources.limits")} configuration field instead.
       `,
       docs: dedent`
-        Note! If the deprecated field ${style("limits")} is defined in the workflow config,
+        Note! If the deprecated field [${style("limits")}](../reference/workflow-config#limits) is defined in the workflow config,
         Garden 0.14 automatically copies the field's contents to the ${style("resources.limits")},
-        even if the ${style("resources.limits")} is defined explicitly.
+        even if the latter is defined explicitly.
 
         Please do not use both ${style("limits")} and ${style("resources.limits")} simultaneously,
         and use only ${style("resources.limits")}. Otherwise, the values from the old field ${style("limits")} will be used.
+
+        See [${style("resources.limits")}](../reference/workflow-config#resources.limits) for the new syntax details.
       `,
     },
   } as const

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -107,6 +107,24 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       `,
       docs: null,
     },
+    containerDeployActionLimits: {
+      docsSection: "Old configuration syntax",
+      docsHeadline: `${style("spec.limits")} configuration field in ${style("container")} Deploy action`,
+      warnHint: deline`
+        Please use the ${style("cpu")} and ${style("memory")} configuration fields instead.
+      `,
+      docs: dedent`
+        Note! If the deprecated field [${style("spec.limits")}](../reference/action-types/deploy/container#spec.limits)
+        explicitly defines any cpu or memory limits in the ${style("container")} Deploy action,
+        Garden 0.14 automatically copies the field's contents to the ${style("spec.cpu")} and ${style("spec.memory")},
+        even if the latter are defined explicitly.
+
+        Please do not use both ${style("spec.limits")} and ${style("spec.cpu")} and/or ${style("spec.memory")} simultaneously,
+        and use only the latter pair of fields. Otherwise, the values from the old field ${style("spec.limits")} will be used.
+
+        See [${style("spec.cpu")}](../reference/action-types/deploy/container#spec.cpu) and [${style("spec.memory")}](../reference/action-types/deploy/container#spec.memory)
+      `,
+    },
     workflowLimits: {
       docsSection: "Old configuration syntax",
       docsHeadline: `${style("limits")} configuration field in workflows`,

--- a/core/test/unit/src/commands/get/get-config.ts
+++ b/core/test/unit/src/commands/get/get-config.ts
@@ -17,7 +17,7 @@ import {
   DEFAULT_TEST_TIMEOUT_SEC,
   GardenApiVersion,
 } from "../../../../../src/constants.js"
-import type { WorkflowConfig } from "../../../../../src/config/workflow.js"
+import type { WorkflowConfig, WorkflowLimitSpec } from "../../../../../src/config/workflow.js"
 import { defaultWorkflowResources } from "../../../../../src/config/workflow.js"
 import { defaultContainerLimits } from "../../../../../src/plugins/container/moduleConfig.js"
 import type { ModuleConfig } from "../../../../../src/config/module.js"
@@ -94,7 +94,7 @@ describe("GetConfigCommand", () => {
         name: "workflow-a",
         kind: "Workflow",
         keepAliveHours: 48,
-        limits: defaultContainerLimits,
+        limits: defaultContainerLimits as WorkflowLimitSpec,
         internal: {
           basePath: garden.projectRoot,
         },

--- a/core/test/unit/src/plugins/kubernetes/container/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/util.ts
@@ -7,7 +7,10 @@
  */
 
 import { expect } from "chai"
-import { getResourceRequirements } from "../../../../../../src/plugins/kubernetes/container/util.js"
+import {
+  getResourceRequirements,
+  resolveResourceLimits,
+} from "../../../../../../src/plugins/kubernetes/container/util.js"
 
 describe("getResourceRequirements", () => {
   it("should return resources", () => {
@@ -43,10 +46,12 @@ describe("getResourceRequirements", () => {
       },
     })
   })
+})
 
+describe("resolveResourceLimits", () => {
   it("should prioritize deprecated limits param", () => {
     expect(
-      getResourceRequirements({ cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } }, { cpu: 50, memory: 50 })
+      resolveResourceLimits({ cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } }, { cpu: 50, memory: 50 })
     ).to.eql({
       requests: {
         cpu: "1m",

--- a/core/test/unit/src/plugins/kubernetes/container/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/util.ts
@@ -51,17 +51,17 @@ describe("getResourceRequirements", () => {
 describe("resolveResourceLimits", () => {
   it("should prioritize deprecated limits param", () => {
     const { resolvedResources } = resolveResourceLimits(
-      { cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } },
-      { cpu: 50, memory: 50 }
+      { cpu: { max: 10, min: 1 }, memory: { max: null, min: 1 } }, // non-deprecated resource limit spec
+      { cpu: 50, memory: 50 } // deprecated resource limit spec
     )
     expect(resolvedResources).to.eql({
-      requests: {
-        cpu: "1m",
-        memory: "1Mi",
+      cpu: {
+        max: 50, // <-- taken from deprecated resource limit spec
+        min: 1, // <-- taken from non-deprecated resource limit spec
       },
-      limits: {
-        cpu: "50m",
-        memory: "50Mi",
+      memory: {
+        max: 50, // <-- taken from deprecated resource limit spec
+        min: 1, // <-- taken from non-deprecated resource limit spec
       },
     })
   })

--- a/core/test/unit/src/plugins/kubernetes/container/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/util.ts
@@ -50,9 +50,11 @@ describe("getResourceRequirements", () => {
 
 describe("resolveResourceLimits", () => {
   it("should prioritize deprecated limits param", () => {
-    expect(
-      resolveResourceLimits({ cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } }, { cpu: 50, memory: 50 })
-    ).to.eql({
+    const { resolvedResources } = resolveResourceLimits(
+      { cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } },
+      { cpu: 50, memory: 50 }
+    )
+    expect(resolvedResources).to.eql({
       requests: {
         cpu: "1m",
         memory: "1Mi",

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -49,6 +49,20 @@ See the reference documentation for details.
 For the `Run` action kind see [`spec.manifestFiles`](../reference/action-types/Run/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/Run/kubernetes-pod.md#spec.manifesttemplates).
 For the `Test` action kind see [`spec.manifestFiles`](../reference/action-types/Test/kubernetes-pod.md#spec.manifestfiles) and [`spec.manifestTemplates`](../reference/action-types/Test/kubernetes-pod.md#spec.manifesttemplates).
 
+<h2 id="containerdeployactionlimits"><code>spec.limits</code> configuration field in <code>container</code> Deploy action</h2>
+
+Please use the `cpu` and `memory` configuration fields instead.
+
+Note! If the deprecated field [`spec.limits`](../reference/action-types/deploy/container#spec.limits)
+explicitly defines any cpu or memory limits in the `container` Deploy action,
+Garden 0.14 automatically copies the field's contents to the `spec.cpu` and `spec.memory`,
+even if the latter are defined explicitly.
+
+Please do not use both `spec.limits` and `spec.cpu` and/or `spec.memory` simultaneously,
+and use only the latter pair of fields. Otherwise, the values from the old field `spec.limits` will be used.
+
+See [`spec.cpu`](../reference/action-types/deploy/container#spec.cpu) and [`spec.memory`](../reference/action-types/deploy/container#spec.memory)
+
 <h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 
 Please use the `resources.limits` configuration field instead.

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -53,7 +53,7 @@ For the `Test` action kind see [`spec.manifestFiles`](../reference/action-types/
 
 Please use the `cpu` and `memory` configuration fields instead.
 
-Note! If the deprecated field [`spec.limits`](../reference/action-types/deploy/container#spec.limits)
+Note! If the deprecated field [`spec.limits`](../reference/action-types/Deploy/container.md#spec.limits)
 is defined in the `container` Deploy action config,
 Garden 0.14 automatically copies the field's contents to the `spec.cpu` and `spec.memory`,
 even if the latter are defined explicitly.
@@ -61,21 +61,21 @@ even if the latter are defined explicitly.
 Please do not use both `spec.limits` and `spec.cpu` and/or `spec.memory` simultaneously,
 and use only the latter pair of fields. Otherwise, the values from the old field `spec.limits` will be used.
 
-See [`spec.cpu`](../reference/action-types/deploy/container#spec.cpu)
-and [`spec.memory`](../reference/action-types/deploy/container#spec.memory) for the new syntax details.
+See [`spec.cpu`](../reference/action-types/Deploy/container.md#spec.cpu)
+and [`spec.memory`](../reference/action-types/Deploy/container.md#spec.memory) for the new syntax details.
 
 <h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 
 Please use the `resources.limits` configuration field instead.
 
-Note! If the deprecated field [`limits`](../reference/workflow-config#limits) is defined in the workflow config,
+Note! If the deprecated field [`limits`](../reference/workflow-config.md#limits) is defined in the workflow config,
 Garden 0.14 automatically copies the field's contents to the `resources.limits`,
 even if the latter is defined explicitly.
 
 Please do not use both `limits` and `resources.limits` simultaneously,
 and use only `resources.limits`. Otherwise, the values from the old field `limits` will be used.
 
-See [`resources.limits`](../reference/workflow-config#resources.limits) for the new syntax details.
+See [`resources.limits`](../reference/workflow-config.md#resources.limits) for the new syntax details.
 
 # Unsupported commands
 

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -54,25 +54,28 @@ For the `Test` action kind see [`spec.manifestFiles`](../reference/action-types/
 Please use the `cpu` and `memory` configuration fields instead.
 
 Note! If the deprecated field [`spec.limits`](../reference/action-types/deploy/container#spec.limits)
-explicitly defines any cpu or memory limits in the `container` Deploy action,
+is defined in the `container` Deploy action config,
 Garden 0.14 automatically copies the field's contents to the `spec.cpu` and `spec.memory`,
 even if the latter are defined explicitly.
 
 Please do not use both `spec.limits` and `spec.cpu` and/or `spec.memory` simultaneously,
 and use only the latter pair of fields. Otherwise, the values from the old field `spec.limits` will be used.
 
-See [`spec.cpu`](../reference/action-types/deploy/container#spec.cpu) and [`spec.memory`](../reference/action-types/deploy/container#spec.memory)
+See [`spec.cpu`](../reference/action-types/deploy/container#spec.cpu)
+and [`spec.memory`](../reference/action-types/deploy/container#spec.memory) for the new syntax details.
 
 <h2 id="workflowlimits"><code>limits</code> configuration field in workflows</h2>
 
 Please use the `resources.limits` configuration field instead.
 
-Note! If the deprecated field `limits` is defined in the workflow config,
+Note! If the deprecated field [`limits`](../reference/workflow-config#limits) is defined in the workflow config,
 Garden 0.14 automatically copies the field's contents to the `resources.limits`,
-even if the `resources.limits` is defined explicitly.
+even if the latter is defined explicitly.
 
 Please do not use both `limits` and `resources.limits` simultaneously,
 and use only `resources.limits`. Otherwise, the values from the old field `limits` will be used.
+
+See [`resources.limits`](../reference/workflow-config#resources.limits) for the new syntax details.
 
 # Unsupported commands
 

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -896,7 +896,7 @@ The maximum duration (in seconds) to wait for resources to deploy and become hea
 [spec](#spec) > limits
 
 {% hint style="warning" %}
-**Deprecated**: Please use the `cpu` and `memory` fields instead.
+**Deprecated**: Please use the `cpu` and `memory` configuration fields instead.
 {% endhint %}
 
 Specify resource limits for the service.

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1735,7 +1735,7 @@ The maximum duration (in seconds) to wait for resources to deploy and become hea
 [services](#services) > limits
 
 {% hint style="warning" %}
-**Deprecated**: Please use the `cpu` and `memory` fields instead.
+**Deprecated**: Please use the `cpu` and `memory` configuration fields instead.
 {% endhint %}
 
 Specify resource limits for the service.

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -1950,7 +1950,7 @@ The maximum duration (in seconds) to wait for resources to deploy and become hea
 [services](#services) > limits
 
 {% hint style="warning" %}
-**Deprecated**: Please use the `cpu` and `memory` fields instead.
+**Deprecated**: Please use the `cpu` and `memory` configuration fields instead.
 {% endhint %}
 
 Specify resource limits for the service.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR also brings a minor UX improvement similar to #7068.

Now Garden prints a warning if both deprecated and new syntax is used. No behaviour breaking changes here. The old syntax is preferred and a user is informed.

This PR also simplifies the responsibility of function `getResourceRequirements`, that is no longer responsible for combining old and new config entries.

This also unlocks #7143.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
