### PR TITLE
feat: add preInit.runScript option for all providers

### DIFF
--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -60,11 +60,19 @@ export const execPlugin = sdk.createGardenPlugin({
 
 export const execProvider = execPlugin.createProvider({
   configSchema: s.object({
-    initScript: s.string().optional().describe(dedent`
-      An optional script to run in the project root when initializing providers. This is handy for running an arbitrary
-      script when initializing. For example, another provider might declare a dependency on this provider, to ensure
-      this script runs before resolving that provider.
-    `),
+    initScript: s
+      .string()
+      .optional()
+      .describe(
+        dedent`
+          DEPRECATED: Use the \`preInit.runScript\` field instead on any provider that needs setup outside of Garden.
+
+          An optional script to run in the project root when initializing providers. This is handy for running an arbitrary
+          script when initializing. For example, another provider might declare a dependency on this provider, to ensure
+          this script runs before resolving that provider.
+        `
+      )
+      .setMetadata({ deprecated: true }),
   }),
   outputsSchema: s.object({
     initScript: s

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -24,7 +24,7 @@ import { Profile } from "../util/profiling.js"
 import { join, dirname } from "path"
 import { deserialize, serialize } from "v8"
 import { environmentStatusSchema } from "../config/status.js"
-import { hashString, isNotNull } from "../util/util.js"
+import { hashString, isNotNull, runScript } from "../util/util.js"
 import { CACHE_DIR_NAME, gardenEnv } from "../constants.js"
 import { stableStringify } from "../util/string.js"
 import { OtelTraced } from "../util/open-telemetry/decorators.js"
@@ -392,6 +392,16 @@ export class ResolveProviderTask extends BaseTask<Provider> {
     if (cachedStatus) {
       providerLog.success(`Provider status cached`)
       return cachedStatus
+    }
+
+    if (tmpProvider.config.preInit?.runScript) {
+      providerLog.info(`Running pre-init script`)
+      await runScript({
+        log: providerLog,
+        cwd: this.garden.projectRoot,
+        script: tmpProvider.config.preInit.runScript,
+      })
+      providerLog.info(`Pre-init script completed successfully`)
     }
 
     // TODO: Remove this condition in 0.14 since we no longer check provider statuses when

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1483,6 +1483,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     # Map of all the providers that this provider depends on.
     dependencies:
       <name>:
@@ -1497,6 +1506,15 @@ providers:
       # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
       # disables the provider. To use a provider in all environments, omit this field.
       environments:
+
+      preInit:
+        # A script to run before the provider is initialized. This is useful for performing any provider-specific
+        # setup outside of Garden. For example, you can use this to perform authentication, such as authenticating
+        # with a Kubernetes cluster provider.
+        # The script will always be run from the project root directory.
+        # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+        # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+        runScript:
 
     moduleConfigs:
       - kind:

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -107,6 +107,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
 # The default environment to use when calling commands without the `--env` parameter. May include a namespace name, in
 # the format `<namespace>.<environment>`. Defaults to the first configured environment, with no namespace set.
 defaultEnvironment: ''
@@ -445,6 +454,26 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `defaultEnvironment`
 

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -30,6 +30,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     # Extra flags to pass to the `docker build` command. Will extend the `spec.extraFlags` specified in each container
     # Build action.
     dockerBuildExtraFlags:
@@ -115,6 +124,26 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].dockerBuildExtraFlags[]`
 

--- a/docs/reference/providers/exec.md
+++ b/docs/reference/providers/exec.md
@@ -37,6 +37,17 @@ providers:
     # Example: `["dev","stage"]`
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
+    # DEPRECATED: Use the `preInit.runScript` field instead on any provider that needs setup outside of Garden.
+    #
     # An optional script to run in the project root when initializing providers. This is handy for running an
     # arbitrary
     # script when initializing. For example, another provider might declare a dependency on this provider, to ensure
@@ -85,9 +96,31 @@ Example: `["dev","stage"]`
 | ------- | -------- |
 | `array` | No       |
 
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `providers[].initScript`
 
 [providers](#providers) > initScript
+
+DEPRECATED: Use the `preInit.runScript` field instead on any provider that needs setup outside of Garden.
 
 An optional script to run in the project root when initializing providers. This is handy for running an arbitrary
 script when initializing. For example, another provider might declare a dependency on this provider, to ensure

--- a/docs/reference/providers/jib.md
+++ b/docs/reference/providers/jib.md
@@ -32,6 +32,15 @@ providers:
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
 ```
 ## Configuration Keys
 
@@ -94,5 +103,25 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -36,6 +36,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     # The container registry domain that should be used for pulling Garden utility images (such as the
     # image used in the Kubernetes sync utility Pod).
     #
@@ -581,6 +590,26 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].utilImageRegistryDomain`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -30,6 +30,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     # The container registry domain that should be used for pulling Garden utility images (such as the
     # image used in the Kubernetes sync utility Pod).
     #
@@ -527,6 +536,26 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].utilImageRegistryDomain`
 

--- a/docs/reference/providers/otel-collector.md
+++ b/docs/reference/providers/otel-collector.md
@@ -39,6 +39,15 @@ providers:
     # Example: `["dev","stage"]`
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     exporters:
       - name:
 
@@ -87,6 +96,26 @@ Example: `["dev","stage"]`
 | Type    | Required |
 | ------- | -------- |
 | `array` | No       |
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].exporters[]`
 

--- a/docs/reference/providers/pulumi.md
+++ b/docs/reference/providers/pulumi.md
@@ -31,6 +31,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     # The version of pulumi to use. Set to `null` to use whichever version of `pulumi` is on your PATH.
     version: 3.122.0
 
@@ -133,6 +142,26 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].version`
 

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -29,6 +29,15 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    preInit:
+      # A script to run before the provider is initialized. This is useful for performing any provider-specific setup
+      # outside of Garden. For example, you can use this to perform authentication, such as authenticating with a
+      # Kubernetes cluster provider.
+      # The script will always be run from the project root directory.
+      # Note that provider statuses are cached, so this script will generally only be run once, but you can force a
+      # re-run by setting `--force-refresh` on any Garden command that uses the provider.
+      runScript:
+
     # If set to true, Garden will run `terraform destroy` on the project root stack when calling `garden delete env`.
     allowDestroy: false
 
@@ -128,6 +137,26 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].preInit`
+
+[providers](#providers) > preInit
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].preInit.runScript`
+
+[providers](#providers) > [preInit](#providerspreinit) > runScript
+
+A script to run before the provider is initialized. This is useful for performing any provider-specific setup outside of Garden. For example, you can use this to perform authentication, such as authenticating with a Kubernetes cluster provider.
+The script will always be run from the project root directory.
+Note that provider statuses are cached, so this script will generally only be run once, but you can force a re-run by setting `--force-refresh` on any Garden command that uses the provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].allowDestroy`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously, users would need to use the `exec` provider with an `initScript` set on the provider to perform any preparation needed outside of Garden (such as authenticating with clusters). Now this is a more native feature on any provider, just set `preInit.runScript` on any given provider.