### PR TITLE
fix(core): set 'waiting to flush' log level to debug

### DIFF
--- a/core/src/cloud/grow/grpc-event-stream.ts
+++ b/core/src/cloud/grow/grpc-event-stream.ts
@@ -153,7 +153,7 @@ export class GrpcEventStream {
     await Promise.race([
       promise,
       (async () => {
-        this.log.info(`Waiting for ${timeoutSec} seconds to flush events to Garden Cloud`)
+        this.log.debug(`Waiting for ${timeoutSec} seconds to flush events to Garden Cloud`)
         await sleep(timeout)
         this.log.debug(
           `GrpcEventStream: Not all events were acknowledged within ${timeoutSec} seconds. Information in Garden Cloud may be incomplete.`


### PR DESCRIPTION
Before this fix, Garden commands would end with the text: 'Waiting for 1 seconds to flush events to Garden Cloud'.

Not sure if it's intentional but feels a bit off and noisy to me.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
