### PR TITLE
chore(renovate): fix config syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
   "ignorePaths": ["core/lib/**", "core/test/data/**", "e2e/projects/**", "examples/**", "plugins/**/test/**"],
   "schedule": ["before 6am on Monday"],
   "minimumReleaseAge": "14 days",
-  "mergeConfidence": "high",
   "prConcurrentLimit": 5,
   "semanticCommits": "auto",
   "packageRules": [


### PR DESCRIPTION
**What this PR does / why we need it**:

There is no such option like `mergeConfidence`. Let's delete it.

Follow-up fix for #7564.

**Which issue(s) this PR fixes**:

Fixes #7566 

**Special notes for your reviewer**:
