### PR TITLE
chore(deps): bump `@kubernetes/client-node` from 1.0.0 to 1.3.0

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -29,7 +29,7 @@
     "@date-fns/utc": "^2.1.0",
     "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
     "@jsdevtools/readdir-enhanced": "^6.0.4",
-    "@kubernetes/client-node": "1.0.0",
+    "@kubernetes/client-node": "1.3.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.200.0",

--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -139,8 +139,8 @@ export async function ensureNamespace(
             },
           })
           result.patched = true
-        } catch {
-          log.warn(`Unable to apply the configured annotations and labels on namespace ${namespace.name}`)
+        } catch (err) {
+          log.warn(`Unable to apply the configured annotations and labels on namespace ${namespace.name}: ${err}`)
         }
       }
 

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -435,17 +435,13 @@ export async function upsertConfigMap({
   }
 
   try {
-    await api.core.createNamespacedConfigMap({ namespace, body: <any>body })
+    await api.core.createNamespacedConfigMap({ namespace, body })
   } catch (err) {
     if (!(err instanceof KubernetesError)) {
       throw err
     }
     if (err.responseStatusCode === 409) {
-      await api.core.patchNamespacedConfigMap({
-        name: key,
-        namespace,
-        body,
-      })
+      await api.core.patchNamespacedConfigMap({ name: key, namespace, body })
     } else {
       throw err
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,7 +1102,7 @@
         "@date-fns/utc": "^2.1.0",
         "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
         "@jsdevtools/readdir-enhanced": "^6.0.4",
-        "@kubernetes/client-node": "1.0.0",
+        "@kubernetes/client-node": "1.3.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.200.0",
@@ -2394,27 +2394,27 @@
       "license": "BSD-2-Clause"
     },
     "core/node_modules/@kubernetes/client-node": {
-      "version": "1.0.0",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.3.0.tgz",
+      "integrity": "sha512-IE0yrIpOT97YS5fg2QpzmPzm8Wmcdf4ueWMn+FiJSI3jgTTQT1u+LUhoYpdfhdHAVxdrNsaBg2C0UXSnOgMoCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^22.0.0",
         "@types/node-fetch": "^2.6.9",
         "@types/stream-buffers": "^3.0.3",
-        "@types/tar": "^6.1.1",
-        "@types/ws": "^8.5.4",
         "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.2.0",
+        "jsonpath-plus": "^10.3.0",
         "node-fetch": "^2.6.9",
         "openid-client": "^6.1.3",
         "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
         "stream-buffers": "^3.0.2",
-        "tar": "^7.0.0",
-        "tmp-promise": "^3.0.2",
-        "tslib": "^2.5.0",
-        "ws": "^8.18.0"
+        "tar-fs": "^3.0.8",
+        "ws": "^8.18.2"
       }
     },
     "core/node_modules/@kubernetes/client-node/node_modules/@types/stream-buffers": {
@@ -2472,6 +2472,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "core/node_modules/@kubernetes/client-node/node_modules/jsonpath-plus": {
@@ -2546,6 +2555,101 @@
       "version": "1.5.3",
       "license": "MIT"
     },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/debug/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/socks/node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/socks/node_modules/ip-address/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/socks/node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/socks-proxy-agent/node_modules/socks/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "core/node_modules/@kubernetes/client-node/node_modules/stream-buffers": {
       "version": "3.0.2",
       "license": "Unlicense",
@@ -2553,406 +2657,236 @@
         "node": ">= 0.10.0"
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar": {
-      "version": "7.4.3",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/chownr": {
-      "version": "3.0.0",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minipass": {
-      "version": "7.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib": {
-      "version": "3.0.1",
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf": {
-      "version": "5.0.10",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob": {
-      "version": "10.4.5",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/foreground-child": {
-      "version": "3.3.0",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
       },
       "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "license": "ISC",
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
+      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
+      "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
       },
       "engines": {
-        "node": ">=12"
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "license": "MIT",
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs/node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs/node_modules/bare-stream": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "streamx": "^2.21.0"
       },
-      "engines": {
-        "node": ">=12"
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "license": "MIT"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width-cjs/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "license": "MIT"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/string-width/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "license": "MIT"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/ansi-styles/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/ansi-styles/node_modules/color-convert/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "license": "MIT"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/string-width/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi-cjs/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/jackspeak/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs/node_modules/bare-stream/node_modules/streamx": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "license": "MIT",
       "optional": true,
-      "engines": {
-        "node": ">=14"
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs/node_modules/bare-stream/node_modules/streamx/node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs/node_modules/bare-stream/node_modules/streamx/node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-fs/node_modules/bare-stream/node_modules/streamx/node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/bare-path/node_modules/bare-os": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/pump/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/pump/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "wrappy": "1"
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/pump/node_modules/once/node_modules/wrappy": {
       "version": "1.0.2",
-      "license": "MIT"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "license": "BlueOak-1.0.0"
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/minizlib/node_modules/rimraf/node_modules/glob/node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/mkdirp": {
-      "version": "3.0.1",
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0"
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/tar-stream/node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/tar-stream/node_modules/streamx": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
-    "core/node_modules/@kubernetes/client-node/node_modules/tslib": {
-      "version": "2.6.2",
-      "license": "0BSD"
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/tar-stream/node_modules/streamx/node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/tar-fs/node_modules/tar-stream/node_modules/streamx/node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "core/node_modules/@kubernetes/client-node/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "core/node_modules/@opentelemetry/core": {
       "version": "2.0.0",
@@ -13941,6 +13875,7 @@
     },
     "node_modules/@types/tar": {
       "version": "6.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -13949,6 +13884,7 @@
     },
     "node_modules/@types/tar/node_modules/minipass": {
       "version": "4.2.8",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"


### PR DESCRIPTION
**What this PR does / why we need it**:

Back-ports #7255 to 0.13.

**Which issue(s) this PR fixes**:

Supersedes #7287

**Special notes for your reviewer**:
