### PR TITLE
chore(renovate): disable auto-update for generated grpc client

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,11 @@
   "automerge": true,
   "packageRules": [
     {
+      "matchPackageNames": ["@buf/garden_grow-platform.bufbuild_es"],
+      "enabled": false,
+      "description": "Pinned manually to current version to ignore intermediate and experimental versions from the dev loop."
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore intermediate and experimental versions from the dev loop.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
