### PR TITLE
chore: deprecate `hostPort` in `container` Deploy action spec

### DIFF
--- a/core/src/plugin/handlers/base/configure.ts
+++ b/core/src/plugin/handlers/base/configure.ts
@@ -16,7 +16,7 @@ import { ActionTypeHandlerSpec } from "./base.js"
 import { pluginContextSchema } from "../../../plugin-context.js"
 import { noTemplateFields } from "../../../config/base.js"
 
-interface ConfigureActionConfigParams<T extends BaseActionConfig> extends PluginActionContextParams {
+export interface ConfigureActionConfigParams<T extends BaseActionConfig> extends PluginActionContextParams {
   log: Log
   config: T
 }

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -719,7 +719,10 @@ export const containerDeploySchemaKeys = memoize(() => ({
   hotReload: joi.any().meta({ internal: true }),
   timeout: k8sDeploymentTimeoutSchema(),
   limits: limitsSchema(),
-  ports: joiSparseArray(portSchema()).unique("name").description("List of ports that the service container exposes."),
+  ports: joiSparseArray(portSchema())
+    .unique("name")
+    .default([])
+    .description("List of ports that the service container exposes."),
   replicas: joi.number().integer().description(deline`
     The number of instances of the service to deploy.
     Defaults to 3 for environments configured with \`production: true\`, otherwise 1.

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -540,7 +540,10 @@ export const portSchema = createSchema({
         The service port maps to the container port:
 
         \`servicePort:80 -> containerPort:8080 -> process:8080\``),
-    hostPort: joi.number().meta({ deprecated: true }),
+    hostPort: joi
+      .number()
+      .description("Number of port to expose on the pod's IP address.")
+      .meta({ deprecated: makeDeprecationMessage({ deprecation: "containerDeployActionHostPort" }) }),
     nodePort: joi.number().allow(true).description(deline`
         Set this to expose the service on the specified port on the host node (may not be supported by all providers).
         Set to \`true\` to have the cluster pick a port automatically, which is most often advisable if the cluster is

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -74,13 +74,11 @@ export interface ServicePortSpec {
   nodePort?: number | true
 }
 
-export interface ContainerVolumeSpecBase {
+export interface ContainerVolumeSpec {
   name: string
   containerPath: string
   hostPath?: string
 }
-
-export interface ContainerVolumeSpec extends ContainerVolumeSpecBase {}
 
 export interface ServiceHealthCheckSpec {
   httpGet?: {

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -562,6 +562,11 @@ export const gardenPlugin = () =>
                 deprecationFound = true
               }
 
+              if (spec.limits) {
+                reportDeprecatedFeatureUsage({ log, deprecation: "containerDeployActionLimits" })
+                deprecationFound = true
+              }
+
               for (const port of spec.ports) {
                 if (port.hostPort !== undefined) {
                   reportDeprecatedFeatureUsage({ log, deprecation: "containerDeployActionHostPort" })

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -567,10 +567,14 @@ export const gardenPlugin = () =>
                 deprecationFound = true
               }
 
-              for (const port of spec.ports) {
-                if (port.hostPort !== undefined) {
-                  reportDeprecatedFeatureUsage({ log, deprecation: "containerDeployActionHostPort" })
-                  deprecationFound = true
+              // ports can be undefined here, because the validation handler,
+              // that sets the default values, is called later
+              if (spec.ports) {
+                for (const port of spec.ports) {
+                  if (port.hostPort !== undefined) {
+                    reportDeprecatedFeatureUsage({ log, deprecation: "containerDeployActionHostPort" })
+                    deprecationFound = true
+                  }
                 }
               }
 

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -15,7 +15,7 @@ import type {
   ContainerActionConfig,
   ContainerBuildActionConfig,
   ContainerModule,
-  ContainerModuleVolumeSpec,
+  ContainerVolumeSpec,
   ContainerRuntimeActionConfig,
 } from "./moduleConfig.js"
 import { containerModuleOutputsSchema, containerModuleSpecSchema, defaultDockerfileName } from "./moduleConfig.js"
@@ -375,7 +375,7 @@ function convertContainerModuleRuntimeActions(
     deploymentImageId = `\${actions.build.${buildAction.name}.outputs.deploymentImageId}`
   }
 
-  function configureActionVolumes(action: ContainerRuntimeActionConfig, volumeSpec: ContainerModuleVolumeSpec[]) {
+  function configureActionVolumes(action: ContainerRuntimeActionConfig, volumeSpec: ContainerVolumeSpec[]) {
     volumeSpec.forEach((v) => {
       action.spec.volumes.push(v)
     })

--- a/core/src/plugins/container/moduleConfig.ts
+++ b/core/src/plugins/container/moduleConfig.ts
@@ -22,7 +22,7 @@ import type {
   ContainerCommonDeploySpec,
   ContainerRunActionSpec,
   ContainerTestActionSpec,
-  ContainerVolumeSpecBase,
+  ContainerVolumeSpec,
 } from "./config.js"
 import {
   containerBuildOutputSchemaKeys,
@@ -44,16 +44,14 @@ import { kebabCase, mapKeys } from "lodash-es"
 // To reduce the amount of edits to make before removing module configs
 export * from "./config.js"
 
-export interface ContainerModuleVolumeSpec extends ContainerVolumeSpecBase {}
-
 export type ContainerServiceSpec = CommonServiceSpec &
   ContainerCommonDeploySpec & {
-    volumes: ContainerModuleVolumeSpec[]
+    volumes: ContainerVolumeSpec[]
   }
 
 export type ContainerTestSpec = BaseTestSpec &
   ContainerTestActionSpec & {
-    volumes: ContainerModuleVolumeSpec[]
+    volumes: ContainerVolumeSpec[]
   }
 export const containerModuleTestSchema = () =>
   baseTestSpecSchema().keys({
@@ -64,7 +62,7 @@ export const containerModuleTestSchema = () =>
 
 export type ContainerTaskSpec = BaseTaskSpec &
   ContainerRunActionSpec & {
-    volumes: ContainerModuleVolumeSpec[]
+    volumes: ContainerVolumeSpec[]
   }
 export const containerTaskSchema = () =>
   baseTaskSpecSchema()

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -310,7 +310,7 @@ export async function createWorkloadManifest({
     const deploymentStrategy = spec.deploymentStrategy
     if (deploymentStrategy === "RollingUpdate") {
       // Need the <any> cast because the library types are busted
-      deployment.spec!.strategy = <any>{
+      deployment.spec!.strategy = {
         type: deploymentStrategy,
         rollingUpdate: {
           // This is optimized for fast re-deployment.

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -9,6 +9,7 @@
 import type {
   V1Affinity,
   V1Container,
+  V1ContainerPort,
   V1DaemonSet,
   V1Deployment,
   V1PodSpec,
@@ -293,15 +294,21 @@ export async function createWorkloadManifest({
       type: "RollingUpdate",
     }
 
-    for (const port of ports.filter((p) => p.hostPort)) {
+    for (const port of ports) {
+      if (!port.hostPort) {
+        continue
+      }
+
       // For daemons we can expose host ports directly on the Pod, as opposed to only via the Service resource.
       // This allows us to choose any port.
       // TODO: validate that conflicting ports are not defined.
-      container.ports!.push({
+      const containerPort: V1ContainerPort = {
         protocol: port.protocol,
         containerPort: port.containerPort,
         hostPort: port.hostPort,
-      })
+      }
+
+      container.ports!.push(containerPort)
     }
   } else {
     const deployment = <V1Deployment>workload

--- a/core/src/plugins/kubernetes/container/service.ts
+++ b/core/src/plugins/kubernetes/container/service.ts
@@ -19,7 +19,7 @@ function toServicePort(portSpec: ServicePortSpec): V1ServicePort {
     name: portSpec.name,
     protocol: portSpec.protocol,
     port: portSpec.servicePort,
-    targetPort: <any>portSpec.containerPort,
+    targetPort: portSpec.containerPort,
   }
 
   if (portSpec.nodePort && portSpec.nodePort !== true) {

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -111,7 +111,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       docsSection: "Deprecated configuration",
       docsHeadline: `${style("spec.ports[].hostPort")} configuration field in ${style("container")} Deploy action`,
       warnHint: deline`
-        The ${style("hostPort")} field of the ${style("V1ContainerPort")} is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
+        It's generally not recommended to use the ${style("hostPort")} field of the ${style("V1ContainerPort")} spec. You can learn more about Kubernetes best practices at: https://kubernetes.io/docs/concepts/configuration/overview/
       `,
       docs: null,
     },

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -107,6 +107,13 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       `,
       docs: null,
     },
+    containerDeployActionHostPort: {
+      docsSection: "Deprecated configuration",
+      docsHeadline: `${style("spec.ports[].hostPort")} configuration field in ${style("container")} Deploy action`,
+      warnHint: deline`
+        The ${style("hostPort")} field of the ${style("V1ContainerPort")} is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
+      `,
+    },
     containerDeployActionLimits: {
       docsSection: "Old configuration syntax",
       docsHeadline: `${style("spec.limits")} configuration field in ${style("container")} Deploy action`,

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -113,6 +113,7 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       warnHint: deline`
         The ${style("hostPort")} field of the ${style("V1ContainerPort")} is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
       `,
+      docs: null,
     },
     containerDeployActionLimits: {
       docsSection: "Old configuration syntax",

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -82,3 +82,9 @@ See [`resources.limits`](../reference/workflow-config.md#resources.limits) for t
 <h2 id="kubernetesplugincleanupclusterregistrycommand"><code>cleanup-cluster-registry</code></h2>
 
 The `cleanup-cluster-registry` command in the `kubernetes` and `local-kubernetes` plugins is not supported in Garden 0.14. This command no longer has any effect as of version 0.13! Please remove this from any pipelines running it.
+
+# Deprecated configuration
+
+<h2 id="containerdeployactionhostport"><code>spec.ports[].hostPort</code> configuration field in <code>container</code> Deploy action</h2>
+
+The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -87,4 +87,4 @@ The `cleanup-cluster-registry` command in the `kubernetes` and `local-kubernetes
 
 <h2 id="containerdeployactionhostport"><code>spec.ports[].hostPort</code> configuration field in <code>container</code> Deploy action</h2>
 
-The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
+It's generally not recommended to use the `hostPort` field of the `V1ContainerPort` spec. You can learn more about Kubernetes best practices at: https://kubernetes.io/docs/concepts/configuration/overview/

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -1033,7 +1033,7 @@ spec:
 [spec](#spec) > [ports](#specports) > hostPort
 
 {% hint style="warning" %}
-**Deprecated**: The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
+**Deprecated**: It's generally not recommended to use the `hostPort` field of the `V1ContainerPort` spec. You can learn more about Kubernetes best practices at: https://kubernetes.io/docs/concepts/configuration/overview/
 {% endhint %}
 
 Number of port to expose on the pod's IP address.

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -1033,8 +1033,10 @@ spec:
 [spec](#spec) > [ports](#specports) > hostPort
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
 {% endhint %}
+
+Number of port to expose on the pod's IP address.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -466,6 +466,7 @@ services:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         servicePort:
 
+        # Number of port to expose on the pod's IP address.
         hostPort:
 
         # Set this to expose the service on the specified port on the host node (may not be supported by all
@@ -1869,8 +1870,10 @@ services:
 [services](#services) > [ports](#servicesports) > hostPort
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
 {% endhint %}
+
+Number of port to expose on the pod's IP address.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1870,7 +1870,7 @@ services:
 [services](#services) > [ports](#servicesports) > hostPort
 
 {% hint style="warning" %}
-**Deprecated**: The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
+**Deprecated**: It's generally not recommended to use the `hostPort` field of the `V1ContainerPort` spec. You can learn more about Kubernetes best practices at: https://kubernetes.io/docs/concepts/configuration/overview/
 {% endhint %}
 
 Number of port to expose on the pod's IP address.

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -534,6 +534,7 @@ services:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         servicePort:
 
+        # Number of port to expose on the pod's IP address.
         hostPort:
 
         # Set this to expose the service on the specified port on the host node (may not be supported by all
@@ -2084,8 +2085,10 @@ services:
 [services](#services) > [ports](#servicesports) > hostPort
 
 {% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
+**Deprecated**: The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
 {% endhint %}
+
+Number of port to expose on the pod's IP address.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -2085,7 +2085,7 @@ services:
 [services](#services) > [ports](#servicesports) > hostPort
 
 {% hint style="warning" %}
-**Deprecated**: The `hostPort` field of the `V1ContainerPort` is generally advised against using it, see the K8s best practices at https://kubernetes.io/docs/concepts/configuration/overview/
+**Deprecated**: It's generally not recommended to use the `hostPort` field of the `V1ContainerPort` spec. You can learn more about Kubernetes best practices at: https://kubernetes.io/docs/concepts/configuration/overview/
 {% endhint %}
 
 Number of port to expose on the pod's IP address.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR restores the missing docs that were mentioned in #1825 and uses the new deprecation utilities to deprecate the config field properly and emit warnings on its usage.

This PR also allows to bring #7143 to the finish line.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
