### PR TITLE
chore(deps): remove deprecated `@types/glob`

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -181,7 +181,6 @@
     "@types/cross-spawn": "^6.0.6",
     "@types/dedent": "^0.7.2",
     "@types/fs-extra": "^11.0.4",
-    "@types/glob": "^8.1.0",
     "@types/global-agent": "^3.0.0",
     "@types/hapi__joi": "^17.1.15",
     "@types/ink-divider": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1268,7 +1268,6 @@
         "@types/cross-spawn": "^6.0.6",
         "@types/dedent": "^0.7.2",
         "@types/fs-extra": "^11.0.4",
-        "@types/glob": "^8.1.0",
         "@types/global-agent": "^3.0.0",
         "@types/hapi__joi": "^17.1.15",
         "@types/ink-divider": "^2.0.4",
@@ -20111,20 +20110,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/glob/node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/hapi__joi": {
       "version": "17.1.15",


### PR DESCRIPTION
**What this PR does / why we need it**:

The `glob` library now has its own types and the `@types/glob` should not be used.
See https://www.npmjs.com/package/@types/glob

**Which issue(s) this PR fixes**:

Supersedes #7513

**Special notes for your reviewer**:
