### PR TITLE
chore(docs): fix newline formatting in hint sections.

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -4,9 +4,7 @@ order: 99
 ---
 
 {% hint style="info" %}
-
 If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Join our [Discord](https://go.garden.io/discord).
-
 {% endhint %}
 
 ## Contributing guidelines

--- a/docs/contributing/contributing-docs.md
+++ b/docs/contributing/contributing-docs.md
@@ -13,7 +13,6 @@ Our `../../gitbook.yaml` file determines link redirects and the basic structure 
 
 {% hint style="warning" %}
 *The `README.md` file at the top of the `docs/` folder and the `reference/*` files are all auto-generated and should never be touched directly. Refer to [Make your changes and open a pull request (PR)](#make-your-changes-and-open-a-pull-request-pr) for details.
-
 {% endhint %}
 
 ## Making your first contribution

--- a/docs/features/code-synchronization.md
+++ b/docs/features/code-synchronization.md
@@ -8,8 +8,8 @@ Garden includes a *sync* mode that allows you to rapidly synchronize your code (
 The sync mode uses [Mutagen](https://mutagen.io/) under the hood. Garden automatically takes care of fetching Mutagen, so you don't need to install any dependencies yourself to make use of sync mode.
 
 {% hint style="info" %}
-This feature used to be called _dev mode_ but as of version 0.13 we've opted for more straightforward terminology. The
-functionality is exactly the same as before.
+This feature used to be called _dev mode_ but as of version 0.13 we've opted for more straightforward terminology.
+The functionality is exactly the same as before.
 {% endhint %}
 
 ## Configuration

--- a/docs/garden-for/containers/building-containers.md
+++ b/docs/garden-for/containers/building-containers.md
@@ -164,8 +164,7 @@ set a specific tag or you can _use template strings for the tag_. For example, y
 - Set a custom prefix on tags with the current git branch: `garden publish --tag 'v0.1-${git.branch}'`
 
 {% hint style="warning" %}
-Note that you most likely need to wrap templated tags with single quotes, to prevent your shell from attempting to
-perform its own substitution.
+Note that you most likely need to wrap templated tags with single quotes, to prevent your shell from attempting to perform its own substitution.
 {% endhint %}
 
 Generally, you can use any template strings available for action configs for the tags, with the addition of the

--- a/docs/garden-for/local-scripts.md
+++ b/docs/garden-for/local-scripts.md
@@ -45,9 +45,9 @@ A Build action which executes a build command "locally" on the host.
 This is commonly used together with exec Deploy actions when a local build step needs to be executed first.
 
 {% hint style="info" %}
-Note that by default, Garden will "stage" the build to the `./garden` directory and execute the
-build there. This is to ensure that the command doesn't mess with your local project
-files. You can disable that by setting `buildAtSource: true`.
+Note that by default, Garden will "stage" the build to the `./garden` directory and execute the build there.
+This is to ensure that the command doesn't mess with your local project files.
+You can disable that by setting `buildAtSource: true`.
 {% endhint %}
 
 For example:

--- a/docs/garden-for/terraform/README.md
+++ b/docs/garden-for/terraform/README.md
@@ -24,7 +24,7 @@ You can also use a combination of the two if you'd like. Below we'll walk throug
 Garden will not automatically apply the Terraform stack, unless you explicitly set the `autoApply` flag on the config for the stack. Instead, Garden will warn you if the stack is out of date.
 
 {% hint style="warning" %}
-We only recommend using `autoApply` for private development environments, since otherwise you may accidentally apply hazardous changes, or conflict with other users of an environment.
+We only recommend using `autoApply` for private development environments, since otherwise you may accidentally apply hazardous changes, or conflict with other users of an environment.
 {% endhint %}
 
 To manually plan and apply stacks, we provide the following commands:

--- a/docs/guides/include-exclude.md
+++ b/docs/guides/include-exclude.md
@@ -38,8 +38,7 @@ The `scan.exclude` field is also used to limit the number of files and directori
 ## .ignore file
 
 {% hint style="info" %}
-Generally, using .gardenignore files is far more performant than exclude config statements and will decrease
-graph resolution time.
+Generally, using `.gardenignore` files is far more performant than exclude config statements and will decrease graph resolution time.
 {% endhint %}
 
 By default, Garden respects `.gardenignore` files and excludes any patterns matched in those files. You can place the ignore files anywhere in your repository, much like `.gitignore` files, and they will follow the same semantics.
@@ -57,8 +56,7 @@ This would cause Garden to ignore `node_modules` and `public` directories across
 Note that _these take precedence over both `scan.include` fields in your project config, and `include` fields in your module configs_. If a path is matched by one of the ignore files, the path will not be included in your project or modules.
 
 {% hint style="warning" %}
-Prior to Garden `0.13`, it was possible to specify _multiple_ ".ignore" files
-using the [`dotIgnoreFiles`](../reference/project-config.md#dotIgnoreFiles) field in a project configuration:
+Prior to Garden `0.13`, it was possible to specify _multiple_ ".ignore" files using the [`dotIgnoreFiles`](../reference/project-config.md#dotIgnoreFiles) field in a project configuration:
 
 ```yaml
 apiVersion: garden.io/v2
@@ -103,8 +101,7 @@ exclude:
 ```
 
 {% hint style="info" %}
-Generally, using `.gardenignore` files is far more performant than exclude config statements and will decrease
-graph resolution time.
+Generally, using `.gardenignore` files is far more performant than exclude config statements and will decrease graph resolution time.
 {% endhint %}
 
 Here we only include the `Dockerfile` and all the `.py` files under `my-sources/`, but exclude the `my-sources/tmp`

--- a/docs/misc/troubleshooting.md
+++ b/docs/misc/troubleshooting.md
@@ -65,8 +65,7 @@ This is likely because they're being excluded somewhere, e.g. in `.gitignore` or
 {% hint style="warning" %}
 Prior to Garden 0.13.0, `.gitignore` files were respected by default.
 In Garden 0.13.0 that behaviour was changed.
-Now it's possible to only specify a [single ".ignore" file](../guides/include-exclude.md)
-in the [project-level configuration](../reference/project-config.md#dotIgnoreFile).
+Now it's possible to only specify a [single ".ignore" file](../guides/include-exclude.md) in the [project-level configuration](../reference/project-config.md#dotIgnoreFile).
 {% endhint %}
 
 Please check your [dotIgnoreFile(s) configuration](../guides/include-exclude.md)


### PR DESCRIPTION
**What this PR does / why we need it**:

Newline characters are rendered as they are in hints sections. This avoids some unwanted line breaks in the rendered text.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
