### PR TITLE
chore: deprecate `podSelector` in sync mode

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -729,12 +729,21 @@ export interface KubernetesTargetResourceSpec {
   containerName?: string
 }
 
+/**
+ * Temporary type to keep podSelector deprecated in sync mode in 0.14.
+ * TODO(0.15): remove this and use {@link KubernetesTargetResourceSyncModeStrictSpec} as a replacement.
+ */
 export type KubernetesTargetResourceSyncModeSpec = Omit<KubernetesTargetResourceSpec, "podSelector"> & {
   /**
    * @deprecated `podSelector` is deprecated in sync mode
    */
   podSelector?: { [key: string]: string }
 }
+
+/**
+ * TODO(0.15): rename this and use it instead of {@link KubernetesTargetResourceSyncModeSpec}.
+ */
+export type KubernetesTargetResourceSyncModeStrictSpec = Omit<KubernetesTargetResourceSyncModeSpec, "podSelector">
 
 export interface ServiceResourceSpec extends KubernetesTargetResourceSpec {
   containerModule?: string

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -729,6 +729,13 @@ export interface KubernetesTargetResourceSpec {
   containerName?: string
 }
 
+export type KubernetesTargetResourceSyncModeSpec = Omit<KubernetesTargetResourceSpec, "podSelector"> & {
+  /**
+   * @deprecated `podSelector` is deprecated in sync mode
+   */
+  podSelector?: { [key: string]: string }
+}
+
 export interface ServiceResourceSpec extends KubernetesTargetResourceSpec {
   containerModule?: string
 }

--- a/core/src/plugins/kubernetes/container/sync.ts
+++ b/core/src/plugins/kubernetes/container/sync.ts
@@ -8,7 +8,7 @@
 
 import type { ContainerDeployAction } from "../../container/moduleConfig.js"
 import { getAppNamespace } from "../namespace.js"
-import type { KubernetesPluginContext, KubernetesTargetResourceSpec } from "../config.js"
+import type { KubernetesPluginContext, KubernetesTargetResourceSyncModeSpec } from "../config.js"
 import type { KubernetesDeployDevModeSyncSpec } from "../sync.js"
 import { getSyncStatus, startSyncs, stopSyncs } from "../sync.js"
 import type { DeployActionHandler } from "../../../plugin/action-types.js"
@@ -87,7 +87,7 @@ export const k8sContainerGetSyncStatus: DeployActionHandler<"getSyncStatus", Con
 
 function getSyncs(action: Executed<ContainerDeployAction>): {
   syncs: KubernetesDeployDevModeSyncSpec[]
-  target?: KubernetesTargetResourceSpec | undefined
+  target?: KubernetesTargetResourceSyncModeSpec | undefined
   deployedResources: KubernetesResource[]
 } {
   const status = action.getStatus()

--- a/core/src/plugins/kubernetes/kubernetes-type/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/config.ts
@@ -83,7 +83,7 @@ const kubernetesPatchResourceSchema = () =>
         dedent`
         The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
 
-        You can read more about the different strategies in the offical Kubernetes documentation at:
+        You can read more about the different strategies in the official Kubernetes documentation at:
         https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
         `
       )

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -30,13 +30,7 @@ import {
 import { dedent, deline, gardenAnnotationKey } from "../../util/string.js"
 import cloneDeep from "fast-copy"
 import { kebabCase, keyBy, omit, set } from "lodash-es"
-import {
-  getResourceContainer,
-  getResourceKey,
-  getResourcePodSpec,
-  getTargetResource,
-  labelSelectorToString,
-} from "./util.js"
+import { getResourceContainer, getResourceKey, getResourcePodSpec, getTargetResource } from "./util.js"
 import type {
   KubernetesResource,
   OctalPermissionMask,
@@ -338,14 +332,7 @@ export async function configureSyncMode({
 
   const dedupedTargets: { [ref: string]: KubernetesTargetResourceSpec } = {}
 
-  const targetKey = (t: KubernetesTargetResourceSpec) => {
-    // todo: remove podSelector
-    if (t.podSelector) {
-      return labelSelectorToString(t.podSelector)
-    } else {
-      return `${t.kind}/${t.name}`
-    }
-  }
+  const targetKey = (t: KubernetesTargetResourceSyncModeStrictSpec) => `${t.kind}/${t.name}`
 
   for (const override of spec.overrides || []) {
     const overrideTarget = override.target

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -69,6 +69,7 @@ import { commandListToShellScript } from "../../util/escape.js"
 import { toClearText } from "../../util/secrets.js"
 import type { V1Container } from "@kubernetes/client-node"
 import { emitNonRepeatableWarning } from "../../warnings.js"
+import { reportDeprecatedFeatureUsage } from "../../util/deprecations.js"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 
@@ -337,7 +338,7 @@ export async function configureSyncMode({
   for (const override of spec.overrides || []) {
     const overrideTarget = override.target
     if (overrideTarget?.podSelector) {
-      // todo: warn with deprecation
+      reportDeprecatedFeatureUsage({ log, deprecation: "podSelectorInSyncMode" })
     }
 
     // ignore override.target.podSelector in sync mode
@@ -388,7 +389,7 @@ export async function configureSyncMode({
   for (const sync of spec.paths || []) {
     const syncTarget = sync.target
     if (syncTarget?.podSelector) {
-      // todo: warn with deprecation
+      reportDeprecatedFeatureUsage({ log, deprecation: "podSelectorInSyncMode" })
     }
 
     // ignore sync.target.podSelector in sync mode

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -354,7 +354,7 @@ export async function configureSyncMode({
       throw new ConfigurationError({
         message: dedent`
           Sync override configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.
-          Either specify a target via the \`spec.sync.overrides[].target\` or \`spec.defaultTarget\`.
+          Either specify a target via the ${styles.highlight("spec.sync.overrides[].target")} or ${styles.highlight("spec.defaultTarget")}.
 
           Override configuration:
           ${(override.command?.length ?? 0) > 0 ? `Command: ${override.command?.join(" ")}` : ""}
@@ -368,7 +368,20 @@ export async function configureSyncMode({
       const key = targetKey(target)
       dedupedTargets[key] = target
     } else {
-      // todo: warn that override config entry has no effect
+      // print a warning instead of throwing an error for compatibility
+      emitNonRepeatableWarning(
+        log,
+        dedent`
+          Sync override configuration on ${action.longDescription()} doesn't specify a target properly.
+          This target must be configured via a pair of ${styles.highlight("kind")} and ${styles.highlight("name")} fields
+          either in the ${styles.highlight("spec.sync.overrides[].target")} or ${styles.highlight("spec.defaultTarget")}.
+
+          Sync override configuration:
+          ${(override.command?.length ?? 0) > 0 ? `Command: ${override.command?.join(" ")}` : ""}
+          ${(override.args?.length ?? 0) > 0 ? `Args: ${override.args?.join(" ")}` : ""}
+          ${(override.image?.length ?? 0) ? `Image: ${override.image}` : ""}
+        `
+      )
     }
   }
 
@@ -390,9 +403,10 @@ export async function configureSyncMode({
     if (!target) {
       throw new ConfigurationError({
         message: dedent`
-          Sync configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.
+          Sync path configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.
+          Either specify a target via the ${styles.highlight("spec.sync.paths[].target")} or ${styles.highlight("spec.defaultTarget")}.
 
-          Sync configuration:
+          Sync path configuration:
           Source path: ${sync.sourcePath}
           Container path: ${sync.containerPath}
           ${sync.containerName ? `Container name: ${sync.containerName}` : ""}
@@ -404,7 +418,20 @@ export async function configureSyncMode({
       const key = targetKey(target)
       dedupedTargets[key] = target
     } else {
-      // todo: warn that sync config entry has no effect
+      // print a warning instead of throwing an error for compatibility
+      emitNonRepeatableWarning(
+        log,
+        dedent`
+          Sync path configuration on ${action.longDescription()} doesn't specify a target properly.
+          This target must be configured via a pair of ${styles.highlight("kind")} and ${styles.highlight("name")} fields
+          either in the ${styles.highlight("spec.sync.paths[].target")} or ${styles.highlight("spec.defaultTarget")}.
+
+          Sync path configuration:
+          Source path: ${sync.sourcePath}
+          Container path: ${sync.containerPath}
+          ${sync.containerName ? `Container name: ${sync.containerName}` : ""}
+        `
+      )
     }
   }
 

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -315,7 +315,6 @@ export async function configureSyncMode({
   // Make sure we don't modify inputs in-place
   manifests = cloneDeep(manifests)
 
-  const overridesByTarget: { [ref: string]: KubernetesDeployOverrideSpec } = {}
   const dedupedTargets: { [ref: string]: KubernetesTargetResourceSpec } = {}
 
   const targetKey = (t: KubernetesTargetResourceSpec) => {
@@ -343,7 +342,6 @@ export async function configureSyncMode({
     }
     if (target.kind && target.name) {
       const key = targetKey(target)
-      overridesByTarget[key] = override
       dedupedTargets[key] = target
     }
   }

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -374,8 +374,7 @@ export async function configureSyncMode({
         log,
         dedent`
           Sync override configuration on ${action.longDescription()} doesn't specify a target properly.
-          This target must be configured via a pair of ${styles.highlight("kind")} and ${styles.highlight("name")} fields
-          either in the ${styles.highlight("spec.sync.overrides[].target")} or ${styles.highlight("spec.defaultTarget")}.
+          This target must be configured via a pair of ${styles.highlight("kind")} and ${styles.highlight("name")} fields either in the ${styles.highlight("spec.sync.overrides[].target")} or ${styles.highlight("spec.defaultTarget")}.
 
           Sync override configuration:
           ${(override.command?.length ?? 0) > 0 ? `Command: ${override.command?.join(" ")}` : ""}
@@ -424,8 +423,7 @@ export async function configureSyncMode({
         log,
         dedent`
           Sync path configuration on ${action.longDescription()} doesn't specify a target properly.
-          This target must be configured via a pair of ${styles.highlight("kind")} and ${styles.highlight("name")} fields
-          either in the ${styles.highlight("spec.sync.paths[].target")} or ${styles.highlight("spec.defaultTarget")}.
+          This target must be configured via a pair of ${styles.highlight("kind")} and ${styles.highlight("name")} fields either in the ${styles.highlight("spec.sync.paths[].target")} or ${styles.highlight("spec.defaultTarget")}.
 
           Sync path configuration:
           Source path: ${sync.sourcePath}

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -330,7 +330,7 @@ export async function configureSyncMode({
       }
     : undefined
 
-  const dedupedTargets: { [ref: string]: KubernetesTargetResourceSpec } = {}
+  const dedupedTargets: { [ref: string]: KubernetesTargetResourceSyncModeStrictSpec } = {}
 
   const targetKey = (t: KubernetesTargetResourceSyncModeStrictSpec) => `${t.kind}/${t.name}`
 

--- a/core/src/util/deprecations.ts
+++ b/core/src/util/deprecations.ts
@@ -107,6 +107,22 @@ export function getDeprecations(style: (s: string) => string = styles.highlight)
       `,
       docs: null,
     },
+    podSelectorInSyncMode: {
+      docsSection: "Deprecated configuration",
+      docsHeadline: `${style("podSelector")} configuration field in sync mode`,
+      warnHint: deline`
+        The ${style("podSelector")} configuration field is deprecated and has no effect in ${style("spec.sync.overrides[].target")} and ${style("spec.sync.paths[].target")} configurations of ${style("kubernetes")} and ${style("helm")} Deploy actions.
+        Please, use the combination of ${style("kind")} and ${style("name")} configuration fields instead.
+      `,
+      docs: dedent`
+      Usage of the ${style("podSelector")} as a target sync resource can cause unpredicted behaviour, because such selector picks up the first matching Pod in the cluster.
+      Instead, a pair of ${style("kind")} and ${style("name")} should be used with one of the following kinds: ${style("Deployment")}, ${style("DaemonSet")} or ${style("StatefulSet")}.
+      Garden ensures that each kind of these resources has exactly 1 Pod when running in sync mode.
+
+      For ${style("kubernetes")} Deploy actions see [${style("spec.sync.overrides[].target")}](../reference/action-types/Deploy/kubernetes#spec.sync.overrides-.target) and [${style("spec.sync.paths[].target")}](../reference/action-types/Deploy/kubernetes#spec.sync.paths-.target).
+      For ${style("helm")} Deploy actions see [${style("spec.sync.overrides[].target")}](../reference/action-types/Deploy/helm#spec.sync.overrides-.target) and [${style("spec.sync.paths[].target")}](../reference/action-types/Deploy/helm#spec.sync.paths-.target).
+      `,
+    },
     containerDeployActionHostPort: {
       docsSection: "Deprecated configuration",
       docsHeadline: `${style("spec.ports[].hostPort")} configuration field in ${style("container")} Deploy action`,

--- a/core/test/integ/src/plugins/kubernetes/sync-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/sync-mode.ts
@@ -944,7 +944,7 @@ describe("sync mode deployments and sync behavior", () => {
           }),
         (err) =>
           expect(stripAnsi(err.message)).to.contain(
-            stripAnsi(`Sync configuration on ${action.longDescription()} doesn't specify a target`)
+            stripAnsi(`Sync path configuration on ${action.longDescription()} doesn't specify a target`)
           )
       )
     })

--- a/core/test/integ/src/plugins/kubernetes/sync-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/sync-mode.ts
@@ -887,26 +887,33 @@ describe("sync mode deployments and sync behavior", () => {
       ]
 
       const target: KubernetesTargetResourceSyncModeSpec = { podSelector: { app: "sync-mode" } }
-      const res = await configureSyncMode({
-        ctx,
-        log: actionLog,
-        provider,
-        action,
-        manifests,
-        defaultTarget: undefined,
-        spec: {
-          paths: [
-            {
-              target,
-              sourcePath: join(action.sourcePath(), "src"),
-              containerPath: "/app/src",
+      await expectError(
+        () =>
+          configureSyncMode({
+            ctx,
+            log: actionLog,
+            provider,
+            action,
+            manifests,
+            defaultTarget: undefined,
+            spec: {
+              paths: [
+                {
+                  target,
+                  sourcePath: join(action.sourcePath(), "src"),
+                  containerPath: "/app/src",
+                },
+              ],
             },
+          }),
+        {
+          contains: [
+            "doesn't specify a target, and none is set as a default",
+            "Either specify a target via the spec.sync.paths[].target or spec.defaultTarget",
+            "The target must be configured via a pair of kind and name fields either in the spec.sync.paths[].target or spec.defaultTarget",
           ],
-        },
-      })
-
-      // Verify that the manifest was not modified (podSelector doesn't modify manifests)
-      expect(res.manifests).to.deep.equal(manifests)
+        }
+      )
     })
     it("should throw an error when sync path has no target and no defaultTarget", async () => {
       const manifests = [

--- a/core/test/integ/src/plugins/kubernetes/sync-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/sync-mode.ts
@@ -8,14 +8,16 @@
 
 import { expect } from "chai"
 import fsExtra from "fs-extra"
-
-const { mkdirp, pathExists, readFile, remove, writeFile } = fsExtra
 import { join } from "path"
 import type { ConfigGraph } from "../../../../../src/graph/config-graph.js"
 import { k8sGetContainerDeployStatus } from "../../../../../src/plugins/kubernetes/container/status.js"
 import type { ActionLog, Log } from "../../../../../src/logger/log-entry.js"
 import { createActionLog } from "../../../../../src/logger/log-entry.js"
-import type { KubernetesPluginContext, KubernetesProvider } from "../../../../../src/plugins/kubernetes/config.js"
+import type {
+  KubernetesPluginContext,
+  KubernetesProvider,
+  KubernetesTargetResourceSyncModeSpec,
+} from "../../../../../src/plugins/kubernetes/config.js"
 import { getMutagenMonitor, Mutagen } from "../../../../../src/mutagen.js"
 import type { KubernetesWorkload, SyncableRuntimeAction } from "../../../../../src/plugins/kubernetes/types.js"
 import { execInWorkload } from "../../../../../src/plugins/kubernetes/util.js"
@@ -41,6 +43,8 @@ import {
 } from "../../../../../src/plugins/kubernetes/constants.js"
 import type { Action, Resolved } from "../../../../../src/actions/types.js"
 import stripAnsi from "strip-ansi"
+
+const { mkdirp, pathExists, readFile, remove, writeFile } = fsExtra
 
 describe("sync mode deployments and sync behavior", () => {
   describe("sync mode deployments", () => {
@@ -882,6 +886,7 @@ describe("sync mode deployments and sync behavior", () => {
         },
       ]
 
+      const target: KubernetesTargetResourceSyncModeSpec = { podSelector: { app: "sync-mode" } }
       const res = await configureSyncMode({
         ctx,
         log: actionLog,
@@ -892,7 +897,7 @@ describe("sync mode deployments and sync behavior", () => {
         spec: {
           paths: [
             {
-              target: { podSelector: { app: "sync-mode" } },
+              target,
               sourcePath: join(action.sourcePath(), "src"),
               containerPath: "/app/src",
             },

--- a/docs/misc/deprecations.md
+++ b/docs/misc/deprecations.md
@@ -85,6 +85,17 @@ The `cleanup-cluster-registry` command in the `kubernetes` and `local-kubernetes
 
 # Deprecated configuration
 
+<h2 id="podselectorinsyncmode"><code>podSelector</code> configuration field in sync mode</h2>
+
+The `podSelector` configuration field is deprecated and has no effect in `spec.sync.overrides[].target` and `spec.sync.paths[].target` configurations of `kubernetes` and `helm` Deploy actions. Please, use the combination of `kind` and `name` configuration fields instead.
+
+Usage of the `podSelector` as a target sync resource can cause unpredicted behaviour, because such selector picks up the first matching Pod in the cluster.
+Instead, a pair of `kind` and `name` should be used with one of the following kinds: `Deployment`, `DaemonSet` or `StatefulSet`.
+Garden ensures that each kind of these resources has exactly 1 Pod when running in sync mode.
+
+For `kubernetes` Deploy actions see [`spec.sync.overrides[].target`](../reference/action-types/Deploy/kubernetes#spec.sync.overrides-.target) and [`spec.sync.paths[].target`](../reference/action-types/Deploy/kubernetes#spec.sync.paths-.target).
+For `helm` Deploy actions see [`spec.sync.overrides[].target`](../reference/action-types/Deploy/helm#spec.sync.overrides-.target) and [`spec.sync.paths[].target`](../reference/action-types/Deploy/helm#spec.sync.paths-.target).
+
 <h2 id="containerdeployactionhostport"><code>spec.ports[].hostPort</code> configuration field in <code>container</code> Deploy action</h2>
 
 It's generally not recommended to use the `hostPort` field of the `V1ContainerPort` spec. You can learn more about Kubernetes best practices at: https://kubernetes.io/docs/concepts/configuration/overview/

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -412,7 +412,7 @@ The name of the resource to patch.
 
 The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
 
-You can read more about the different strategies in the offical Kubernetes documentation at:
+You can read more about the different strategies in the official Kubernetes documentation at:
 https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
 
 | Type     | Default       | Required |

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -493,7 +493,7 @@ The name of the resource to patch.
 
 The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
 
-You can read more about the different strategies in the offical Kubernetes documentation at:
+You can read more about the different strategies in the official Kubernetes documentation at:
 https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
 
 | Type     | Default       | Required |

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -493,7 +493,7 @@ The name of the resource to patch.
 
 The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
 
-You can read more about the different strategies in the offical Kubernetes documentation at:
+You can read more about the different strategies in the official Kubernetes documentation at:
 https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
 
 | Type     | Default       | Required |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -226,7 +226,7 @@ patchResources:
 
     # The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
     #
-    # You can read more about the different strategies in the offical Kubernetes documentation at:
+    # You can read more about the different strategies in the official Kubernetes documentation at:
     # https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
     strategy: strategic
 
@@ -1008,7 +1008,7 @@ The name of the resource to patch.
 
 The patch strategy to use. One of 'json', 'merge', or 'strategic'. Defaults to 'strategic'.
 
-You can read more about the different strategies in the offical Kubernetes documentation at:
+You can read more about the different strategies in the official Kubernetes documentation at:
 https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
 
 | Type     | Default       | Required |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,5 +1,5 @@
 # Plugins
 
-Here we'll keep the offically supported and bundled Garden plugins, until we at some point split (at least some of them) out of the repo entirely.
+Here we'll keep the officially supported and bundled Garden plugins, until we at some point split (at least some of them) out of the repo entirely.
 
 _Note: We are still in process of migrating plugin code to here from the core package._


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes deprecates the usage of `podSelector` in sync mode.
The code was changed to throw a config error if only `podSelector` is specified as a target resource for sync mode.

That `podSelector` did not work properly prior to this fix and could lead to either a runtime error or to a non-working sync mode with warning. Throwing a meaningful configuration error looks like a better UX here.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
