### PR TITLE
feat(exec): support arbitratry outputs from exec actions

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1578,7 +1578,7 @@ export class Garden {
   /**
    * Add an action config to the context, after validating and calling the appropriate configure plugin handler.
    */
-  protected addRawActionConfig(config: BaseActionConfig) {
+  protected addRawActionConfig(config: BaseActionConfig, overwrite = false) {
     const parentTemplateName = config.internal.templateName
     this.log.silly(
       () =>
@@ -1587,7 +1587,7 @@ export class Garden {
     const key = actionReferenceToString(config)
     const existing = this.actionConfigs[config.kind][config.name]
 
-    if (existing) {
+    if (existing && !overwrite) {
       // Resolve the actual values of the `disabled` flag
       config.disabled = this.evaluateDisabledFlag(config)
       existing.disabled = this.evaluateDisabledFlag(existing)

--- a/core/src/plugins/exec/build.ts
+++ b/core/src/plugins/exec/build.ts
@@ -83,6 +83,7 @@ export const execBuildHandler = execBuild.addHandler("build", async ({ action, l
     output.detail.fresh = true
     output.detail.buildLog = result.outputLog
     success = result.success
+    output.outputs = result.outputs
   }
 
   if (output.detail?.buildLog) {
@@ -110,10 +111,11 @@ execBuild.addHandler("getStatus", async ({ action, log, ctx }) => {
 
   try {
     const result = await execRunCommand({ command: statusCommand, action, ctx, log })
+
     return {
       state: "ready" as const,
       detail: { runtime: ACTION_RUNTIME_LOCAL, buildLog: result.outputLog },
-      outputs: {},
+      outputs: result.outputs,
     }
   } catch (err) {
     if (!isExpectedStatusCommandError(err)) {

--- a/core/src/plugins/exec/config.ts
+++ b/core/src/plugins/exec/config.ts
@@ -17,7 +17,21 @@ import type { ExecDeploy, ExecDeployConfig } from "./deploy.js"
 
 const s = sdk.schema
 
-export const execPathDoc = dedent`
+export const execCommonCommandDoc = dedent`
+  **Action outputs**
+
+  Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the \`GARDEN_ACTION_OUTPUTS_PATH\` or \`GARDEN_ACTION_OUTPUTS_JSON_PATH\` environment variables.
+
+  If you write a JSON file to \`<GARDEN_ACTION_OUTPUTS_JSON_PATH>\` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.
+
+  You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with \`.\` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to \`<GARDEN_ACTION_OUTPUTS_PATH>/my-output\`, the action outputs will contain a \`my-output\` key with the value \`<contents of my-output.txt>\`.
+
+  It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.
+
+  Note that if you provide a \`statusCommand\`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.
+
+  **Build field**
+
   Note that if a Build is referenced in the \`build\` field, the command will be run from the build directory for that Build action. If that Build has \`buildAtSource: true\` set, the command will be run from the source directory of the Build action. If no \`build\` reference is set, the command is run from the source directory of this action.
 `
 export const execEnvVarDoc = "Environment variables to set when running the command."
@@ -85,6 +99,8 @@ export const execStatusCommandSchema = s.array(s.string()).describe(sdk.util.ded
   If this is specified, it is run before the action's \`command\`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the \`command\` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
 
   If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+
+  Action outputs are also read from the directory after the status command is run (if the status is "ready"). If your action command writes outputs when run, you'll need to ensure that the outputs are consistent between the status command and the main command, to avoid unexpected results.
 `)
 
 export const execRunSpecSchema = execCommonSchema.extend({
@@ -95,7 +111,7 @@ export const execRunSpecSchema = execCommonSchema.extend({
       sdk.util.dedent`
         The command to run.
 
-        ${execPathDoc}
+        ${execCommonCommandDoc}
       `
     )
     .example(["npm", "run", "build"]),

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -80,11 +80,7 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
   const result = {
     state: runResultToActionState(detail),
     detail,
-    outputs: {
-      log: commandResult.outputLog,
-      stdout: commandResult.stdout,
-      stderr: commandResult.stderr,
-    },
+    outputs: commandResult.outputs,
   } as const
 
   if (!commandResult.success) {

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -82,11 +82,7 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
   const result = {
     state: runResultToActionState(detail),
     detail,
-    outputs: {
-      log: commandResult.outputLog,
-      stdout: commandResult.stdout,
-      stderr: commandResult.stderr,
-    },
+    outputs: commandResult.outputs,
   } as const
 
   if (!commandResult.success) {

--- a/core/test/unit/src/commands/build.ts
+++ b/core/test/unit/src/commands/build.ts
@@ -57,6 +57,8 @@ describe("BuildCommand", () => {
         state: "ready",
         outputs: {
           log: "A",
+          stdout: "A",
+          stderr: "",
         },
         detail: { fresh: true, buildLog: "A" },
         version: versionA,
@@ -65,6 +67,8 @@ describe("BuildCommand", () => {
         state: "ready",
         outputs: {
           log: "B",
+          stdout: "B",
+          stderr: "",
         },
         detail: { fresh: true, buildLog: "B" },
         version: versionB,

--- a/core/test/unit/src/plugins/exec/common.ts
+++ b/core/test/unit/src/plugins/exec/common.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { join } from "path"
+import { getRootLogger } from "../../../../../src/logger/logger.js"
+import { execOutputsJsonFilename, execRunCommand, readExecOutputs } from "../../../../../src/plugins/exec/common.js"
+import tmp from "tmp-promise"
+import fsExtra from "fs-extra"
+import { expect } from "chai"
+import type { TestGarden } from "../../../../helpers.js"
+import { expectError, getDataDir, makeTestGarden } from "../../../../helpers.js"
+import type { PluginContext } from "../../../../../src/plugin-context.js"
+import type { Log } from "../../../../../src/logger/log-entry.js"
+import { dedent } from "../../../../../src/util/string.js"
+
+const { mkdirp, writeFile } = fsExtra
+
+describe("readExecOutputs", () => {
+  let tmpDir: tmp.DirectoryResult
+
+  const log = getRootLogger().createLog()
+
+  beforeEach(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+  })
+
+  afterEach(async () => {
+    await tmpDir.cleanup()
+  })
+
+  it("reads JSON outputs", async () => {
+    const expected = { foo: "bar" }
+    await writeFile(join(tmpDir.path, execOutputsJsonFilename), JSON.stringify(expected))
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql(expected)
+  })
+
+  it("reads outputs from files", async () => {
+    const pathA = join(tmpDir.path, "foo")
+    await writeFile(pathA, "bar")
+    const pathB = join(tmpDir.path, "baz")
+    await writeFile(pathB, "qux")
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({ foo: "bar", baz: "qux" })
+  })
+
+  it("ignores disallowed keys in file outputs", async () => {
+    const pathA = join(tmpDir.path, "log")
+    await writeFile(pathA, "bar")
+    const pathB = join(tmpDir.path, "stdout")
+    await writeFile(pathB, "qux")
+    const pathC = join(tmpDir.path, "stderr")
+    await writeFile(pathC, "qux")
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("ignores disallowed keys in JSON outputs", async () => {
+    const jsonPath = join(tmpDir.path, execOutputsJsonFilename)
+    await writeFile(jsonPath, JSON.stringify({ log: "bar", stdout: "qux", stderr: "qux" }))
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("ignores files starting with a dot", async () => {
+    const pathA = join(tmpDir.path, ".foo")
+    await writeFile(pathA, "bar")
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("ignores files that are not valid output keys", async () => {
+    const pathA = join(tmpDir.path, "foo.bar")
+    await writeFile(pathA, "bar")
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("ignores files that are not valid output keys in JSON outputs", async () => {
+    const jsonPath = join(tmpDir.path, execOutputsJsonFilename)
+    await writeFile(jsonPath, JSON.stringify({ "foo.bar": "baz" }))
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("ignores directories", async () => {
+    const pathA = join(tmpDir.path, "foo")
+    await mkdirp(pathA)
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("ignores non-primitive values in JSON outputs", async () => {
+    const expected = { foo: { bar: "baz" } }
+    await writeFile(join(tmpDir.path, execOutputsJsonFilename), JSON.stringify(expected))
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({})
+  })
+
+  it("overrides JSON outputs with file outputs", async () => {
+    const expected = { foo: "bar" }
+    await writeFile(join(tmpDir.path, execOutputsJsonFilename), JSON.stringify(expected))
+    const pathA = join(tmpDir.path, "foo")
+    await writeFile(pathA, "baz")
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql({ foo: "baz" })
+  })
+
+  it("throws if the outputs JSON file is not a valid JSON object/map", async () => {
+    const jsonPath = join(tmpDir.path, execOutputsJsonFilename)
+    await writeFile(jsonPath, "not a valid JSON object/map")
+
+    await expectError(() => readExecOutputs(log, tmpDir.path), {
+      contains: `Outputs JSON file ${jsonPath} is not a valid JSON object/map`,
+    })
+  })
+
+  it("throws if the outputs JSON file contains an array", async () => {
+    const jsonPath = join(tmpDir.path, execOutputsJsonFilename)
+    await writeFile(jsonPath, JSON.stringify(["foo", "bar"]))
+
+    await expectError(() => readExecOutputs(log, tmpDir.path), {
+      contains: `Outputs JSON file ${jsonPath} is not a valid JSON object/map`,
+    })
+  })
+
+  it("returns an empty object if the outputs directory does not exist", async () => {
+    const outputs = await readExecOutputs(log, join(tmpDir.path, "does-not-exist"))
+
+    expect(outputs).to.eql({})
+  })
+
+  it("allows non-string values in JSON outputs", async () => {
+    const expected = { foo: 123, bar: true, baz: null }
+    await writeFile(join(tmpDir.path, execOutputsJsonFilename), JSON.stringify(expected))
+
+    const outputs = await readExecOutputs(log, tmpDir.path)
+
+    expect(outputs).to.eql(expected)
+  })
+})
+
+describe("execRunCommand", () => {
+  let garden: TestGarden
+  let log: Log
+  let ctx: PluginContext
+
+  before(async () => {
+    garden = await makeTestGarden(getDataDir("test-project-exec"))
+    const execProvider = await garden.resolveProvider({ log: garden.log, name: "exec" })
+    ctx = await garden.getPluginContext({ provider: execProvider, templateContext: undefined, events: undefined })
+    // graph = await garden.getResolvedConfigGraph({ log: garden.log, emit: false })
+    log = garden.log
+    // router = await garden.getActionRouter()
+  })
+
+  after(async () => {
+    garden?.close()
+  })
+
+  it("runs a command", async () => {
+    const command = ["echo", "hello"]
+    const action = await garden.addAndResolveAction(
+      {
+        kind: "Run",
+        type: "exec",
+        name: "test",
+        spec: {
+          command,
+        },
+      },
+      true
+    )
+
+    const result = await execRunCommand({
+      command,
+      ctx,
+      action,
+      log,
+    })
+
+    expect(result.outputLog).to.equal("hello")
+  })
+
+  it("runs a command with a shell", async () => {
+    const command = ["echo hello"]
+    const action = await garden.addAndResolveAction(
+      {
+        kind: "Run",
+        type: "exec",
+        name: "test",
+        spec: {
+          command,
+          shell: true,
+        },
+      },
+      true
+    )
+
+    const result = await execRunCommand({
+      command,
+      ctx,
+      action,
+      log,
+    })
+
+    expect(result.outputLog).to.equal("hello")
+  })
+
+  it("gathers outputs from files", async () => {
+    const command = [
+      dedent`
+        echo "hello" > $GARDEN_ACTION_OUTPUTS_PATH/foo
+        echo "world" > $GARDEN_ACTION_OUTPUTS_PATH/bar
+      `,
+    ]
+    const action = await garden.addAndResolveAction(
+      {
+        kind: "Run",
+        type: "exec",
+        name: "test",
+        spec: {
+          shell: true,
+          command,
+        },
+      },
+      true
+    )
+
+    const result = await execRunCommand({
+      command,
+      ctx,
+      action,
+      log,
+    })
+
+    expect(result.outputs).to.eql({ foo: "hello", bar: "world", log: "", stdout: "", stderr: "" })
+  })
+
+  it("gathers outputs from JSON file", async () => {
+    const command = [
+      dedent`
+        echo '{"foo": "hello", "bar": "world"}' > $GARDEN_ACTION_JSON_OUTPUTS_PATH
+      `,
+    ]
+    const action = await garden.addAndResolveAction(
+      {
+        kind: "Run",
+        type: "exec",
+        name: "test",
+        spec: {
+          shell: true,
+          command,
+        },
+      },
+      true
+    )
+
+    const result = await execRunCommand({
+      command,
+      ctx,
+      action,
+      log,
+    })
+
+    expect(result.outputs).to.eql({ foo: "hello", bar: "world", log: "", stdout: "", stderr: "" })
+  })
+})

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -434,6 +434,8 @@ If this is specified, it is run before the action's `command`. If the status com
 
 If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
 
+Action outputs are also read from the directory after the status command is run (if the status is "ready"). If your action command writes outputs when run, you'll need to ensure that the outputs are consistent between the status command and the main command, to avoid unexpected results.
+
 | Type    | Required |
 | ------- | -------- |
 | `array` | No       |

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -379,6 +379,20 @@ If this is set to true, it is highly recommended to also define `statusCommand` 
 
 The command to run to perform the deployment.
 
+**Action outputs**
+
+Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the `GARDEN_ACTION_OUTPUTS_PATH` or `GARDEN_ACTION_OUTPUTS_JSON_PATH` environment variables.
+
+If you write a JSON file to `<GARDEN_ACTION_OUTPUTS_JSON_PATH>` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.
+
+You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with `.` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to `<GARDEN_ACTION_OUTPUTS_PATH>/my-output`, the action outputs will contain a `my-output` key with the value `<contents of my-output.txt>`.
+
+It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.
+
+Note that if you provide a `statusCommand`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.
+
+**Build field**
+
 Note that if a Build is referenced in the `build` field, the command will be run from the build directory for that Build action. If that Build has `buildAtSource: true` set, the command will be run from the source directory of the Build action. If no `build` reference is set, the command is run from the source directory of this action.
 
 | Type    | Required |
@@ -395,6 +409,20 @@ If this is not specified, the deployment is always reported as "unknown", so it'
 
 If `persistent: true`, Garden will run this command at an interval until it returns a zero exit code or times out.
 
+**Action outputs**
+
+Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the `GARDEN_ACTION_OUTPUTS_PATH` or `GARDEN_ACTION_OUTPUTS_JSON_PATH` environment variables.
+
+If you write a JSON file to `<GARDEN_ACTION_OUTPUTS_JSON_PATH>` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.
+
+You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with `.` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to `<GARDEN_ACTION_OUTPUTS_PATH>/my-output`, the action outputs will contain a `my-output` key with the value `<contents of my-output.txt>`.
+
+It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.
+
+Note that if you provide a `statusCommand`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.
+
+**Build field**
+
 Note that if a Build is referenced in the `build` field, the command will be run from the build directory for that Build action. If that Build has `buildAtSource: true` set, the command will be run from the source directory of the Build action. If no `build` reference is set, the command is run from the source directory of this action.
 
 | Type    | Required |
@@ -406,6 +434,20 @@ Note that if a Build is referenced in the `build` field, the command will be run
 [spec](#spec) > cleanupCommand
 
 Optionally set a command to clean the deployment up, e.g. when running `garden delete env`.
+
+**Action outputs**
+
+Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the `GARDEN_ACTION_OUTPUTS_PATH` or `GARDEN_ACTION_OUTPUTS_JSON_PATH` environment variables.
+
+If you write a JSON file to `<GARDEN_ACTION_OUTPUTS_JSON_PATH>` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.
+
+You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with `.` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to `<GARDEN_ACTION_OUTPUTS_PATH>/my-output`, the action outputs will contain a `my-output` key with the value `<contents of my-output.txt>`.
+
+It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.
+
+Note that if you provide a `statusCommand`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.
+
+**Build field**
 
 Note that if a Build is referenced in the `build` field, the command will be run from the build directory for that Build action. If that Build has `buildAtSource: true` set, the command will be run from the source directory of the Build action. If no `build` reference is set, the command is run from the source directory of this action.
 

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -395,6 +395,20 @@ A POSIX-style path to copy the artifacts to, relative to the project artifacts d
 
 The command to run.
 
+**Action outputs**
+
+Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the `GARDEN_ACTION_OUTPUTS_PATH` or `GARDEN_ACTION_OUTPUTS_JSON_PATH` environment variables.
+
+If you write a JSON file to `<GARDEN_ACTION_OUTPUTS_JSON_PATH>` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.
+
+You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with `.` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to `<GARDEN_ACTION_OUTPUTS_PATH>/my-output`, the action outputs will contain a `my-output` key with the value `<contents of my-output.txt>`.
+
+It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.
+
+Note that if you provide a `statusCommand`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.
+
+**Build field**
+
 Note that if a Build is referenced in the `build` field, the command will be run from the build directory for that Build action. If that Build has `buildAtSource: true` set, the command will be run from the source directory of the Build action. If no `build` reference is set, the command is run from the source directory of this action.
 
 Example: `["npm","run","build"]`
@@ -412,6 +426,8 @@ The command to run to check the status of the action.
 If this is specified, it is run before the action's `command`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the `command` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
 
 If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+
+Action outputs are also read from the directory after the status command is run (if the status is "ready"). If your action command writes outputs when run, you'll need to ensure that the outputs are consistent between the status command and the main command, to avoid unexpected results.
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -395,6 +395,20 @@ A POSIX-style path to copy the artifacts to, relative to the project artifacts d
 
 The command to run.
 
+**Action outputs**
+
+Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the `GARDEN_ACTION_OUTPUTS_PATH` or `GARDEN_ACTION_OUTPUTS_JSON_PATH` environment variables.
+
+If you write a JSON file to `<GARDEN_ACTION_OUTPUTS_JSON_PATH>` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.
+
+You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with `.` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to `<GARDEN_ACTION_OUTPUTS_PATH>/my-output`, the action outputs will contain a `my-output` key with the value `<contents of my-output.txt>`.
+
+It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.
+
+Note that if you provide a `statusCommand`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.
+
+**Build field**
+
 Note that if a Build is referenced in the `build` field, the command will be run from the build directory for that Build action. If that Build has `buildAtSource: true` set, the command will be run from the source directory of the Build action. If no `build` reference is set, the command is run from the source directory of this action.
 
 Example: `["npm","run","build"]`
@@ -412,6 +426,8 @@ The command to run to check the status of the action.
 If this is specified, it is run before the action's `command`. If the status command runs successfully and returns exit code of 0, the action is considered already complete and the `command` is not run. To indicate that the action is not complete, the status command should return a non-zero exit code.
 
 If this is not specified, the status is always reported as "unknown", so specifying this can be useful to avoid running the action unnecessarily.
+
+Action outputs are also read from the directory after the status command is run (if the status is "ready"). If your action command writes outputs when run, you'll need to ensure that the outputs are consistent between the status command and the main command, to avoid unexpected results.
 
 | Type    | Required |
 | ------- | -------- |


### PR DESCRIPTION
From the docs:

---
Exec actions can write outputs to a JSON file or a directory. The action command is provided with the path to the outputs directory or JSON file via the `GARDEN_ACTION_OUTPUTS_PATH` or `GARDEN_ACTION_OUTPUTS_JSON_PATH` environment variables.

If you write a JSON file to `<GARDEN_ACTION_OUTPUTS_JSON_PATH>` this file will be read and its contents will be used as the action outputs. Nested JSON objects are not supported. Only the top-level key-value pairs, where values are primitive types (string, number, boolean, null), will be used.

You can also write outputs to files in the directory. In this scenario, each file with a valid identifier as a filename (this excludes paths starting with `.` for example) in the directory will be read and its filename will be added as the key in the action outputs, with the contents of the file as the value. Sub-directories are not supported and will be ignored. For example, if you write some string to `<GARDEN_ACTION_OUTPUTS_PATH>/my-output`, the action outputs will contain a `my-output` key with the value `<contents of my-output.txt>`.

It is allowed to mix and match between the two approaches. In that scenario the JSON file will be read first, and any additional valid filenames in the directory will be added as additional action outputs, overriding keys in the JSON file if they overlap.

Note that if you provide a `statusCommand`, the outputs will also be read from the directory after the status command is run. You'll need to ensure that the outputs are consistent between the status command and the command that is run, to avoid unexpected results.

---
