### PR TITLE
chore: update engine requirements to node >=22 and npm >=10

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,8 +11,8 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
-    "node": ">=18",
-    "npm": ">=8"
+    "node": ">=22",
+    "npm": ">=10"
   },
   "preferGlobal": true,
   "private": true,

--- a/core/package.json
+++ b/core/package.json
@@ -11,8 +11,8 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
-    "node": ">=18",
-    "npm": ">=8"
+    "node": ">=22",
+    "npm": ">=10"
   },
   "preferGlobal": true,
   "files": [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,8 +11,8 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
-    "node": ">=18",
-    "npm": ">=8"
+    "node": ">=22",
+    "npm": ">=10"
   },
   "preferGlobal": true,
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,8 +77,8 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8"
+        "node": ">=22",
+        "npm": ">=10"
       }
     },
     "cli": {
@@ -113,8 +113,8 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8"
+        "node": ">=22",
+        "npm": ">=10"
       }
     },
     "cli/node_modules/@scg82/exit-hook": {
@@ -1207,8 +1207,8 @@
         "utility-types": "^3.11.0"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8"
+        "node": ">=22",
+        "npm": ">=10"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.3"
@@ -12083,8 +12083,8 @@
         "username": "^7.0.0"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8"
+        "node": ">=22",
+        "npm": ">=10"
       }
     },
     "e2e/node_modules/@types/mocha": {
@@ -49150,8 +49150,8 @@
         "ulid": "^3.0.1"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8"
+        "node": ">=22",
+        "npm": ">=10"
       }
     },
     "sdk/node_modules/ulid": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
-    "node": ">=18",
-    "npm": ">=8"
+    "node": ">=22",
+    "npm": ">=10"
   },
   "private": true,
   "devDependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -11,8 +11,8 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
-    "node": ">=18",
-    "npm": ">=8"
+    "node": ">=22",
+    "npm": ">=10"
   },
   "preferGlobal": true,
   "private": true,


### PR DESCRIPTION
**What this PR does / why we need it**:

We use Node 22 in production.

**Which issue(s) this PR fixes**:

Supersedes #7385

**Special notes for your reviewer**:
