### PR TITLE
feat(config): add version.excludeFields to exclude config fields from…

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -71,7 +71,7 @@ import { dirname } from "node:path"
 import type { ResolvedTemplate } from "../template/types.js"
 import type { WorkflowConfig } from "../config/workflow.js"
 import type { VariablesContext } from "../config/template-contexts/variables.js"
-import { deepMap } from "../util/objects.js"
+import { deepFilter, deepMap } from "../util/objects.js"
 
 // TODO: split this file
 
@@ -261,6 +261,41 @@ export const baseActionConfigSchema = createSchema({
     version: joi
       .object()
       .keys({
+        excludeFields: joi
+          .array()
+          .items(joi.array().items(joi.string()))
+          .description(
+            dedent`
+            Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. \`[spec, env, HOSTNAME]\` would ignore \`spec.env.HOSTNAME\` in the configuration when computing the version.
+
+            For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+            \`\`\`yaml
+            version:
+              excludeFields:
+                - [spec, env, HOSTNAME]
+            \`\`\`
+
+            Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+            \`\`\`yaml
+            kind: Test
+            type: container
+            ...
+            spec:
+              artifacts:
+                - source: foo
+                  target: bar  # Gets excluded from the version calculation
+            version:
+              excludeFields:
+                - [spec, artifacts, "*", target]
+            \`\`\`
+
+            Only simple \`"*"\` wildcards are supported for the moment (i.e. you can't exclude by \`"something*"\` or use question marks for individual character matching).
+
+            Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+          `
+          ),
         excludeValues: joiSparseArray(joi.string()).description(
           dedent`
             Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
@@ -275,7 +310,9 @@ export const baseActionConfigSchema = createSchema({
 
             With the \`hostname\` variable being defined in the Project configuration.
 
-            For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+            For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+            For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the \`excludeFields\` option, since that can be applied more surgically.
           `
         ),
       })
@@ -1026,10 +1063,44 @@ export function replaceExcludeValues(config: BaseActionConfig, log: ActionLog) {
 
   const excludeValues = config.version?.excludeValues || []
   const excludeValueRegexes = excludeValues.map((v) => new RegExp(v, "g"))
+  const excludeFields = config.version?.excludeFields || []
+
+  if (excludeFields.length > 0) {
+    configToHash = deepFilter(configToHash, (_v, _key, path) => {
+      for (const excludePath of excludeFields) {
+        let allPartsMatched = true
+
+        if (path.length < excludePath.length) {
+          break
+        }
+
+        for (let i = 0; i < path.length; i++) {
+          if (path[i] !== excludePath[i] && excludePath[i] !== "*") {
+            allPartsMatched = false
+            break
+          }
+        }
+
+        if (allPartsMatched) {
+          return false
+        }
+      }
+
+      return true
+    })
+  }
 
   if (excludeValues.length > 0) {
     configToHash = deepMap(configToHash, (v, _key, path) => {
+      path = path.filter(isString) // The paths referenced in excludeFields ignore array indices
+
       if (isString(v)) {
+        for (const excludePath of config.version?.excludeFields || []) {
+          if (path.join(".") === excludePath.join(".")) {
+            return excludeValueReplacement
+          }
+        }
+
         for (const regex of excludeValueRegexes) {
           if (regex.test(v as string)) {
             log.verbose(`Excluding value ${v} from version calculation for ${path.join(".")}`)

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -45,6 +45,7 @@ export interface ActionSourceSpec {
 }
 
 export interface ActionVersionConfig {
+  excludeFields?: (string | number)[][]
   excludeValues?: string[]
 }
 

--- a/core/src/util/objects.ts
+++ b/core/src/util/objects.ts
@@ -46,12 +46,16 @@ export function deepMap<V, R>(
  */
 export function deepFilter<V>(
   value: CollectionOrValue<V>,
-  fn: (value: any, key: string | number) => boolean
+  fn: (value: any, key: string | number, keyPath: (number | string)[]) => boolean,
+  keyPath: (number | string)[] = []
 ): CollectionOrValue<V> {
   if (isArray(value)) {
-    return value.filter(fn).map((v) => deepFilter(v, fn))
+    return value.filter((v, k) => fn(v, k, [...keyPath, k])).map((v, k) => deepFilter(v, fn, [...keyPath, k]))
   } else if (isPlainObject(value)) {
-    return mapValues(pickBy(value, fn), (v) => deepFilter(v, fn))
+    return mapValues(
+      pickBy(value, (v, k) => fn(v, k, [...keyPath, k])),
+      (v, k) => deepFilter(v, fn, [...keyPath, k])
+    )
   } else {
     return value
   }

--- a/core/test/data/test-projects/version-exclude-fields/actions.garden.yml
+++ b/core/test/data/test-projects/version-exclude-fields/actions.garden.yml
@@ -2,7 +2,9 @@ kind: Test
 type: test
 name: test
 version:
-  excludeValues:
-    - ${var.hostname}
+  excludeFields:
+    - [spec, env, HOSTNAME]
 spec:
-  command: [echo, "${var.hostname}"]
+  command: ["echo"]
+  env:
+    HOSTNAME: ${var.hostname}

--- a/core/test/data/test-projects/version-exclude-fields/project.garden.yml
+++ b/core/test/data/test-projects/version-exclude-fields/project.garden.yml
@@ -1,6 +1,6 @@
 apiVersion: garden.io/v2
 kind: Project
-name: version-exclude-values
+name: version-exclude-fields
 environments:
   - name: a
     variables:

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4388,6 +4388,38 @@ describe("Garden", () => {
       expect(resolvedA.configVersion(gardenA.log)).to.equal(resolvedB.configVersion(gardenB.log))
     })
 
+    it("correctly handles version.excludeFields", async () => {
+      const projectRoot = getDataDir("test-projects", "version-exclude-fields")
+      const gardenA = await makeTestGarden(projectRoot, { environmentString: "a" })
+      const gardenB = await makeTestGarden(projectRoot, { environmentString: "b" })
+
+      const graphA = await gardenA.getConfigGraph({ log: gardenA.log, emit: false })
+      const graphB = await gardenB.getConfigGraph({ log: gardenB.log, emit: false })
+
+      const a = graphA.getTest("test")
+      const b = graphB.getTest("test")
+
+      const resolvedA = await resolveAction({
+        garden: gardenA,
+        graph: graphA,
+        log: gardenA.log,
+        action: a,
+      })
+      const resolvedB = await resolveAction({
+        garden: gardenB,
+        graph: graphB,
+        log: gardenB.log,
+        action: b,
+      })
+
+      // The spec.env field should have different values between environments
+      expect(resolvedA.getSpec().env).to.not.eql(resolvedB.getSpec().env)
+
+      // But the config versions should still resolve to the same
+      expect(a.configVersion(gardenA.log)).to.equal(b.configVersion(gardenB.log))
+      expect(resolvedA.configVersion(gardenA.log)).to.equal(resolvedB.configVersion(gardenB.log))
+    })
+
     describe("disabled actions", () => {
       context("should not throw if disabled action does not have a configured provider", () => {
         it("when action is disabled explicitly via `disabled: true` flag", async () => {

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -206,11 +206,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -222,7 +259,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -206,11 +206,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -222,7 +259,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -218,11 +218,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -234,7 +271,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -248,11 +248,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -264,7 +301,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -252,11 +252,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -268,7 +305,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -254,11 +254,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -270,7 +307,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -252,11 +252,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -268,7 +305,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -256,11 +256,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -272,7 +309,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -248,11 +248,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -264,7 +301,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -248,11 +248,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -264,7 +301,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -250,11 +250,48 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeFields[]`
+
+[version](#version) > excludeFields
+
+Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+
+For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeFields:
+    - [spec, env, HOSTNAME]
+```
+
+Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:
+
+```yaml
+kind: Test
+type: container
+...
+spec:
+  artifacts:
+    - source: foo
+      target: bar  # Gets excluded from the version calculation
+version:
+  excludeFields:
+    - [spec, artifacts, "*", target]
+```
+
+Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use question marks for individual character matching).
+
+Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should.
+
+| Type           | Required |
+| -------------- | -------- |
+| `array[array]` | No       |
+
 ### `version.excludeValues[]`
 
 [version](#version) > excludeValues
 
-Specify one or more string values that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+Specify one or more configuration fields that should be ignored when computing the version hash for this action. You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
 
 For example, you might have a variable that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:
 
@@ -266,7 +303,9 @@ version:
 
 With the `hostname` variable being defined in the Project configuration.
 
-For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration is not affected.
+For each value specified under this field, every occurrence of that string value (even as part of a longer string) will be replaced when calculating the action version. The action configuration (used when performing the action) is not affected.
+
+For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the `excludeFields` option, since that should be more surgical.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1910,8 +1910,41 @@ actionConfigs:
           optional:
 
       version:
-        # Specify one or more string values that should be ignored when computing the version hash for this action.
-        # You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+        # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
+        # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
+        # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+        #
+        # For example, you might have a field that naturally changes for every individual test or dev environment,
+        # such as a dynamic hostname. You could solve for that with something like this:
+        #
+        # version:
+        #   excludeFields:
+        #     - [spec, env, HOSTNAME]
+        #
+        # Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields
+        # on all objects in arrays. Example:
+        #
+        # kind: Test
+        # type: container
+        # ...
+        # spec:
+        #   artifacts:
+        #     - source: foo
+        #       target: bar  # Gets excluded from the version calculation
+        # version:
+        #   excludeFields:
+        #     - [spec, artifacts, "*", target]
+        #
+        # Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use
+        # question marks for individual character matching).
+        #
+        # Note that it is very important not to specify overly broad exclusions here, as this may cause the version to
+        # change too rarely, which may cause build errors or tests to not run when they should.
+        excludeFields:
+
+        # Specify one or more configuration fields that should be ignored when computing the version hash for this
+        # action. You may use template expressions here. This is useful to avoid dynamic values affecting cache
+        # versions.
         #
         # For example, you might have a variable that naturally changes for every individual test or dev environment,
         # such as a dynamic hostname. You could solve for that with something like this:
@@ -1923,7 +1956,11 @@ actionConfigs:
         # With the `hostname` variable being defined in the Project configuration.
         #
         # For each value specified under this field, every occurrence of that string value (even as part of a longer
-        # string) will be replaced when calculating the action version. The action configuration is not affected.
+        # string) will be replaced when calculating the action version. The action configuration (used when performing
+        # the action) is not affected.
+        #
+        # For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the
+        # `excludeFields` option, since that should be more surgical.
         excludeValues:
 
       # The spec for the specific action type.
@@ -2144,8 +2181,41 @@ actionConfigs:
           optional:
 
       version:
-        # Specify one or more string values that should be ignored when computing the version hash for this action.
-        # You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+        # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
+        # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
+        # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+        #
+        # For example, you might have a field that naturally changes for every individual test or dev environment,
+        # such as a dynamic hostname. You could solve for that with something like this:
+        #
+        # version:
+        #   excludeFields:
+        #     - [spec, env, HOSTNAME]
+        #
+        # Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields
+        # on all objects in arrays. Example:
+        #
+        # kind: Test
+        # type: container
+        # ...
+        # spec:
+        #   artifacts:
+        #     - source: foo
+        #       target: bar  # Gets excluded from the version calculation
+        # version:
+        #   excludeFields:
+        #     - [spec, artifacts, "*", target]
+        #
+        # Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use
+        # question marks for individual character matching).
+        #
+        # Note that it is very important not to specify overly broad exclusions here, as this may cause the version to
+        # change too rarely, which may cause build errors or tests to not run when they should.
+        excludeFields:
+
+        # Specify one or more configuration fields that should be ignored when computing the version hash for this
+        # action. You may use template expressions here. This is useful to avoid dynamic values affecting cache
+        # versions.
         #
         # For example, you might have a variable that naturally changes for every individual test or dev environment,
         # such as a dynamic hostname. You could solve for that with something like this:
@@ -2157,7 +2227,11 @@ actionConfigs:
         # With the `hostname` variable being defined in the Project configuration.
         #
         # For each value specified under this field, every occurrence of that string value (even as part of a longer
-        # string) will be replaced when calculating the action version. The action configuration is not affected.
+        # string) will be replaced when calculating the action version. The action configuration (used when performing
+        # the action) is not affected.
+        #
+        # For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the
+        # `excludeFields` option, since that should be more surgical.
         excludeValues:
 
       # The spec for the specific action type.
@@ -2317,8 +2391,41 @@ actionConfigs:
           optional:
 
       version:
-        # Specify one or more string values that should be ignored when computing the version hash for this action.
-        # You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+        # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
+        # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
+        # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+        #
+        # For example, you might have a field that naturally changes for every individual test or dev environment,
+        # such as a dynamic hostname. You could solve for that with something like this:
+        #
+        # version:
+        #   excludeFields:
+        #     - [spec, env, HOSTNAME]
+        #
+        # Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields
+        # on all objects in arrays. Example:
+        #
+        # kind: Test
+        # type: container
+        # ...
+        # spec:
+        #   artifacts:
+        #     - source: foo
+        #       target: bar  # Gets excluded from the version calculation
+        # version:
+        #   excludeFields:
+        #     - [spec, artifacts, "*", target]
+        #
+        # Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use
+        # question marks for individual character matching).
+        #
+        # Note that it is very important not to specify overly broad exclusions here, as this may cause the version to
+        # change too rarely, which may cause build errors or tests to not run when they should.
+        excludeFields:
+
+        # Specify one or more configuration fields that should be ignored when computing the version hash for this
+        # action. You may use template expressions here. This is useful to avoid dynamic values affecting cache
+        # versions.
         #
         # For example, you might have a variable that naturally changes for every individual test or dev environment,
         # such as a dynamic hostname. You could solve for that with something like this:
@@ -2330,7 +2437,11 @@ actionConfigs:
         # With the `hostname` variable being defined in the Project configuration.
         #
         # For each value specified under this field, every occurrence of that string value (even as part of a longer
-        # string) will be replaced when calculating the action version. The action configuration is not affected.
+        # string) will be replaced when calculating the action version. The action configuration (used when performing
+        # the action) is not affected.
+        #
+        # For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the
+        # `excludeFields` option, since that should be more surgical.
         excludeValues:
 
       # The spec for the specific action type.
@@ -2490,8 +2601,41 @@ actionConfigs:
           optional:
 
       version:
-        # Specify one or more string values that should be ignored when computing the version hash for this action.
-        # You may use template expressions here. This is useful to avoid dynamic values affecting cache versions.
+        # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
+        # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
+        # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
+        #
+        # For example, you might have a field that naturally changes for every individual test or dev environment,
+        # such as a dynamic hostname. You could solve for that with something like this:
+        #
+        # version:
+        #   excludeFields:
+        #     - [spec, env, HOSTNAME]
+        #
+        # Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields
+        # on all objects in arrays. Example:
+        #
+        # kind: Test
+        # type: container
+        # ...
+        # spec:
+        #   artifacts:
+        #     - source: foo
+        #       target: bar  # Gets excluded from the version calculation
+        # version:
+        #   excludeFields:
+        #     - [spec, artifacts, "*", target]
+        #
+        # Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by `"something*"` or use
+        # question marks for individual character matching).
+        #
+        # Note that it is very important not to specify overly broad exclusions here, as this may cause the version to
+        # change too rarely, which may cause build errors or tests to not run when they should.
+        excludeFields:
+
+        # Specify one or more configuration fields that should be ignored when computing the version hash for this
+        # action. You may use template expressions here. This is useful to avoid dynamic values affecting cache
+        # versions.
         #
         # For example, you might have a variable that naturally changes for every individual test or dev environment,
         # such as a dynamic hostname. You could solve for that with something like this:
@@ -2503,7 +2647,11 @@ actionConfigs:
         # With the `hostname` variable being defined in the Project configuration.
         #
         # For each value specified under this field, every occurrence of that string value (even as part of a longer
-        # string) will be replaced when calculating the action version. The action configuration is not affected.
+        # string) will be replaced when calculating the action version. The action configuration (used when performing
+        # the action) is not affected.
+        #
+        # For instances when the value to replace may be overly broad (e.g. "api") it is generally better to use the
+        # `excludeFields` option, since that should be more surgical.
         excludeValues:
 
       # The spec for the specific action type.


### PR DESCRIPTION
… versions

This extends PR #7572 to additionally allow excluding specific fields from an action config when computing its version.

From the docs:
---
Specify a list of config fields that should be ignored when computing the version hash for this action. Each item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]` would ignore `spec.env.HOSTNAME` in the configuration when computing the version.

For example, you might have a field that naturally changes for every individual test or dev environment, such as a dynamic hostname. You could solve for that with something like this:

```yaml
version:
  excludeFields:
    - [spec, env, HOSTNAME]
```

Arrays can also be indexed with numeric indices, but you can also use wildcards to exclude specific fields on all objects in arrays. Example:

```yaml
kind: Test
type: container
...
spec:
  artifacts:
    - source: foo
      target: bar  # Gets excluded from the version calculation
version:
  excludeFields:
    - [spec, artifacts, "*", target]
```

Only simple `"*"` wildcards are supported for the moment (i.e. you can't exclude by "something*" or use question marks for individual character matching).

Note that it is very important not to specify overly broad exclusions here, as this may cause the version to change too rarely, which may cause build errors or tests to not run when they should. ---
