### PR TITLE
chore(renovate): group PRs by package manager and version scope

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "ignorePaths": ["core/test/data/**", "e2e/projects/**", "examples/**", "plugins/**/test/**"],
+  "ignorePaths": ["core/lib/**", "core/test/data/**", "e2e/projects/**", "examples/**", "plugins/**/test/**"],
   "packageRules": [
     {
       "matchManagers": ["npm"],

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
     {
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "npm dev dependencies (major)",
+      "labels": ["dev-dependencies", "javascript"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "npm dev dependencies (non-major)",
       "labels": ["dev-dependencies", "javascript"]
@@ -18,6 +25,13 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "npm prod dependencies (non-major)",
       "labels": ["dependencies", "javascript"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "cargo dev dependencies (major)",
+      "labels": ["dev-dependencies", "rust"]
     },
     {
       "matchManagers": ["cargo"],

--- a/renovate.json
+++ b/renovate.json
@@ -6,14 +6,32 @@
   "ignorePaths": ["core/test/data/**", "e2e/projects/**", "examples/**", "plugins/**/test/**"],
   "packageRules": [
     {
+      "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "dev dependencies (non-major)"
+      "groupName": "npm dev dependencies (non-major)",
+      "labels": ["dev-dependencies", "javascript"]
     },
     {
+      "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "prod dependencies (non-major)"
+      "groupName": "npm prod dependencies (non-major)",
+      "labels": ["dependencies", "javascript"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "cargo dev dependencies (non-major)",
+      "labels": ["dev-dependencies", "rust"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "cargo prod dependencies (non-major)",
+      "labels": ["dependencies", "rust"]
     }
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Group minor and patches dependencies for npm and cargo package managers separately.
* Always combine major updates for dev dependencies.
* Ignore updates for copied libs like `fsevents`

The goal is to split the dependencies by language/package manager and to minimize the number of produced PRs.
We still keep individual PRs for major updates in prod dependencies, but for dev dependencies it should be fine to combine.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
