### PR TITLE
chore(images): version updates in Garden's `buildkit` docker image

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -62,14 +62,14 @@ export function getK8sSyncUtilImagePath(registryDomain: string): DockerImageWith
 
 export function getBuildkitImagePath(registryDomain: string): DockerImageWithDigest {
   const buildkitImageName: DockerImageWithDigest =
-    "gardendev/buildkit:v-0.16.0@sha256:ee7aa12e6fdba79ee9838631995fa7c5a12aba9091a0753dedfe891d430c8182"
+    "gardendev/buildkit:v0.23.1@sha256:976685a5be67f760a7139d10e4dee5f9d08ce03b575849599dcb29b7aa0f4342"
 
   return makeImagePath({ imageName: buildkitImageName, registryDomain })
 }
 
 export function getBuildkitRootlessImagePath(registryDomain: string): DockerImageWithDigest {
   const buildkitRootlessImageName: DockerImageWithDigest =
-    "gardendev/buildkit:v-0.16.0-rootless@sha256:634506c016691b079e44614c5de65e0b0d4a98070304f6089e15f0279bfca411"
+    "gardendev/buildkit:v0.23.1-rootless@sha256:ab947d61620c0167394cee687f0a2a2a22c9bcf0e34f353d78fb9cab2fde1d28"
 
   return makeImagePath({ imageName: buildkitRootlessImageName, registryDomain })
 }

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -18,13 +18,13 @@ RUN cd /usr/local/bin && \
 ARG TARGETARCH
 # GCR credential helper
 RUN cd /usr/local/bin && \
-  GCR_HELPER_VERSION="2.1.22" && \
+  GCR_HELPER_VERSION="2.1.29" && \
   GCR_HELPER_DISTR_NAME="docker-credential-gcr_linux_$TARGETARCH-${GCR_HELPER_VERSION}.tar.gz" && \
   wget https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/${GCR_HELPER_DISTR_NAME} && \
   if [ "$TARGETARCH" = "amd64" ]; then \
-    echo "443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694  ${GCR_HELPER_DISTR_NAME}" | sha256sum -c; \
+    echo "9e676f2233b93e763276101dd8530e634aebf5d31d5581f64e7ffa978aefa0d8  ${GCR_HELPER_DISTR_NAME}" | sha256sum -c; \
   elif [ "$TARGETARCH" = "arm64" ]; then \
-    echo "b607dfb7516dc1ca6a2a05322d938cea58cc5975e2063efc3695ee6ddb2dccc7  ${GCR_HELPER_DISTR_NAME}" | sha256sum -c; \
+    echo "edb3b0c1f667fb1fc5250d84a4d623886b3f0313d2838ed20885018c141348f9  ${GCR_HELPER_DISTR_NAME}" | sha256sum -c; \
   fi && \
   tar xzf ${GCR_HELPER_DISTR_NAME} && \
   rm ${GCR_HELPER_DISTR_NAME} && \

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -5,13 +5,13 @@ RUN apk add --no-cache wget
 ARG TARGETARCH
 # ECR credential helper
 RUN cd /usr/local/bin && \
-  ECR_HELPER_VERSION="0.8.0" && \
+  ECR_HELPER_VERSION="0.10.0" && \
   ECR_HELPER_DISTR_NAME="docker-credential-ecr-login" && \
   wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECR_HELPER_VERSION}/linux-$TARGETARCH/${ECR_HELPER_DISTR_NAME} && \
   if [ "$TARGETARCH" = "amd64" ]; then \
-    echo "dcc7ae9915b5d8fa2d9e2b18fc30bab5bfbbce5b82401c7644e6ab97973ac35c  ${ECR_HELPER_DISTR_NAME}" | sha256sum -c; \
+    echo "90fd5506d242a26b0e116b0a1ee7e67aa469e653f641a19939fe27b53bc4d20f  ${ECR_HELPER_DISTR_NAME}" | sha256sum -c; \
   elif [ "$TARGETARCH" = "arm64" ]; then \
-    echo "d62badea3153688ec5c24f440df9fb84ff4b02c624dff9288967267e7445daa1  ${ECR_HELPER_DISTR_NAME}" | sha256sum -c; \
+    echo "6c4392e081a08bfd0dcfe8baf62f3dbb6fdf41a99d426bdddddfb32b10ea2a75  ${ECR_HELPER_DISTR_NAME}" | sha256sum -c; \
   fi && \
   chmod +x ${ECR_HELPER_DISTR_NAME}
 

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM moby/buildkit:v0.16.0@sha256:bc1fe18224dbcb92599139db0c745696c48ba9fd4ac24038d1fa81fdd7dcac27 as buildkit
+FROM moby/buildkit:v0.23.1@sha256:dbc2dfd9342fd5c891ea94e9774c15cab985681e5ff995a9e366066aa0b9b2b4 as buildkit
 
 RUN apk add --no-cache wget
 
@@ -30,7 +30,7 @@ RUN cd /usr/local/bin && \
   rm ${GCR_HELPER_DISTR_NAME} && \
   chmod +x docker-credential-gcr
 
-FROM moby/buildkit:v0.13.2-rootless@sha256:1fa728c7d7e97630ee551a69c7f8672ebdfc859922822ee249cf80ab3ee2ee4c as buildkit-rootless
+FROM moby/buildkit:v0.23.1-rootless@sha256:6d65d4ed00cc9e9183da5f3e5ecbe033ed6409e557785eac11c14c5f11048731 as buildkit-rootless
 
 COPY --from=buildkit /usr/local/bin/${ECR_HELPER_DISTR_NAME} /usr/local/bin/${ECR_HELPER_DISTR_NAME}
 COPY --from=buildkit /usr/local/bin/docker-credential-gcr /usr/local/bin/docker-credential-gcr

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -4,7 +4,7 @@ name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
 variables:
   image-name: gardendev/buildkit
-  release-tag: v0.16.0
+  release-tag: v0.23.1
 spec:
   publishId: ${var.image-name}:${var.release-tag}
   localId: ${var.image-name}
@@ -22,7 +22,7 @@ dependencies:
   - build.buildkit
 variables:
   image-name: gardendev/buildkit
-  release-tag: v0.16.0-rootless
+  release-tag: v0.23.1-rootless
 spec:
   publishId: ${var.image-name}:${var.release-tag}
   localId: ${var.image-name}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update `moby/buildkit` to v0.23.1
* Update `docker-credential-ecr-login` to 0.10.0
* Update `docker-credential-gcr` to 2.1.29

**Which issue(s) this PR fixes**:

Supersedes #7375

**Special notes for your reviewer**:
