### PR TITLE
feat(config): add project-level excludeValuesFromActionVersions field

### DIFF
--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -111,6 +111,7 @@ export class PluginsCommand extends Command<Args> {
       actions: [],
       moduleGraph: new ModuleGraph({ modules: [], moduleTypes: {} }),
       groups: [],
+      excludeValuesFromActionVersions: await garden.getExcludeValuesForActionVersions(),
     })
 
     // Commands can optionally ask for all the modules in the project/environment

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -416,3 +416,5 @@ export class RemoteSourceConfigContext extends EnvironmentConfigContext {
     this.variables = this.var = variables
   }
 }
+
+export class ExcludeValuesFromActionVersionsContext extends RemoteSourceConfigContext {}

--- a/core/src/docs/generate.ts
+++ b/core/src/docs/generate.ts
@@ -91,6 +91,7 @@ export async function writeConfigReferenceDocs(
         },
         defaultEnvironment,
         dotIgnoreFile: defaultDotIgnoreFile,
+        excludeValuesFromActionVersions: [],
         variablesFrom: [],
         variables: {},
         environments: [

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1306,7 +1306,7 @@ export class Garden {
     })
   }
 
-  // @Memoize(() => true)
+  @pMemoizeDecorator()
   async getExcludeValuesForActionVersions(): Promise<string[]> {
     const context = new ExcludeValuesFromActionVersionsContext(this, this.variables)
     const source = { yamlDoc: this.projectConfig.internal.yamlDoc, path: ["excludeValuesFromActionVersions"] }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -113,6 +113,7 @@ import { resolveConfigTemplate } from "./config/config-template.js"
 import type { TemplatedModuleConfig } from "./plugins/templated.js"
 import {
   DefaultEnvironmentContext,
+  ExcludeValuesFromActionVersionsContext,
   ProjectConfigContext,
   RemoteSourceConfigContext,
 } from "./config/template-contexts/project.js"
@@ -1301,7 +1302,20 @@ export class Garden {
       moduleGraph: graph.moduleGraph,
       // TODO: perhaps groups should be resolved here
       groups: graph.getGroups(),
+      excludeValuesFromActionVersions: await this.getExcludeValuesForActionVersions(),
     })
+  }
+
+  // @Memoize(() => true)
+  async getExcludeValuesForActionVersions(): Promise<string[]> {
+    const context = new ExcludeValuesFromActionVersionsContext(this, this.variables)
+    const source = { yamlDoc: this.projectConfig.internal.yamlDoc, path: ["excludeValuesFromActionVersions"] }
+    const evaluated = deepEvaluate(this.projectConfig.excludeValuesFromActionVersions, { context, opts: {} })
+    const resolved = validateSchema<string[]>(evaluated, joi.array().items(joi.string()), {
+      context: "excludeValuesFromActionVersions",
+      source,
+    })
+    return resolved
   }
 
   @OtelTraced({
@@ -2349,10 +2363,11 @@ export async function makeDummyGarden(root: string, gardenOpts: GardenOpts) {
     },
     defaultEnvironment: "",
     dotIgnoreFile: defaultDotIgnoreFile,
-    variablesFrom: [],
+    excludeValuesFromActionVersions: [],
     environments: [{ name: environmentName, defaultNamespace: _defaultNamespace, variables: {} }],
     providers: [],
     variables: {},
+    variablesFrom: [],
   }
   gardenOpts.config = config
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -286,6 +286,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
     actions: [],
     moduleGraph,
     groups: groupConfigs,
+    excludeValuesFromActionVersions: await garden.getExcludeValuesForActionVersions(),
   })
 
   let batchNo = 1

--- a/core/src/graph/config-graph.ts
+++ b/core/src/graph/config-graph.ts
@@ -94,17 +94,20 @@ export abstract class BaseConfigGraph<
 
   readonly moduleGraph: ModuleGraph
   readonly environmentName: string
+  readonly excludeValuesFromActionVersions: string[]
 
   constructor({
     environmentName,
     actions,
     moduleGraph,
     groups,
+    excludeValuesFromActionVersions,
   }: {
     environmentName: string
     actions: Action[]
     moduleGraph: ModuleGraph
     groups: GroupConfig[]
+    excludeValuesFromActionVersions: string[]
   }) {
     this.environmentName = environmentName
     this.dependencyGraph = {}
@@ -116,6 +119,7 @@ export abstract class BaseConfigGraph<
     }
     this.groups = {}
     this.moduleGraph = moduleGraph
+    this.excludeValuesFromActionVersions = excludeValuesFromActionVersions
 
     for (const action of actions) {
       this.addActionInternal(action)
@@ -467,6 +471,7 @@ export abstract class BaseConfigGraph<
       actions: this.getActions(),
       moduleGraph: this.moduleGraph,
       groups: Object.values(this.groups),
+      excludeValuesFromActionVersions: this.excludeValuesFromActionVersions,
     })
   }
 

--- a/core/src/tasks/resolve-action.ts
+++ b/core/src/tasks/resolve-action.ts
@@ -236,6 +236,7 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
       actions: [...resolvedDependencies, ...executedDependencies],
       moduleGraph: this.graph.moduleGraph,
       groups: this.graph.getGroups(),
+      excludeValuesFromActionVersions: this.graph.excludeValuesFromActionVersions,
     })
 
     const resolvedAction = actionToResolved(action, {

--- a/core/test/data/test-projects/project-exclude-values/actions.garden.yml
+++ b/core/test/data/test-projects/project-exclude-values/actions.garden.yml
@@ -1,0 +1,5 @@
+kind: Test
+type: test
+name: test
+spec:
+  command: [echo, "${var.hostname}"]

--- a/core/test/data/test-projects/project-exclude-values/project.garden.yml
+++ b/core/test/data/test-projects/project-exclude-values/project.garden.yml
@@ -1,0 +1,14 @@
+apiVersion: garden.io/v2
+kind: Project
+name: project-exclude-values
+environments:
+  - name: a
+    variables:
+      hostname: a.example.com
+  - name: b
+    variables:
+      hostname: b.example.com
+excludeValuesFromActionVersions:
+  - ${var.hostname}
+providers:
+  - name: test-plugin

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -113,6 +113,7 @@ export const getDefaultProjectConfig = (): ProjectConfig =>
     },
     defaultEnvironment,
     dotIgnoreFile: defaultDotIgnoreFile,
+    excludeValuesFromActionVersions: [],
     variablesFrom: [],
     environments: [{ name: "default", defaultNamespace, variables: {} }],
     providers: [{ name: "test-plugin" }],

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -61,6 +61,7 @@ describe("resolveProjectConfig", () => {
         basePath: ".",
       },
       environments: [{ name: "default", defaultNamespace: null, variables: {} }],
+      excludeValuesFromActionVersions: [],
       providers: [{ name: "foo" }],
       variables: {},
     }

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -130,6 +130,28 @@ defaultEnvironment: ''
 # for details.
 dotIgnoreFile: .gardenignore
 
+# A list of string values that should be excluded when computing action versions.
+#
+# Setting values here is equivalent to adding them to the `version.excludeValues` field on all actions in the project.
+#
+# These values can be templated, and generally should be templated. A typical example is to exclude the namespace of
+# the environment, or a hostname suffix used across many Deploy actions. For example:
+#
+# excludeValuesFromActionVersions:
+#   - "${var.hostname-suffix}"  # resolving to something like "my-branch.dev.my-org.com"
+#
+# **Important:**
+# You should be careful to not make these values too broad, since the strings will be replaced for every field in all
+# actions across the project when computing versions. For example, if a value here resolves to a short and generic
+# string like "api", the string "api" will be replaced for every field in all actions across the project when
+# computing versions. This could lead to unexpected issues like tests getting skipped when they shouldn't, deployments
+# not updating etc.
+#
+# However, something more specific like a branch name, commit hash, PR number etc., ideally with some specific prefix
+# or suffix, is generally safer to do. That said, this field only affects version computation, not the actual action
+# configuration when it's executed.
+excludeValuesFromActionVersions:
+
 proxy:
   # The URL that Garden uses when creating port forwards. Defaults to "localhost".
   #
@@ -513,6 +535,28 @@ Example:
 ```yaml
 dotIgnoreFile: ".gitignore"
 ```
+
+### `excludeValuesFromActionVersions[]`
+
+A list of string values that should be excluded when computing action versions.
+
+Setting values here is equivalent to adding them to the `version.excludeValues` field on all actions in the project.
+
+These values can be templated, and generally should be templated. A typical example is to exclude the namespace of the environment, or a hostname suffix used across many Deploy actions. For example:
+
+```yaml
+excludeValuesFromActionVersions:
+  - "${var.hostname-suffix}"  # resolving to something like "my-branch.dev.my-org.com"
+```
+
+**Important:**
+You should be careful to not make these values too broad, since the strings will be replaced for every field in all actions across the project when computing versions. For example, if a value here resolves to a short and generic string like "api", the string "api" will be replaced for every field in all actions across the project when computing versions. This could lead to unexpected issues like tests getting skipped when they shouldn't, deployments not updating etc.
+
+However, something more specific like a branch name, commit hash, PR number etc., ideally with some specific prefix or suffix, is generally safer to do. That said, this field only affects version computation, not the actual action configuration when it's executed.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
 
 ### `proxy`
 


### PR DESCRIPTION
This simplifies action version exclusion for larger projects. Effectively this allows adding a set of values to every action's `version.excludeValues`, which can make filtering out ephemeral values much simpler across many actions.

From the Project `excludeValuesFromActionVersions` reference:

---
A list of string values that should be excluded when computing action versions.

Setting values here is equivalent to adding them to the \`version.excludeValues\` field on all actions in the project.

These values can be templated, and generally should be templated. A typical example is to exclude the namespace of the environment, or a hostname suffix used across many Deploy actions. For example:

```yaml
excludeValuesFromActionVersions:
  - "${var.hostname-suffix}"  # resolving to something like "my-branch.dev.my-org.com"
```

**Important:**
You should be careful to not make these values too broad, since the strings will be replaced for every field in all actions across the project when computing versions. For example, if a value here resolves to a short and generic string like "api", the string "api" will be replaced for every field in all actions across the project when computing versions. This could lead to unexpected issues like tests getting skipped when they shouldn't, deployments not updating etc.

However, something more specific like a branch name, commit hash, PR number etc., ideally with some specific prefix or suffix, is generally safer to do. That said, this field only affects version computation, not the actual action configuration when it's executed.

---
