### PR TITLE
fix(terraform): use backendConfig with plugin commands (#7249)

### DIFF
--- a/plugins/terraform/src/commands.ts
+++ b/plugins/terraform/src/commands.ts
@@ -49,11 +49,13 @@ function makeRootCommand(commandName: string): PluginCommand {
       })
       await remove(cachePath)
 
+      // Use provider config
       const root = join(ctx.projectRoot, provider.config.initRoot)
       const workspace = provider.config.workspace || null
+      const backendConfig = provider.config.backendConfig
 
       await ensureWorkspace({ ctx, provider, root, log, workspace })
-      await ensureTerraformInit({ ctx, provider, root, log })
+      await ensureTerraformInit({ ctx, provider, root, log, backendConfig })
 
       args = [commandName, ...(await prepareVariables(root, provider.config.variables)), ...args]
 
@@ -93,10 +95,12 @@ function makeActionCommand(commandName: string): PluginCommand {
       const root = join(action.sourcePath(), spec.root)
 
       const provider = ctx.provider as TerraformProvider
+      // Use action spec
       const workspace = spec.workspace || null
+      const backendConfig = spec.backendConfig
 
       await ensureWorkspace({ ctx, provider, root, log, workspace })
-      await ensureTerraformInit({ ctx, provider, root, log })
+      await ensureTerraformInit({ ctx, provider, root, log, backendConfig })
 
       args = [commandName, ...(await prepareVariables(root, spec.variables)), ...args.slice(1)]
       await terraform(ctx, provider).spawnAndWait({

--- a/plugins/terraform/src/handlers.ts
+++ b/plugins/terraform/src/handlers.ts
@@ -31,9 +31,10 @@ export const getTerraformStatus: DeployActionHandler<"getStatus", TerraformDeplo
 
   const variables = spec.variables
   const workspace = spec.workspace || null
+  const backendConfig = spec.backendConfig
 
   await ensureWorkspace({ log, ctx, provider, root, workspace })
-  await ensureTerraformInit({ log, ctx, provider, root, backendConfig: spec.backendConfig })
+  await ensureTerraformInit({ log, ctx, provider, root, backendConfig })
 
   const status = await getStackStatus({
     ctx,

--- a/plugins/terraform/src/helpers.ts
+++ b/plugins/terraform/src/helpers.ts
@@ -94,7 +94,7 @@ const terraformValidateOutputSchema = s
 
 /**
  * Reads the current backend config from the `.terraform/terraform.tfstate` file and
- * compares it to the backend config supplied by the user via the Garden config (passed)
+ * compares it to the backend config supplied by the user via the Garden config passed
  * as an argument to this function.
  *
  * Returns true if the user defined backend config is different from the one in the `tfstate` file.
@@ -125,7 +125,7 @@ export async function hasBackendConfigChanged({
     throw err
   }
 
-  const currentBackendConfig = tfState?.backend?.["config"] as { [key: string]: string } | undefined
+  const currentBackendConfig = tfState?.backend?.["config"] as { [key: string]: string | null | undefined } | undefined
 
   const hasChanged =
     (currentBackendConfig &&
@@ -209,7 +209,7 @@ export async function ensureTerraformInit(params: TerraformParams & { backendCon
     // It failed when running "terraform init": in this case we only add the error from the
     // first validation try
     if (initError) {
-      const resultErrors = res.diagnostics.map((d: any) => `${startCase(d.severity)}: ${d.summary}\n${d.detail || ""}`)
+      const resultErrors = res.diagnostics.map((d) => `${startCase(d.severity)}: ${d.summary}\n${d.detail || ""}`)
       errorMsg += dedent`\n\n${resultErrors.join("\n")}
 
         Garden tried running "terraform init" but got the following error:\n

--- a/plugins/terraform/test/terraform.ts
+++ b/plugins/terraform/test/terraform.ts
@@ -40,7 +40,7 @@ const moduleDirName = dirname(fileURLToPath(import.meta.url))
  *
  * Used for testing the `backendConfig` logic.
  */
-export class TerraformMockBackendServer {
+export class MockTerraformBackendServer {
   private server: http.Server
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private interceptedRequests: any[] = []
@@ -399,23 +399,30 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
     })
 
-    context("backendConfig defined", () => {
+    context("backendConfig defined for provider", () => {
       const testRootBackendConfig = resolve(moduleDirName, "../../test/", "test-project-backendconfig")
       tfRoot = join(testRootBackendConfig, "tf")
-      stateDirPath = join(tfRoot, ".terraform")
+      const tfDirPath = join(tfRoot, ".terraform")
+      // Keep track of servers so we can stop them at end of test suite
+      const tfServers: MockTerraformBackendServer[] = []
 
-      let server: TerraformMockBackendServer
-      let port: number
-
-      before(async () => {
-        port = await getPort()
-        server = new TerraformMockBackendServer(port)
+      const startMockTerraformBackendServer = async () => {
+        const port = await getPort()
+        const server = new MockTerraformBackendServer(port)
         await server.start()
-      })
+        tfServers.push(server)
+
+        return { server, port }
+      }
+
+      const resetBackendConfigProject = async () => {
+        if (tfDirPath && (await pathExists(tfDirPath))) {
+          await remove(tfDirPath)
+        }
+      }
 
       beforeEach(async () => {
-        await reset()
-        server.clearInterceptedRequests()
+        await resetBackendConfigProject()
       })
 
       afterEach(async () => {
@@ -423,10 +430,14 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
 
       after(async () => {
-        await server.stop()
+        for (const server of tfServers) {
+          await server.stop()
+        }
+        await resetBackendConfigProject()
       })
 
       it("should dynamically set backend config", async () => {
+        const { server, port } = await startMockTerraformBackendServer()
         const testGarden = await makeTestGarden(testRootBackendConfig, {
           plugins: [gardenPlugin()],
           environmentString: "local",
@@ -449,6 +460,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
 
       it("should NOT re-initialize Terraform if no state file present", async () => {
+        const { port } = await startMockTerraformBackendServer()
         const testGarden = await makeTestGarden(testRootBackendConfig, {
           plugins: [gardenPlugin()],
           environmentString: "local",
@@ -458,9 +470,11 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
             "address": `http://localhost:${port}/terraform/state?some-dynamic-key`,
           },
         })
+
         await testGarden.resolveProvider({ log: testGarden.log, name: "terraform" })
 
         const messages = getRootLogMessages(testGarden.log, (e) => e.level === LogLevel.info)
+
         // A fresh test project won't have a statefile
         expect(messages).to.not.include(
           "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
@@ -468,6 +482,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
 
       it("should re-initialize Terraform with -reconfigure flag if backendConfig changes", async () => {
+        const { server, port } = await startMockTerraformBackendServer()
         const testGardenA = await makeTestGarden(testRootBackendConfig, {
           plugins: [gardenPlugin()],
           environmentString: "local",
@@ -506,6 +521,38 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
         expect(messages).to.include(
           "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
         )
+      })
+
+      it("uses backendConfig for commamnds", async () => {
+        const { server, port } = await startMockTerraformBackendServer()
+        const testGarden = await makeTestGarden(testRootBackendConfig, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          forceRefresh: true,
+          variableOverrides: {
+            "tf-version": terraformVersion,
+            "address": `http://localhost:${port}/terraform/state?some-dynamic-key-using-plugin-command`,
+          },
+        })
+        const provider = (await testGarden.resolveProvider({
+          log: testGarden.log,
+          statusOnly: true,
+          name: "terraform",
+        })) as TerraformProvider
+        const ctx = await testGarden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+        const graph = await testGarden.getConfigGraph({ log: testGarden.log, emit: false })
+        const command = findByName(getTerraformCommands(), "plan-root")!
+        await command.handler({
+          ctx,
+          garden: testGarden,
+          args: ["-input=false"],
+          log: testGarden.log,
+          graph,
+        })
+
+        const requests = server.getInterceptedRequests()
+        const requestUrl = requests[0].url
+        expect(requestUrl).to.eql("/terraform/state?some-dynamic-key-using-plugin-command")
       })
     })
   })
@@ -966,25 +1013,30 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
     })
 
-    context("backendConfig defined", () => {
+    context("backendConfig defined for action", () => {
       const testRootBackendConfigAction = resolve(moduleDirName, "../../test/", "test-project-backendconfig-action")
       tfRoot = join(testRootBackendConfigAction, "tf")
-      stateDirPath = join(tfRoot, ".terraform")
+      const tfDirPath = join(tfRoot, ".terraform")
+      // Keep track of servers so we can stop them at end of test suite
+      const tfServers: MockTerraformBackendServer[] = []
 
-      let server: TerraformMockBackendServer
-      let port: number
-
-      before(async () => {
-        port = await getPort()
-        server = new TerraformMockBackendServer(port)
+      const startMockTerraformBackendServer = async () => {
+        const port = await getPort()
+        const server = new MockTerraformBackendServer(port)
         await server.start()
-      })
+        tfServers.push(server)
+
+        return { server, port }
+      }
+
+      const resetBackendConfigActionProject = async () => {
+        if (tfDirPath && (await pathExists(tfDirPath))) {
+          await remove(tfDirPath)
+        }
+      }
 
       beforeEach(async () => {
-        tfRoot = join(testRootBackendConfigAction, "tf")
-        stateDirPath = join(tfRoot, ".terraform")
-        await reset()
-        server.clearInterceptedRequests()
+        await resetBackendConfigActionProject()
       })
 
       afterEach(async () => {
@@ -992,10 +1044,14 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
 
       after(async () => {
-        await server.stop()
+        for (const server of tfServers) {
+          await server.stop()
+        }
+        await resetBackendConfigActionProject()
       })
 
       it("should dynamically set backend config", async () => {
+        const { server, port } = await startMockTerraformBackendServer()
         const testGarden = await makeTestGarden(testRootBackendConfigAction, {
           plugins: [gardenPlugin()],
           environmentString: "local",
@@ -1032,6 +1088,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
 
       it("should NOT re-initialize Terraform if no state file present", async () => {
+        const { port } = await startMockTerraformBackendServer()
         const testGarden = await makeTestGarden(testRootBackendConfigAction, {
           plugins: [gardenPlugin()],
           environmentString: "local",
@@ -1062,6 +1119,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
         await testGarden.processTasks({ tasks: [deployTask], throwOnError: true })
 
         const messages = getRootLogMessages(testGarden.log, (e) => e.level === LogLevel.info)
+
         // A fresh test project won't have a statefile
         expect(messages).to.not.include(
           "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
@@ -1069,6 +1127,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
       })
 
       it("should re-initialize Terraform with -reconfigure flag if backendConfig changes", async () => {
+        const { server, port } = await startMockTerraformBackendServer()
         const testGarden = await makeTestGarden(testRootBackendConfigAction, {
           plugins: [gardenPlugin()],
           environmentString: "local",
@@ -1134,6 +1193,41 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
         expect(messages).to.include(
           "Detected change in backend config, will re-initialize Terraform with '-reconfigure' flag"
         )
+      })
+
+      it("uses backendConfig for commamnds", async () => {
+        const { server, port } = await startMockTerraformBackendServer()
+        const testGarden = await makeTestGarden(testRootBackendConfigAction, {
+          plugins: [gardenPlugin()],
+          environmentString: "local",
+          variableOverrides: {
+            "tf-version": terraformVersion,
+          },
+        })
+        const provider = (await testGarden.resolveProvider({
+          log: testGarden.log,
+          statusOnly: true,
+          name: "terraform",
+        })) as TerraformProvider
+        const ctx = await testGarden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+        const graph = await testGarden.getConfigGraph({ log: testGarden.log, emit: false })
+        const action = graph.getDeploy("tf-backendconfig-deploy") as TerraformDeploy
+        action._config.spec.backendConfig = {
+          address: `http://localhost:${port}/terraform/state?some-dynamic-key-for-action-using-plugin-command`,
+        }
+
+        const command = findByName(getTerraformCommands(), "plan-action")!
+        await command.handler({
+          ctx,
+          garden: testGarden,
+          args: ["tf-backendconfig-deploy", "-input=false"],
+          log: garden.log,
+          graph,
+        })
+
+        const requests = server.getInterceptedRequests()
+        const requestUrl = requests[0].url
+        expect(requestUrl).to.eql("/terraform/state?some-dynamic-key-for-action-using-plugin-command")
       })
     })
   })


### PR DESCRIPTION
Cherry pick changes from #7249 to 0.13 branch. See original PR description below.

---

* fix(terraform): use backendConfig with plugin commands

Before this fix, we weren't passing the `backendConfig to Terraform when using plugins commands.

That is, for commands like `garden plugins terraform apply-root` the `backendConfig` specified in the Garden config would be ignored.

This commit fixes that and adds tests.

* tests: fix terraform tests

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
