### PR TITLE
fix(template): do not throw circular reference error when resolving cross-references in the same scope

### DIFF
--- a/core/src/config/template-contexts/variables.ts
+++ b/core/src/config/template-contexts/variables.ts
@@ -73,7 +73,7 @@ export class VariablesContext extends LayeredContext {
 
       // capture the needed context, so variables can be resolved correctly
       const capturedScope = new GenericContext(
-        `captured scope ${i} in ${description}`,
+        `peer variables for cross-referencing ${i} in ${description}`,
         capture(currentScope, neededContext, { isFinalContext })
       )
       layers.push(capturedScope)

--- a/core/src/template/ast.ts
+++ b/core/src/template/ast.ts
@@ -8,7 +8,12 @@
 
 import { isArray, isNumber, isString } from "lodash-es"
 import type { ConfigContext, ContextResolveOpts } from "../config/template-contexts/base.js"
-import { ContextResolveError, getUnavailableReason, renderKeyPath } from "../config/template-contexts/base.js"
+import {
+  ContextCircularlyReferencesItself,
+  ContextResolveError,
+  getUnavailableReason,
+  renderKeyPath,
+} from "../config/template-contexts/base.js"
 import { ConfigurationError, InternalError } from "../exceptions.js"
 import { getHelperFunctions } from "./functions/index.js"
 import type { EvaluateTemplateArgs } from "./types.js"
@@ -813,8 +818,8 @@ export class ContextLookupExpression extends TemplateExpression {
       throw new TemplateStringError({
         message: getUnavailableReason(result),
         loc: this.loc,
+        causedByCircularReferenceError: result.explanation.reason === "circular_reference",
         yamlSource,
-        lookupResult: result,
       })
     }
 
@@ -838,6 +843,7 @@ export class ContextLookupExpression extends TemplateExpression {
           loc: this.loc,
           yamlSource,
           wrappedErrors: [e],
+          causedByCircularReferenceError: e instanceof ContextCircularlyReferencesItself,
         })
       }
       // wrap configuration error into template string error for better ux
@@ -855,6 +861,7 @@ export class ContextLookupExpression extends TemplateExpression {
           loc: this.loc,
           yamlSource,
           wrappedErrors: [e],
+          causedByCircularReferenceError: e.causedByCircularReferenceError,
         })
       }
       throw e

--- a/core/src/template/capture.ts
+++ b/core/src/template/capture.ts
@@ -38,7 +38,7 @@ export function capture<Input extends ParsedTemplate>(
 
 export class CapturedContextTemplateValue extends UnresolvedTemplateValue {
   constructor(
-    private readonly wrapped: ParsedTemplate,
+    readonly wrapped: ParsedTemplate,
     private readonly context: ConfigContext,
     private readonly opts: ContextResolveOpts
   ) {

--- a/core/src/template/errors.ts
+++ b/core/src/template/errors.ts
@@ -33,11 +33,14 @@ export class TemplateStringError extends GardenError {
   type = "template-string"
 
   loc: Location
+  yamlSource: ConfigSource
   originalMessage: string
   lookupResult?: ContextResolveOutputNotFound
 
+  causedByCircularReferenceError: boolean
+
   constructor(
-    params: GardenErrorParams & { loc: Location; yamlSource: ConfigSource; lookupResult?: ContextResolveOutputNotFound }
+    params: GardenErrorParams & { loc: Location; yamlSource: ConfigSource; causedByCircularReferenceError?: boolean }
   ) {
     // TODO: Use Location information from parser to point to the specific part
     let enriched = addYamlContext({ source: params.yamlSource, message: params.message })
@@ -56,7 +59,8 @@ export class TemplateStringError extends GardenError {
 
     super({ ...params, message: enriched })
     this.loc = params.loc
+    this.yamlSource = params.yamlSource
     this.originalMessage = params.message
-    this.lookupResult = params.lookupResult
+    this.causedByCircularReferenceError = params.causedByCircularReferenceError || false
   }
 }

--- a/core/test/data/test-projects/variable-crossreferences-merge/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences-merge/garden.yml
@@ -1,0 +1,17 @@
+apiVersion: garden.io/v2
+kind: Project
+name: variable-crossreferences-merge
+
+environments:
+  - name: local
+    variables:
+      $merge: ${var.patch}
+      patch:
+        bar: baz
+
+providers:
+  - name: test-plugin
+
+variables:
+  patch:
+    foo: bar

--- a/core/test/data/test-projects/variable-crossreferences/garden.yml
+++ b/core/test/data/test-projects/variable-crossreferences/garden.yml
@@ -1,6 +1,6 @@
 apiVersion: garden.io/v1
 kind: Project
-name: duplicate-module
+name: variable-crossreferences
 
 environments:
   - name: local

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3569,7 +3569,7 @@ describe("Garden", () => {
       expect(module.spec.bla).to.equal("default")
     })
 
-    it("should correctly resolve template strings with $merge keys", async () => {
+    it("should correctly resolve template strings with merge operator", async () => {
       const test = createGardenPlugin({
         name: "test",
         createModuleTypes: [

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -2119,7 +2119,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should collapse $merge keys on objects", () => {
+  it("should collapse merge operator keys on objects", () => {
     const obj = {
       $merge: { a: "a", b: "b" },
       b: "B",
@@ -2137,7 +2137,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should collapse $merge keys based on position on object", () => {
+  it("should collapse merge operator keys based on position on object", () => {
     const obj = {
       b: "B",
       c: "c",
@@ -2155,7 +2155,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should resolve $merge keys before collapsing", () => {
+  it("should resolve merge operator before collapsing", () => {
     const obj = {
       $merge: "${obj}",
       b: "B",
@@ -2173,7 +2173,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should resolve $merge keys depth-first", () => {
+  it("should resolve merge operators depth-first", () => {
     const obj = {
       b: "B",
       c: "c",
@@ -2194,7 +2194,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should resolve $merge keys if one object is undefined but it can fall back to another object", () => {
+  it("should resolve merge operator if one object is undefined but it can fall back to another object", () => {
     const obj = {
       $merge: "${var.doesnotexist || var.obj}",
       c: "c",
@@ -2211,7 +2211,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should resolve $merge keys if a dependency cannot be resolved but there's a fallback", () => {
+  it("should resolve merge operator if a dependency cannot be resolved but there's a fallback", () => {
     const obj = {
       "key-value-array": {
         $forEach: "${inputs.merged-object || []}",
@@ -2251,7 +2251,7 @@ describe("parse and evaluate template collections", () => {
     })
   })
 
-  it("should ignore $merge keys if the object to be merged is undefined", () => {
+  it("should ignore merge operator if the object to be merged is undefined", () => {
     const context = new TestContext({ var: { obj: { a: "a", b: "b" } } })
 
     const parsed = parseTemplateCollection({
@@ -2638,7 +2638,7 @@ describe("parse and evaluate template collections", () => {
       })
     })
 
-    it("$merge should correctly merge objects with overlapping property names inside $forEach loop", () => {
+    it("merge operator should correctly merge objects with overlapping property names inside $forEach loop", () => {
       const services = [
         {
           "env-overrides": {},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @stefreak, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This is a backport of #7550 for 0.13.

* fix(template): do not throw circular reference error

Fixes a condition we overlooked when implementing the new cross references feature (introduced in https://github.com/garden-io/garden/pull/6814)

In old garden versions, template expressions like
```
variables:
  foo: ${var.foo}
```
where totally normal, as ${var.foo} just referred to a value in the parent context.

With cross referencing in mind, we will try to resolve var.foo in the peer variable context, but if that leads to a circular reference error we fall back to resolving the value in the parent context.

This seems like a good compromise to preserve the new functionality while retaining the behaviour from older garden versions.