### PR TITLE
feat(config): add version.excludeDependencies to action config

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -45,6 +45,7 @@ export interface ActionSourceSpec {
 }
 
 export interface ActionVersionConfig {
+  excludeDependencies?: ActionReference[]
   excludeFields?: (string | number)[][]
   excludeValues?: string[]
 }

--- a/core/test/data/test-projects/version-exclude-dependencies/actions.garden.yml
+++ b/core/test/data/test-projects/version-exclude-dependencies/actions.garden.yml
@@ -1,0 +1,26 @@
+kind: Build
+type: test
+name: test
+include: []
+spec:
+  command: ["echo"]
+---
+kind: Run
+type: test
+name: prepare
+include: ["*.log"]
+spec:
+  command: ["echo"]
+---
+kind: Test
+type: test
+name: test
+include: []
+dependencies:
+  - run.prepare
+  - build.test
+version:
+  excludeDependencies:
+    - run.prepare
+spec:
+  command: ["echo"]

--- a/core/test/data/test-projects/version-exclude-dependencies/project.garden.yml
+++ b/core/test/data/test-projects/version-exclude-dependencies/project.garden.yml
@@ -1,0 +1,7 @@
+apiVersion: garden.io/v2
+kind: Project
+name: version-exclude-dependencies
+environments:
+  - name: default
+providers:
+  - name: test-plugin

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -206,6 +206,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -206,6 +206,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -218,6 +218,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -248,6 +248,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -252,6 +252,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -254,6 +254,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -252,6 +252,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -256,6 +256,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -248,6 +248,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -248,6 +248,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -250,6 +250,29 @@ Whether the varfile is optional.
 | -------- | -------- |
 | `object` | No       |
 
+### `version.excludeDependencies[]`
+
+[version](#version) > excludeDependencies
+
+Specify a list of dependencies that should be ignored when computing the version hash for this action.
+
+Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action.
+However, there are cases where you might want to exclude certain dependencies from the version hash.
+
+For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:
+
+```yaml
+version:
+  excludeDependencies:
+    - run.setup
+```
+
+Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+
+| Type                     | Required |
+| ------------------------ | -------- |
+| `array[actionReference]` | No       |
+
 ### `version.excludeFields[]`
 
 [version](#version) > excludeFields

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1910,6 +1910,24 @@ actionConfigs:
           optional:
 
       version:
+        # Specify a list of dependencies that should be ignored when computing the version hash for this action.
+        #
+        # Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing
+        # the version hash for this action.
+        # However, there are cases where you might want to exclude certain dependencies from the version hash.
+        #
+        # For example, you might have a dependency that naturally changes for every individual test or dev
+        # environment, such as a setup script that runs before the test. You could solve for that with something like
+        # this:
+        #
+        # version:
+        #   excludeDependencies:
+        #     - run.setup
+        #
+        # Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each
+        # dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+        excludeDependencies:
+
         # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
         # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
         # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
@@ -2180,6 +2198,24 @@ actionConfigs:
           optional:
 
       version:
+        # Specify a list of dependencies that should be ignored when computing the version hash for this action.
+        #
+        # Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing
+        # the version hash for this action.
+        # However, there are cases where you might want to exclude certain dependencies from the version hash.
+        #
+        # For example, you might have a dependency that naturally changes for every individual test or dev
+        # environment, such as a setup script that runs before the test. You could solve for that with something like
+        # this:
+        #
+        # version:
+        #   excludeDependencies:
+        #     - run.setup
+        #
+        # Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each
+        # dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+        excludeDependencies:
+
         # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
         # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
         # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
@@ -2389,6 +2425,24 @@ actionConfigs:
           optional:
 
       version:
+        # Specify a list of dependencies that should be ignored when computing the version hash for this action.
+        #
+        # Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing
+        # the version hash for this action.
+        # However, there are cases where you might want to exclude certain dependencies from the version hash.
+        #
+        # For example, you might have a dependency that naturally changes for every individual test or dev
+        # environment, such as a setup script that runs before the test. You could solve for that with something like
+        # this:
+        #
+        # version:
+        #   excludeDependencies:
+        #     - run.setup
+        #
+        # Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each
+        # dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+        excludeDependencies:
+
         # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
         # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
         # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.
@@ -2598,6 +2652,24 @@ actionConfigs:
           optional:
 
       version:
+        # Specify a list of dependencies that should be ignored when computing the version hash for this action.
+        #
+        # Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing
+        # the version hash for this action.
+        # However, there are cases where you might want to exclude certain dependencies from the version hash.
+        #
+        # For example, you might have a dependency that naturally changes for every individual test or dev
+        # environment, such as a setup script that runs before the test. You could solve for that with something like
+        # this:
+        #
+        # version:
+        #   excludeDependencies:
+        #     - run.setup
+        #
+        # Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each
+        # dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.
+        excludeDependencies:
+
         # Specify a list of config fields that should be ignored when computing the version hash for this action. Each
         # item should be an array of strings, specifying the path to the field to ignore, e.g. `[spec, env, HOSTNAME]`
         # would ignore `spec.env.HOSTNAME` in the configuration when computing the version.


### PR DESCRIPTION
This allows further control over how action versions are calculated, by excluding certain dependencies of the action from affecting the version.

From the added docs:

---

### `version.excludeDependencies[]`

Specify a list of dependencies that should be ignored when computing the version hash for this action.

Generally, the versions of all dependencies (both implicit and explicitly specified) are used when computing the version hash for this action. However, there are cases where you might want to exclude certain dependencies from the version hash.

For example, you might have a dependency that naturally changes for every individual test or dev environment, such as a setup script that runs before the test. You could solve for that with something like this:

```yaml
version:
  excludeDependencies:
    - run.setup
```

Where `run.setup` refers to a Run action named `setup`. You can also use the full action reference for each dependency to exclude, e.g. `{ kind: "Run", name: "setup" }`.

---
