### PR TITLE
test: ensure unique namespaces for Pulumi tests to avoid concurrency issues

### DIFF
--- a/plugins/pulumi/test/handlers.ts
+++ b/plugins/pulumi/test/handlers.ts
@@ -68,10 +68,8 @@ describe("pulumi plugin handlers", () => {
         force: false,
       })
       const versionTag = await getStackVersionTag({ log: actionLog, ctx, provider, action })
+      // We do not inspect namespace name here, as we use generated unique values to avoid concurrency issues
       expect(status.state).to.eql("ready")
-
-      // The service outputs should include all pulumi stack outputs for the deployed stack.
-      expect(status.outputs?.namespace).to.eql("pulumi-test")
 
       // The deployed stack should have been tagged with the service version
       expect(versionTag).to.eql(action.versionString())

--- a/plugins/pulumi/test/test-project-k8s/k8s-deployment/garden.yml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-deployment/garden.yml
@@ -11,6 +11,6 @@ spec:
   allowDestroy: true
   pulumiVariables:
     pulumi-k8s-test:orgName: ${var.orgName}
-    pulumi-k8s-test:namespace: pulumi-test-default
+    pulumi-k8s-test:namespace: pulumi-test-default-${uuidv4()}
     pulumi-k8s-test:appName: api-pulumi-variables-override
     pulumi-k8s-test:isMinikube: "true"

--- a/plugins/pulumi/test/test-project-k8s/k8s-namespace-new-module/garden.yml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-namespace-new-module/garden.yml
@@ -9,7 +9,7 @@ cacheStatus: true
 allowDestroy: true
 pulumiVariables:
   pulumi-k8s-test:orgName: ${var.orgName}
-  pulumi-k8s-test:namespace: pulumi-test
+  pulumi-k8s-test:namespace: pulumi-test-${uuidv4()}
   pulumi-k8s-test:isMinikube: "true"
 
 

--- a/plugins/pulumi/test/test-project-k8s/k8s-namespace-new/garden.yml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-namespace-new/garden.yml
@@ -10,5 +10,5 @@ spec:
   allowDestroy: true
   pulumiVariables:
     pulumi-k8s-test:orgName: ${var.orgName}
-    pulumi-k8s-test:namespace: pulumi-test
+    pulumi-k8s-test:namespace: pulumi-test-${uuidv4()}
     pulumi-k8s-test:isMinikube: "true"

--- a/plugins/pulumi/test/test-project-k8s/k8s-namespace/garden.yml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-namespace/garden.yml
@@ -9,7 +9,7 @@ spec:
   allowDestroy: true
   pulumiVariables:
     pulumi-k8s-test:orgName: ${var.orgName}
-    pulumi-k8s-test:namespace: pulumi-test
+    pulumi-k8s-test:namespace: pulumi-test-${uuidv4()}
     pulumi-k8s-test:appName: api-pulumi-variables-override
     pulumi-k8s-test:isMinikube: "true"
 

--- a/plugins/pulumi/test/test-project-k8s/k8s-namespace/varfile3-new-schema.yaml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-namespace/varfile3-new-schema.yaml
@@ -1,4 +1,0 @@
-    test: foo
-    config:
-      pulumi-k8s-test:namespace: pulumi-varfile-ns
-      pulumi-k8s-test:appName: app-name-from-pulumi-varfile

--- a/plugins/pulumi/test/variables.ts
+++ b/plugins/pulumi/test/variables.ts
@@ -70,18 +70,16 @@ describe("pulumi action variables and varfiles", () => {
         force: false,
       })
       const configFile = await loadYamlFile(join(nsActionRoot, "Pulumi.local.yaml"))
-      expect(configFile).to.eql({
-        config: {
-          "pulumi-k8s-test:orgName": "gordon-garden-bot",
-          "pulumi-k8s-test:namespace": "pulumi-test",
-          "pulumi-k8s-test:appName": "api-pulumi-variables-override",
-          "pulumi-k8s-test:isMinikube": "true",
-        },
-        backend: {
-          url: "https://api.pulumi.com",
-        },
+      expect(configFile.backend).to.eql({
+        url: "https://api.pulumi.com",
+      })
+      expect(configFile.config).to.deep.include({
+        "pulumi-k8s-test:orgName": "gordon-garden-bot",
+        "pulumi-k8s-test:appName": "api-pulumi-variables-override",
+        "pulumi-k8s-test:isMinikube": "true",
       })
     })
+
     for (const configType of ["action", "module"]) {
       context(`using ${configType} configs`, () => {
         it("uses a varfile with the new schema and merges varfiles and action variables correctly", async () => {
@@ -95,17 +93,14 @@ describe("pulumi action variables and varfiles", () => {
             force: false,
           })
           const configFile = await loadYamlFile(join(nsNewActionRoot, "Pulumi.local.yaml"))
-          expect(configFile).to.eql({
-            test: "foo",
-            config: {
-              "pulumi-k8s-test:orgName": "gordon-garden-bot",
-              "pulumi-k8s-test:namespace": "pulumi-test",
-              "pulumi-k8s-test:appName": "app-name-from-pulumi-varfile",
-              "pulumi-k8s-test:isMinikube": "true",
-            },
-            backend: {
-              url: "https://api.pulumi.com",
-            },
+          expect(configFile.backend).to.eql({
+            url: "https://api.pulumi.com",
+          })
+          expect(configFile.test).to.eql("foo")
+          expect(configFile.config).to.deep.include({
+            "pulumi-k8s-test:orgName": "gordon-garden-bot",
+            "pulumi-k8s-test:appName": "app-name-from-pulumi-varfile",
+            "pulumi-k8s-test:isMinikube": "true",
           })
         })
       })


### PR DESCRIPTION
**What this PR does / why we need it**:

Back-port ##7443 to 0.13.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
