### PR TITLE
chore(deps): cumulative dependency updates from renovate bot

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 jq 1.6
 nodejs 22
 kubectl 1.24.6
-helm 3.10.0
+helm 3.18.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 jq 1.6
 nodejs 22
-kubectl 1.24.6
+kubectl 1.33.2
 helm 3.18.3

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "^11.3.0",
     "lodash-es": "^4.17.21",
     "minimist": "^1.2.8",
-    "mocha": "^11.7.0",
+    "mocha": "^11.7.1",
     "typescript": "^5.8.3"
   },
   "scripts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
     "node": ">=22",
-    "npm": ">=10"
+    "npm": ">=10.9.2"
   },
   "preferGlobal": true,
   "private": true,

--- a/core/lib/fsevents/package.json
+++ b/core/lib/fsevents/package.json
@@ -13,7 +13,7 @@
     "fsevents.node"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=18.20.8"
   },
   "scripts": {
     "clean": "node-gyp clean && rm -f fsevents.node",

--- a/core/package.json
+++ b/core/package.json
@@ -186,7 +186,7 @@
     "@types/hapi__joi": "^17.1.15",
     "@types/has-ansi": "^3.0.0",
     "@types/ink-divider": "^2.0.4",
-    "@types/inquirer": "7.3.3",
+    "@types/inquirer": "9.0.8",
     "@types/ip": "^1.1.3",
     "@types/is-git-url": "^1.0.2",
     "@types/is-glob": "^4.0.4",

--- a/core/package.json
+++ b/core/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
     "node": ">=22",
-    "npm": ">=10"
+    "npm": ">=10.9.2"
   },
   "preferGlobal": true,
   "files": [

--- a/core/package.json
+++ b/core/package.json
@@ -236,7 +236,7 @@
     "finalhandler": "^2.1.0",
     "google-auth-library": "^10.1.0",
     "md5": "^2.3.0",
-    "mocha": "^11.7.0",
+    "mocha": "^11.7.1",
     "mockttp": "^3.17.1",
     "nock": "^12.0.3",
     "nodemon": "^3.1.10",

--- a/core/package.json
+++ b/core/package.json
@@ -182,7 +182,7 @@
     "@types/dedent": "^0.7.2",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
-    "@types/global-agent": "^2.1.3",
+    "@types/global-agent": "^3.0.0",
     "@types/hapi__joi": "^17.1.15",
     "@types/has-ansi": "^3.0.0",
     "@types/ink-divider": "^2.0.4",

--- a/core/package.json
+++ b/core/package.json
@@ -223,7 +223,7 @@
     "@types/uniqid": "^5.3.4",
     "@types/unzip-stream": "^0.3.4",
     "@types/uuid": "^10.0.0",
-    "@types/which": "^1.3.2",
+    "@types/which": "^3.0.4",
     "@types/write-file-atomic": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
     "node": ">=22",
-    "npm": ">=10"
+    "npm": ">=10.9.2"
   },
   "preferGlobal": true,
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1176,7 +1176,7 @@
         "@types/uniqid": "^5.3.4",
         "@types/unzip-stream": "^0.3.4",
         "@types/uuid": "^10.0.0",
-        "@types/which": "^1.3.2",
+        "@types/which": "^3.0.4",
         "@types/write-file-atomic": "^4.0.3",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
@@ -5742,7 +5742,9 @@
       "license": "MIT"
     },
     "core/node_modules/@types/which": {
-      "version": "1.3.2",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
+      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1139,7 +1139,7 @@
         "@types/hapi__joi": "^17.1.15",
         "@types/has-ansi": "^3.0.0",
         "@types/ink-divider": "^2.0.4",
-        "@types/inquirer": "7.3.3",
+        "@types/inquirer": "9.0.8",
         "@types/ip": "^1.1.3",
         "@types/is-git-url": "^1.0.2",
         "@types/is-glob": "^4.0.4",
@@ -5528,12 +5528,14 @@
       "license": "MIT"
     },
     "core/node_modules/@types/inquirer": {
-      "version": "7.3.3",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.8.tgz",
+      "integrity": "sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/through": "*",
-        "rxjs": "^6.4.0"
+        "rxjs": "^7.2.0"
       }
     },
     "core/node_modules/@types/inquirer/node_modules/@types/through": {
@@ -5545,18 +5547,19 @@
       }
     },
     "core/node_modules/@types/inquirer/node_modules/rxjs": {
-      "version": "6.6.7",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "core/node_modules/@types/inquirer/node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,7 +1135,7 @@
         "@types/dedent": "^0.7.2",
         "@types/fs-extra": "^11.0.4",
         "@types/glob": "^8.1.0",
-        "@types/global-agent": "^2.1.3",
+        "@types/global-agent": "^3.0.0",
         "@types/hapi__joi": "^17.1.15",
         "@types/has-ansi": "^3.0.0",
         "@types/ink-divider": "^2.0.4",
@@ -5514,6 +5514,13 @@
       "peerDependencies": {
         "typescript": ">=5.6.2"
       }
+    },
+    "core/node_modules/@types/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-OmvaPJtTaY/wd1hxelLJmf8oKQpmKZdrlfQ+MWL59eKSEHJDDEifIo69248bdJ0yLIN+iMNQ6sKMtnwU6AxajA==",
+      "dev": true,
+      "license": "MIT"
     },
     "core/node_modules/@types/has-ansi": {
       "version": "3.0.0",
@@ -17570,11 +17577,6 @@
     },
     "node_modules/@types/glob/node_modules/@types/minimatch": {
       "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/global-agent": {
-      "version": "2.1.3",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "fs-extra": "^11.3.0",
         "lodash-es": "^4.17.21",
         "minimist": "^1.2.8",
-        "mocha": "^11.7.0",
+        "mocha": "^11.7.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -161,9 +161,9 @@
       }
     },
     "cli/node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1189,7 +1189,7 @@
         "finalhandler": "^2.1.0",
         "google-auth-library": "^10.1.0",
         "md5": "^2.3.0",
-        "mocha": "^11.7.0",
+        "mocha": "^11.7.1",
         "mockttp": "^3.17.1",
         "nock": "^12.0.3",
         "nodemon": "^3.1.10",
@@ -6900,9 +6900,9 @@
       "license": "MIT"
     },
     "core/node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -46140,7 +46140,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.3",
         "chai": "^5.2.0",
-        "mocha": "^11.7.0",
+        "mocha": "^11.7.1",
         "source-map-support": "^0.5.21",
         "strip-ansi": "^7.1.0"
       }
@@ -46151,9 +46151,9 @@
       "license": "MIT"
     },
     "plugins/jib/node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -47008,7 +47008,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.3",
         "chai": "^5.2.0",
-        "mocha": "^11.7.0",
+        "mocha": "^11.7.1",
         "strip-ansi": "^7.1.0"
       }
     },
@@ -47043,9 +47043,9 @@
       "license": "MIT"
     },
     "plugins/pulumi/node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -47888,7 +47888,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.3",
         "chai": "^5.2.0",
-        "mocha": "^11.7.0",
+        "mocha": "^11.7.1",
         "source-map-support": "^0.5.21",
         "split2": "^4.2.0",
         "strip-ansi": "^7.1.0"
@@ -47903,9 +47903,9 @@
       "license": "MIT"
     },
     "plugins/terraform/node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
       },
       "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=10.9.2"
       }
     },
     "cli": {
@@ -114,7 +114,7 @@
       },
       "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=10.9.2"
       }
     },
     "cli/node_modules/@scg82/exit-hook": {
@@ -1208,7 +1208,7 @@
       },
       "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=10.9.2"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.3"
@@ -12091,7 +12091,7 @@
       },
       "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=10.9.2"
       }
     },
     "e2e/node_modules/@types/mocha": {
@@ -48781,7 +48781,7 @@
       },
       "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=10.9.2"
       }
     },
     "sdk/node_modules/ulid": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
     "node": ">=22",
-    "npm": ">=10"
+    "npm": ">=10.9.2"
   },
   "private": true,
   "devDependencies": {

--- a/plugins/jib/package.json
+++ b/plugins/jib/package.json
@@ -22,7 +22,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
     "chai": "^5.2.0",
-    "mocha": "^11.7.0",
+    "mocha": "^11.7.1",
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0"
   },

--- a/plugins/pulumi/package.json
+++ b/plugins/pulumi/package.json
@@ -23,7 +23,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
     "chai": "^5.2.0",
-    "mocha": "^11.7.0",
+    "mocha": "^11.7.1",
     "strip-ansi": "^7.1.0"
   },
   "scripts": {

--- a/plugins/terraform/package.json
+++ b/plugins/terraform/package.json
@@ -22,7 +22,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
     "chai": "^5.2.0",
-    "mocha": "^11.7.0",
+    "mocha": "^11.7.1",
     "source-map-support": "^0.5.21",
     "split2": "^4.2.0",
     "strip-ansi": "^7.1.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/garden-io/garden",
   "engines": {
     "node": ">=22",
-    "npm": ">=10"
+    "npm": ">=10.9.2"
   },
   "preferGlobal": true,
   "private": true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Combines the following renovate PRs:
* #7370
* #7371
* #7378
* #7385
* #7410
* #7411
* #7412
* #7415

This is done because of concurrency issues with pulumi plugin test. So the `test-plugins` fails quite often when multiple pipelines are running.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
