### PR TITLE
ci: simplify AWS setup in circleci

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -472,15 +472,10 @@ jobs:
       - checkout
       - *attach-workspace
       - aws-cli/setup:
-          aws_access_key_id: GARDEN_CODE_SIGNING_AWS_ACCESS_KEY_ID # This is the string of the env variable containing the key, not the value itself
-          aws_secret_access_key: GARDEN_CODE_SIGNING_AWS_SECRET_ACCESS_KEY # This is the string of the env variable containing the key, not the value itself
-          configure_profile_region: true
-          region: eu-central-1
-          profile_name: windows-code-signing-ib
       - run:
           name: Run script to sign Windows binaries
           command: |
-            ./scripts/sign-windows-binary.sh --version <<parameters.version>> --file dist/windows-amd64/garden.exe --profile windows-code-signing-ib
+            ./scripts/sign-windows-binary.sh --version <<parameters.version>> --file dist/windows-amd64/garden.exe
       - run:
           name: Prepare the windows binary zip and cleanup
           command: |


### PR DESCRIPTION
Let's just set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY directly in the circleci context, rather than remapping it or relying on profile. this simplifies the code and makes it easier to troubleshoot and understand.
This hopefully also fixes the AWS auth issue we have on main.

co-authored-by: vova <vladimir@garden.io>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
