### PR TITLE
feat(exec): add statusCommand for more efficient exec Build/Test/Run actions

### DIFF
--- a/core/src/plugins/exec/config.ts
+++ b/core/src/plugins/exec/config.ts
@@ -79,6 +79,14 @@ export const artifactsSchema = s
   .default([])
   .describe("A list of artifacts to copy after the run.")
 
+export const execStatusCommandSchema = s.array(s.string()).describe(sdk.util.dedent`
+  The command to run to check the status of the action.
+
+  If this is specified, it is run before the action's \`command\`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the \`command\` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
+
+  If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+`)
+
 export const execRunSpecSchema = execCommonSchema.extend({
   artifacts: artifactsSchema.optional(),
   command: s
@@ -91,6 +99,7 @@ export const execRunSpecSchema = execCommonSchema.extend({
       `
     )
     .example(["npm", "run", "build"]),
+  statusCommand: execStatusCommandSchema.optional(),
   env: s.envVars().default({}).describe(execEnvVarDoc),
 })
 

--- a/core/src/plugins/exec/convert.ts
+++ b/core/src/plugins/exec/convert.ts
@@ -38,6 +38,7 @@ export function prepareExecBuildAction(params: ConvertModuleParams<ExecModule>):
       spec: {
         shell: true, // This keeps the old pre-0.13 behavior
         command: module.spec.build?.command,
+        statusCommand: module.spec.build?.statusCommand,
         env: module.spec.env,
       },
     }
@@ -133,6 +134,7 @@ export async function convertExecModule(params: ConvertModuleParams<ExecModule>)
       spec: {
         shell: true, // This keeps the old pre-0.13 behavior
         command: task.spec.command,
+        statusCommand: task.spec.statusCommand,
         artifacts: task.spec.artifacts,
         env: prepareEnv(task.spec.env),
       },
@@ -154,6 +156,7 @@ export async function convertExecModule(params: ConvertModuleParams<ExecModule>)
       spec: {
         shell: true, // This keeps the old pre-0.13 behavior
         command: test.spec.command,
+        statusCommand: test.spec.statusCommand,
         artifacts: test.spec.artifacts,
         env: prepareEnv(test.spec.env),
       },

--- a/core/src/plugins/exec/moduleConfig.ts
+++ b/core/src/plugins/exec/moduleConfig.ts
@@ -182,6 +182,7 @@ export const execServiceSchema = () =>
 
 export interface ExecTestSpec extends BaseTestSpec {
   command: string[]
+  statusCommand?: string[]
   env: { [key: string]: string }
   artifacts?: ArtifactSpec[]
 }
@@ -200,6 +201,18 @@ export const execTestSchema = () =>
           `
         )
         .required(),
+      statusCommand: joi
+        .sparseArray()
+        .items(joi.string().allow(""))
+        .description(
+          dedent`
+          The command to run to check the status of the test.
+
+          If this is specified, it is run before the \`command\`. If the status command runs successfully and returns exit code of 0, the test is considered already complete and the \`command\` is not run. To indicate that the test is not complete, the status command should return a non-zero exit code.
+
+          ${execPathDoc}
+          `
+        ),
       env: joiEnvVars().description("Environment variables to set when running the command."),
       artifacts: artifactsSchema().description("A list of artifacts to copy after the test run."),
     })
@@ -208,6 +221,7 @@ export const execTestSchema = () =>
 export interface ExecTaskSpec extends BaseTaskSpec {
   artifacts?: ArtifactSpec[]
   command: string[]
+  statusCommand?: string[]
   env: { [key: string]: string }
 }
 
@@ -228,12 +242,25 @@ export const execTaskSpecSchema = createSchema({
         `
       )
       .required(),
+    statusCommand: joi
+      .sparseArray()
+      .items(joi.string().allow(""))
+      .description(
+        dedent`
+        The command to run to check the status of the task.
+
+        If this is specified, it is run before the \`command\`. If the status command runs successfully and returns exit code of 0, the task is considered already complete and the \`command\` is not run. To indicate that the task is not complete, the status command should return a non-zero exit code.
+
+        ${execPathDoc}
+        `
+      ),
     env: joiEnvVars().description("Environment variables to set when running the command."),
   }),
 })
 
 interface ExecModuleBuildSpec {
   command: string[]
+  statusCommand?: string[]
 }
 
 export interface ExecModuleSpec extends ModuleSpec {
@@ -259,6 +286,15 @@ export const execModuleBuildSpecSchema = createSchema({
       `
       )
       .example(["npm", "run", "build"]),
+    statusCommand: joiArray(joi.string()).description(
+      dedent`
+        The command to run to check the status of the build.
+
+        If this is specified, it is run before the build \`command\`. If the status command runs successfully and returns exit code of 0, the build is considered already complete and the \`command\` is not run. To indicate that the build is not complete, the status command should return a non-zero exit code.
+
+        ${execPathDoc}
+        `
+    ),
   }),
 })
 

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -11,7 +11,7 @@ import { renderMessageWithDivider } from "../../logger/util.js"
 import type { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType } from "../../plugin/sdk.js"
 import { sdk } from "../../plugin/sdk.js"
 import { styles } from "../../logger/styles.js"
-import { copyArtifacts, execRunCommand } from "./common.js"
+import { copyArtifacts, execGetResultHandler, execRunCommand } from "./common.js"
 import { execRunSpecSchema, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config.js"
 import { execProvider } from "./exec.js"
 import { InternalError } from "../../exceptions.js"
@@ -105,3 +105,5 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
 
   return result
 })
+
+execRun.addHandler("getResult", execGetResultHandler)

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -11,7 +11,7 @@ import { renderMessageWithDivider } from "../../logger/util.js"
 import type { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType } from "../../plugin/sdk.js"
 import { sdk } from "../../plugin/sdk.js"
 import { styles } from "../../logger/styles.js"
-import { copyArtifacts, execRunCommand } from "./common.js"
+import { copyArtifacts, execGetResultHandler, execRunCommand } from "./common.js"
 import { execRunSpecSchema, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config.js"
 import { execProvider } from "./exec.js"
 import { InternalError } from "../../exceptions.js"
@@ -107,3 +107,5 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
 
   return result
 })
+
+execTest.addHandler("getResult", execGetResultHandler)

--- a/core/test/data/test-project-exec/run-status.garden.yml
+++ b/core/test/data/test-project-exec/run-status.garden.yml
@@ -1,0 +1,44 @@
+kind: Module
+name: module-run-status
+type: exec
+build:
+  command: [touch module-built.log && echo built]
+  statusCommand: [test -f module-built.log && echo already built]
+tasks:
+  - name: module-run-status-task
+    command: [touch module-task-done.log && echo task done]
+    statusCommand: [test -f module-task-done.log && echo already done]
+tests:
+  - name: unit
+    command: [touch module-test-done.log && echo test done]
+    statusCommand: [test -f module-test-done.log && echo already done]
+
+---
+
+kind: Build
+type: exec
+name: build-status
+spec:
+  shell: true
+  command: [touch build-done.log && echo build done]
+  statusCommand: [test -f build-done.log && echo already done]
+
+---
+
+kind: Run
+type: exec
+name: run-status
+spec:
+  shell: true
+  command: [touch run-done.log && echo run done]
+  statusCommand: [test -f run-done.log && echo already done]
+
+---
+
+kind: Test
+type: exec
+name: test-status
+spec:
+  shell: true
+  command: [touch test-done.log && echo test done]
+  statusCommand: [test -f test-done.log && echo already done]

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -5293,9 +5293,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-0caa1284cd"
-      const moduleBVersionString = "v-18fd5b86c0"
-      const moduleCVersionString = "v-c8700eabbf"
+      const moduleAVersionString = "v-e9654e4f83"
+      const moduleBVersionString = "v-1181dd3716"
+      const moduleCVersionString = "v-efb183be26"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -334,7 +334,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot, { noCache: true })
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-0caa1284cd"
+    const fixedVersionString = "v-e9654e4f83"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -424,6 +424,20 @@ Example: `["npm","run","build"]`
 | ------- | ------- | -------- |
 | `array` | `[]`    | No       |
 
+### `spec.statusCommand[]`
+
+[spec](#spec) > statusCommand
+
+The command to run to check the status of the action.
+
+If this is specified, it is run before the action's `command`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the `command` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
+
+If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
 ### `spec.env`
 
 [spec](#spec) > env

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -403,6 +403,20 @@ Example: `["npm","run","build"]`
 | ------- | -------- |
 | `array` | Yes      |
 
+### `spec.statusCommand[]`
+
+[spec](#spec) > statusCommand
+
+The command to run to check the status of the action.
+
+If this is specified, it is run before the action's `command`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the `command` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
+
+If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
 ### `spec.env`
 
 [spec](#spec) > env

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -403,6 +403,20 @@ Example: `["npm","run","build"]`
 | ------- | -------- |
 | `array` | Yes      |
 
+### `spec.statusCommand[]`
+
+[spec](#spec) > statusCommand
+
+The command to run to check the status of the action.
+
+If this is specified, it is run before the action's `command`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the `command` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
+
+If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
 ### `spec.env`
 
 [spec](#spec) > env

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -65,6 +65,16 @@ build:
   # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
   command: []
 
+  # The command to run to check the status of the build.
+  #
+  # If this is specified, it is run before the build `command`. If the status command runs successfully and returns
+  # exit code of 0, the build is considered already complete and the `command` is not run. To indicate that the build
+  # is not complete, the status command should return a non-zero exit code.
+  #
+  # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+  # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
+  statusCommand: []
+
 # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
 # instead of in the Garden build directory (under .garden/build/<module-name>).
 #
@@ -302,6 +312,16 @@ tasks:
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     command:
 
+    # The command to run to check the status of the task.
+    #
+    # If this is specified, it is run before the `command`. If the status command runs successfully and returns exit
+    # code of 0, the task is considered already complete and the `command` is not run. To indicate that the task is
+    # not complete, the status command should return a non-zero exit code.
+    #
+    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
+    statusCommand:
+
     # Environment variables to set when running the command.
     env: {}
 
@@ -328,6 +348,16 @@ tests:
     # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     command:
+
+    # The command to run to check the status of the test.
+    #
+    # If this is specified, it is run before the `command`. If the status command runs successfully and returns exit
+    # code of 0, the test is considered already complete and the `command` is not run. To indicate that the test is
+    # not complete, the status command should return a non-zero exit code.
+    #
+    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
+    statusCommand:
 
     # Environment variables to set when running the command.
     env: {}
@@ -479,6 +509,21 @@ build:
     - run
     - build
 ```
+
+### `build.statusCommand[]`
+
+[build](#build) > statusCommand
+
+The command to run to check the status of the build.
+
+If this is specified, it is run before the build `command`. If the status command runs successfully and returns exit code of 0, the build is considered already complete and the `command` is not run. To indicate that the build is not complete, the status command should return a non-zero exit code.
+
+By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 ### `local`
 
@@ -940,6 +985,21 @@ If the top level `local` directive is set to `true`, the command runs in the mod
 | --------------- | -------- |
 | `array[string]` | Yes      |
 
+### `tasks[].statusCommand[]`
+
+[tasks](#tasks) > statusCommand
+
+The command to run to check the status of the task.
+
+If this is specified, it is run before the `command`. If the status command runs successfully and returns exit code of 0, the task is considered already complete and the `command` is not run. To indicate that the task is not complete, the status command should return a non-zero exit code.
+
+By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `tasks[].env`
 
 [tasks](#tasks) > env
@@ -1013,6 +1073,21 @@ If the top level `local` directive is set to `true`, the command runs in the mod
 | Type            | Required |
 | --------------- | -------- |
 | `array[string]` | Yes      |
+
+### `tests[].statusCommand[]`
+
+[tests](#tests) > statusCommand
+
+The command to run to check the status of the test.
+
+If this is specified, it is run before the `command`. If the status command runs successfully and returns exit code of 0, the test is considered already complete and the `command` is not run. To indicate that the test is not complete, the status command should return a non-zero exit code.
+
+By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
 
 ### `tests[].env`
 


### PR DESCRIPTION
This was already supported on exec Deploy actions, now expanded to all exec action kinds. This is useful to avoid unnecessary executions of these actions.

I'll separately add a complete guide on exec actions, once custom exec action outputs have been implemented in a separate PR.
