### PR TITLE
chore(deps): remove unnecessary `@types/has-ansi`

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -184,7 +184,6 @@
     "@types/glob": "^8.1.0",
     "@types/global-agent": "^3.0.0",
     "@types/hapi__joi": "^17.1.15",
-    "@types/has-ansi": "^3.0.0",
     "@types/ink-divider": "^2.0.4",
     "@types/inquirer": "9.0.8",
     "@types/ip": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,7 +1146,6 @@
         "@types/glob": "^8.1.0",
         "@types/global-agent": "^3.0.0",
         "@types/hapi__joi": "^17.1.15",
-        "@types/has-ansi": "^3.0.0",
         "@types/ink-divider": "^2.0.4",
         "@types/inquirer": "9.0.8",
         "@types/ip": "^1.1.3",
@@ -5507,11 +5506,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-OmvaPJtTaY/wd1hxelLJmf8oKQpmKZdrlfQ+MWL59eKSEHJDDEifIo69248bdJ0yLIN+iMNQ6sKMtnwU6AxajA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "core/node_modules/@types/has-ansi": {
-      "version": "3.0.0",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

We use `has-ansi` version 6.0.0 which already has type definitions.

The latest version of `@types/has-ansi` is 5.0.2, and it was released 2 years ago, so it's 1 older than the latest `has-ansi` 6.0.0.

**Which issue(s) this PR fixes**:

Supersedes #7379

**Special notes for your reviewer**:
