### PR TITLE
chore(dependabot): disable updates for `@bufbuild/protobuf`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    # Pinned manually to current version to be consistent with @buf/garden_grow-platform.bufbuild_es
+    ignore:
+      - dependency-name: "@bufbuild/protobuf"
 
   ### 0.13 branch
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We maintain it manually to be consistent with `@buf/garden_grow-platform.bufbuild_es`.

**Which issue(s) this PR fixes**:

Follow-up change for #7442.

**Special notes for your reviewer**:
