### PR TITLE
chore(renovate): set PR creation schedule and limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,14 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "cargo prod dependencies (non-major)",
       "labels": ["dependencies", "rust"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "labels": ["dependencies", "docker"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "labels": ["dependencies", "github-actions"]
     }
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Limit the number of concurrent PRs to 5
* Set the minimal dependency version age to 1 week
* Schedule the updates to happen weekly, on Monday morning
* Do not group any major version updates
* Enable auto-merge

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
