### PR TITLE
chore(renovate): change version range strategy to bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,6 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "prod dependencies (non-major)"
     }
-  ]
+  ],
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is done keep `package.json` and `package-lock.json` files in sync.
Otherwise, only the `package-json.lock` file will be updated, and every local run of `npm i`
 will change the lockfile.

See https://github.com/renovatebot/renovate/discussions/28797#discussioncomment-9303179

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
