### PR TITLE
feat: garden diff command, to compare action versions between branches/commits

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -65,6 +65,7 @@
     "dedent": "^1.6.0",
     "deline": "^1.0.4",
     "dependency-graph": "^0.11.0",
+    "diff": "^8.0.2",
     "directory-tree": "^3.5.2",
     "docker-file-parser": "^1.0.7",
     "dotenv": "^16.6.1",

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -605,13 +605,20 @@ export abstract class BaseAction<
     return false
   }
 
-  getDependency<K extends ActionKind>(ref: ActionReference<K>, opts?: GetActionOpts) {
+  getDependencyReference(ref: ActionReference) {
     for (const dep of this.dependencies) {
       if (actionRefMatches(dep, ref)) {
-        return <PickTypeByKind<K, BuildAction, DeployAction, RunAction, TestAction>>this.graph.getActionByRef(ref, opts)
+        return dep
       }
     }
+    return null
+  }
 
+  getDependency<K extends ActionKind>(ref: ActionReference<K>, opts?: GetActionOpts) {
+    const dep = this.getDependencyReference(ref)
+    if (dep) {
+      return <PickTypeByKind<K, BuildAction, DeployAction, RunAction, TestAction>>this.graph.getActionByRef(ref, opts)
+    }
     return null
   }
 

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -142,6 +142,7 @@ export interface ActionStatusMap<T extends BaseAction = BaseAction> {
 
 export interface ActionDependencyAttributes {
   explicit: boolean // Set to true if action config explicitly states the dependency
+  // TODO: also indicate _which_ outputs are required
   needsStaticOutputs: boolean // Set to true if action cannot be resolved without resolving the dependency
   needsExecutedOutputs: boolean // Set to true if action cannot be resolved without the dependency executed
 }

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -23,6 +23,7 @@ import { gardenEnv } from "../constants.js"
 import { envSupportsEmoji } from "../logger/util.js"
 import type { ConfigDump } from "../garden.js"
 import { styles } from "../logger/styles.js"
+import dotenv from "dotenv"
 
 export const OUTPUT_RENDERERS = {
   json: (data: DeepPrimitiveMap) => {
@@ -305,20 +306,44 @@ export class BooleanParameter extends Parameter<boolean> {
   }
 }
 
+export interface Tag {
+  key: string
+  value: string
+}
+
 /**
  * Similar to `StringsOption`, but doesn't split individual option values on `,`
  */
-export class TagsOption extends Parameter<string[] | undefined> {
+export class TagsOption extends Parameter<Tag[][] | undefined> {
   type = "array:tag"
-  schema = joi.array().items(joi.string())
+  schema = joi.array().items(joi.array().items(joi.object().keys({ key: joi.string(), value: joi.string() })))
 
-  override coerce(input?: string | string[]): string[] {
+  override coerce(input?: string | string[]): Tag[][] {
     if (!input) {
       return []
     } else if (!isArray(input)) {
       input = [input]
     }
-    return input
+
+    const parameterErrorMsg = `Unable to parse the given input. Format should be key=value.`
+    const output: Tag[][] = []
+    try {
+      for (const tagGroup of input) {
+        const tags: Tag[] = []
+        for (const t of tagGroup.split(",")) {
+          const parsed = Object.entries(dotenv.parse(t))[0]
+          if (!parsed) {
+            throw new ParameterError({ message: `${parameterErrorMsg}. Got: '${t}'` })
+          }
+          tags.push({ key: parsed[0], value: parsed[1] })
+        }
+        output.push(tags)
+      }
+    } catch {
+      throw new ParameterError({ message: `${parameterErrorMsg}. Got: '${input}'` })
+    }
+
+    return output
   }
 }
 

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -351,11 +351,15 @@ export class EnvironmentParameter extends StringOption {
   override type = "string"
   override schema = joi.environment()
 
-  constructor({ help = "The environment (and optionally namespace) to work against.", required = false } = {}) {
+  constructor({
+    help = "The environment (and optionally namespace) to work against.",
+    required = false,
+    aliases = ["e"],
+  } = {}) {
     super({
       help,
       required,
-      aliases: ["e"],
+      aliases,
       getSuggestions: ({ configDump }) => {
         return configDump.allEnvironmentNames
       },

--- a/core/src/commands/commands.ts
+++ b/core/src/commands/commands.ts
@@ -40,6 +40,7 @@ import { UtilCommand } from "./util/util.js"
 import { ValidateCommand } from "./validate.js"
 import { UpCommand } from "./up.js"
 import { VersionCommand } from "./version.js"
+import { DiffCommand } from "./diff.js"
 
 export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new BuildCommand(),
@@ -50,6 +51,7 @@ export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new DeleteCommand(),
   new DeployCommand(),
   new DevCommand(),
+  new DiffCommand(),
   new ExecCommand(),
   new GetCommand(),
   new LinkCommand(),

--- a/core/src/commands/diff.ts
+++ b/core/src/commands/diff.ts
@@ -154,6 +154,23 @@ When setting the \`--b-X\` flags, the values will be overridden in the compariso
 
 In most cases you should use this with the \`--resolve\` flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the \`--action\` flag to only diff specific actions.
 
+Examples:
+    # compare the current default environment to the ci environment (assuming one is defined in the project configuration)
+    garden diff --b-env ci
+    # compare the current default environment to the ci environment and fully resolve values for a complete comparison (note that this may trigger actions being executed)
+    garden diff --b-env ci --resolve
+    # compare the staging env to the ci env
+    garden diff --env staging --b-env ci
+    # compare the current branch to other-branch (using the default environment in both cases)
+    garden diff --b-branch other-branch
+    # compare the current branch's default environment to other-branch's ci environment
+    garden diff --b-branch other-branch --b-env ci
+    # compare the resolved api Build action between the default environment and ci
+    garden diff --b-env ci --action build.api --resolve
+    # compare the current default environment to the ci environment and override the HOSTNAME variable in the ci environment
+    garden diff --b-env ci --b-var HOSTNAME=remote.acme
+    # compare the current default environment to the ci environment and override the HOSTNAME variable in both environments
+    garden diff --var HOSTNAME=local.acme --b-env ci --b-var HOSTNAME=remote.acme
   `
 
   override arguments = diffArgs

--- a/core/src/commands/diff.ts
+++ b/core/src/commands/diff.ts
@@ -40,28 +40,28 @@ const { readFile } = fsExtra
 const diffArgs = {}
 
 const diffOpts = {
-  "commit": new StringOption({
-    help: "A commit ID to compare with.",
+  "b-commit": new StringOption({
+    help: "Check out the specified commit in the comparison project (B).",
   }),
-  "branch": new StringOption({
-    help: "A branch to compare with.",
+  "b-branch": new StringOption({
+    help: "Check out the specified branch in the comparison project (B).",
   }),
-  "diff-env": new EnvironmentParameter({
-    help: "Override the Garden environment for the comparison.",
+  "b-env": new EnvironmentParameter({
+    help: "Override the Garden environment for the comparison project (B).",
     aliases: [],
   }),
-  "diff-local-env": new TagsOption({
-    help: 'Override a local environment variable in the comparison (as templated using ${local.env.*}) with the specified value, formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". You can specify multiple variables by repeating the flag.',
+  "b-local-env-var": new TagsOption({
+    help: 'Override a local environment variable in the comparison project (B), as templated using ${local.env.*}, with the specified value. This should be formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". You can specify multiple variables by repeating the flag.',
   }),
-  "diff-var": new TagsOption({
-    help: 'Override a variable in the comparison with the specified value, formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". Analogous to the --var global flag in the Garden CLI. You can specify multiple variables by repeating the flag.',
+  "b-var": new TagsOption({
+    help: 'Override a Garden variable in the comparison project (B) with the specified value, formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". Analogous to the --var global flag in the Garden CLI. You can specify multiple variables by repeating the flag.',
   }),
   "resolve": new BooleanParameter({
     help: "Fully resolve each action before comparing. Note that this may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.",
     defaultValue: false,
   }),
   "action": new StringsParameter({
-    help: "Specify an action to diff, as <kind>.<name>. Can be specified multiple times. If none is specified, all actions will be diffed.",
+    help: "Specify an action to diff, as <kind>.<name>. Can be specified multiple times. If none is specified, all actions will be compared.",
     defaultValue: undefined,
   }),
   // TODO: Support comparing with a directory path
@@ -142,15 +142,18 @@ export class DiffCommand extends Command<Args, Opts, DiffResult> {
   override description = dedent`
 **[EXPERIMENTAL] This command is still under development and may change in the future, including parameters and output format.**
 
-Compare the current working directory Garden project with the specified branch or commit.
+Compare the current working directory Garden project with the specified branch/commit, or with other differences (all specified via \`--b-X\` flags).
 
 Use this to understand the impact of your changes on action versions.
 
+In the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
+
+The different \`--b-X\` flags define the comparison project (B). At least one of these flags must be specified, and they can be combined in any number of ways.
+
+When setting the \`--b-X\` flags, the values will be overridden in the comparison project (B). If you want to change variables or set a different environment in the _current_ project (A), you can use the normal \`--var\`, \`--env\` etc. flags. For example, if you want to test the impact of overriding a variable value for both sides, you can use the \`--var\` flag to override the value in the current project (A), and then use the \`--b-var\` flag to override the value in the comparison project (B), e.g. \`--b-var some-var=foo --var some-var=bar\`.
+
 In most cases you should use this with the \`--resolve\` flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the \`--action\` flag to only diff specific actions.
 
-Note that in the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
-
-When setting the \`--diff-X\` flags, the values will be overridden in the comparison project (B). If you want to change variables or set a different environment in the _current_ project (A), you can use the normal \`--var\`, \`--env\` etc. flags. For example, if you want to test the impact of overriding a variable value for both sides, you can use the \`--var\` flag to override the value in the current project (A), and then use the \`--diff-var\` flag to override the value in the comparison project (B), e.g. \`--diff-var some-var=foo --var some-var=bar\`.
   `
 
   override arguments = diffArgs
@@ -173,30 +176,36 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
       }) + "\n"
     )
 
+    const bEnv = opts["b-env"]
+    const bLocalEnvOverrides = opts["b-local-env-var"]
+    const bVariableOverrides = opts["b-var"]
+    const bBranch = opts["b-branch"]
+    const bCommit = opts["b-commit"]
+
     let missingDiffParams = true
 
-    if (opts["diff-env"]) {
+    if (bEnv) {
       missingDiffParams = false
     }
 
-    const comparisonEnv = opts["diff-env"] || `${gardenA.namespace}.${gardenA.environmentName}`
+    const comparisonEnv = bEnv || `${gardenA.namespace}.${gardenA.environmentName}`
 
     let localEnvOverrides: StringMap = {}
-    if (opts["diff-local-env"]) {
-      localEnvOverrides = fromPairs(opts["diff-local-env"].flatMap((group) => group.map((t) => [t.key, t.value])))
+    if (bLocalEnvOverrides) {
+      localEnvOverrides = fromPairs(bLocalEnvOverrides.flatMap((group) => group.map((t) => [t.key, t.value])))
       missingDiffParams = false
     }
 
     let variableOverrides: StringMap = {}
-    if (opts["diff-var"]) {
-      variableOverrides = fromPairs(opts["diff-var"].flatMap((group) => group.map((t) => [t.key, t.value])))
+    if (bVariableOverrides) {
+      variableOverrides = fromPairs(bVariableOverrides.flatMap((group) => group.map((t) => [t.key, t.value])))
       missingDiffParams = false
     }
 
-    if (missingDiffParams && !opts.branch && !opts.commit) {
+    if (missingDiffParams && !bBranch && !bCommit) {
       throw new ParameterError({
         message:
-          "No diff parameters specified. Please specify one or more of --branch, --commit, --diff-env, --diff-local-env, --diff-var.",
+          "No diff parameters specified. Please specify one or more of --branch, --commit, --b-env, --b-local-env, --b-var.",
       })
     }
 
@@ -208,7 +217,7 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
     let commitish: string | null = null
     let projectRootB = gardenA.projectRoot
 
-    if (opts.branch && opts.commit) {
+    if (bBranch && bCommit) {
       throw new ParameterError({ message: "Cannot specify both branch and commit" })
     }
 
@@ -219,8 +228,8 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
           environmentString: comparisonEnv,
           variableOverrides: gardenA.opts.variableOverrides || {},
           localEnvOverrides: gardenA.opts.localEnvOverrides || {},
-          branch: opts.branch,
-          commit: opts.commit,
+          branch: bBranch,
+          commit: bCommit,
         }) +
         "\n"
     )
@@ -233,28 +242,28 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
       log.info({ msg: "Filtering to actions: " + actionsFilter.join(", ") })
     }
 
-    if (opts.branch || opts.commit) {
+    if (bBranch || bCommit) {
       log.info({ msg: "Fetching repo origin" })
 
       // Fetch the repo origin
       await gitCli.exec("fetch", "origin")
     }
 
-    if (opts.branch) {
-      log.info({ msg: "Comparing with branch " + chalk.white.bold(opts.branch) })
+    if (bBranch) {
+      log.info({ msg: "Comparing with branch " + chalk.white.bold(bBranch) })
       try {
-        await gitCli.exec("ls-remote", "--heads", "origin", opts.branch)
-        commitish = opts.branch
+        await gitCli.exec("ls-remote", "--heads", "origin", bBranch)
+        commitish = bBranch
       } catch (e) {
-        throw new ParameterError({ message: "Could not find branch " + chalk.white.bold(opts.branch) })
+        throw new ParameterError({ message: "Could not find branch " + chalk.white.bold(bBranch) })
       }
-    } else if (opts.commit) {
-      log.info({ msg: "Comparing with commit " + chalk.white.bold(opts.commit) })
+    } else if (bCommit) {
+      log.info({ msg: "Comparing with commit " + chalk.white.bold(bCommit) })
       try {
-        await gitCli.exec("rev-parse", "--verify", opts.commit)
-        commitish = opts.commit
+        await gitCli.exec("rev-parse", "--verify", bCommit)
+        commitish = bCommit
       } catch (e) {
-        throw new ParameterError({ message: "Could not find commit " + chalk.white.bold(opts.commit) })
+        throw new ParameterError({ message: "Could not find commit " + chalk.white.bold(bCommit) })
       }
     }
 
@@ -324,7 +333,7 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
     // Compare actions (first pass)
     const actionsPreliminary: ActionDiffPreliminary[] = await Promise.all(
       toposortedActions.map((node) =>
-        actionDiffPreliminary({ log, gardenA, gardenB, graphA, graphB, node, resolve: opts.resolve })
+        actionDiffPreliminary({ log, gardenA, gardenB, graphA, graphB, node, resolveAction: opts.resolve })
       )
     )
 
@@ -384,7 +393,7 @@ async function actionDiffPreliminary({
   graphA,
   graphB,
   node,
-  resolve,
+  resolveAction,
 }: {
   log: Log
   gardenA: Garden
@@ -392,7 +401,7 @@ async function actionDiffPreliminary({
   graphA: ConfigGraph
   graphB: ConfigGraph
   node: RenderedNode
-  resolve: boolean
+  resolveAction: boolean
 }): Promise<ActionDiffPreliminary> {
   const actionA = graphA.getActionByRef({ kind: node.kind, name: node.name })
 
@@ -441,7 +450,7 @@ async function actionDiffPreliminary({
   let resolvedConfigDiff: string | null = null
 
   // Note: It would be possible to resolve configs that don't require any execution, as an enhancement
-  if (resolve) {
+  if (resolveAction) {
     log.debug({ msg: "Comparing resolved configs" })
     const projectExcludeValuesA = await gardenA.getExcludeValuesForActionVersions()
     const projectExcludeValuesB = await gardenB.getExcludeValuesForActionVersions()
@@ -1081,7 +1090,7 @@ function describeConfiguration({
   }
 
   if (commit) {
-    output += `Commit: ${commit}\n`
+    output += `Commit: ${chalk.bold(commit)}\n`
   }
 
   if (Object.keys(variableOverrides || {}).length > 0) {

--- a/core/src/commands/diff.ts
+++ b/core/src/commands/diff.ts
@@ -1,0 +1,1043 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import { dedent, indentBlock } from "../util/string.js"
+import type { CommandParams } from "./base.js"
+import { Command } from "./base.js"
+import { printHeader } from "../logger/util.js"
+import { BooleanParameter, EnvironmentParameter, StringOption, StringsParameter, TagsOption } from "../cli/params.js"
+import tmp from "tmp-promise"
+import { GitCli } from "../vcs/git.js"
+import { ParameterError } from "../exceptions.js"
+import type { ActionReference, DeepPrimitiveMap, StringMap } from "../config/common.js"
+import { parseActionReference } from "../config/common.js"
+import type { ConfigGraph, RenderedNode } from "../graph/config-graph.js"
+import type { ActionDependency, ActionKind, ActionVersion } from "../actions/types.js"
+import { actionReferenceToString, replaceExcludeValues, type BaseAction } from "../actions/base.js"
+import { Garden } from "../garden.js"
+import type { BaseGardenResource } from "../config/base.js"
+import { fromPairs, isEqual, keyBy, repeat } from "lodash-es"
+import { styles } from "../logger/styles.js"
+import type { Log } from "../logger/log-entry.js"
+import type { VcsFile } from "../vcs/vcs.js"
+import type { ChangeObject } from "diff"
+import { diffJson, diffLines } from "diff"
+import fsExtra from "fs-extra"
+import { deepResolveContext } from "../config/template-contexts/base.js"
+import { sanitizeValue } from "../util/logging.js"
+import stringWidth from "string-width"
+import { relative } from "path"
+const { readFile } = fsExtra
+
+// TODO: Break this out into smaller files
+
+const diffArgs = {}
+
+const diffOpts = {
+  "commit": new StringOption({
+    help: "A commit ID to compare with.",
+  }),
+  "branch": new StringOption({
+    help: "A branch to compare with.",
+  }),
+  "diff-env": new EnvironmentParameter({
+    help: "Override the Garden environment for the comparison.",
+  }),
+  "diff-local-env": new TagsOption({
+    help: 'Override a local environment variable in the comparison (as templated using ${local.env.*}) with the specified value, formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". You can specify multiple variables by repeating the flag.',
+  }),
+  "diff-var": new TagsOption({
+    help: 'Override a variable in the comparison with the specified value, formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". Analogous to the --var global flag in the Garden CLI. You can specify multiple variables by repeating the flag.',
+  }),
+  "resolve": new BooleanParameter({
+    help: "Fully resolve each action before comparing. Note that this may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.",
+    defaultValue: false,
+  }),
+  "action": new StringsParameter({
+    help: "Specify an action to diff, as <kind>.<name>. Can be specified multiple times. If none is specified, all actions will be diffed.",
+    defaultValue: undefined,
+  }),
+  // TODO: Support comparing with a directory path
+  // TODO: Option to diff source file contents
+}
+
+type Args = typeof diffArgs
+type Opts = typeof diffOpts
+
+type DiffStatus = "added" | "removed" | "modified" | "unchanged"
+
+interface FileDiff {
+  status: DiffStatus
+  path: string
+  diff?: string // Only present for modified files
+}
+
+interface WorkflowDiff {
+  status: DiffStatus
+  rawConfigDiff: string | null
+}
+
+interface ProjectDiff {
+  status: "modified" | "unchanged"
+  rawConfigDiff: string | null
+  resolvedVariablesDiff: string | null
+}
+
+// TODO: Would be good to include which action outputs are required by the dependant, when applicable
+interface ActionDependencyPathDetail {
+  by: ActionReference
+  on: ActionDependency
+}
+
+interface VersionChange {
+  dependency: string
+  status: DiffStatus
+  versionA: string | null
+  versionB: string | null
+}
+
+interface AffectedDependantNode {
+  key: string
+  versionA: ActionVersion | null
+  versionB: ActionVersion | null
+  dependencyPaths: ActionDependencyPathDetail[][]
+}
+
+interface ActionDiffPreliminary {
+  status: DiffStatus
+  key: string
+  kind: ActionKind
+  name: string
+  versionA: ActionVersion | null
+  versionB: ActionVersion | null
+  diffDescriptions: string[]
+  rawConfigDiff: string | null
+  resolvedConfigDiff: string | null
+  files: FileDiff[]
+}
+
+interface ActionDiff extends ActionDiffPreliminary {
+  diffSummary: string
+  affectedDependants: AffectedDependantNode[]
+}
+
+interface DiffResult {
+  projectConfig: ProjectDiff
+  workflows: { [key: string]: WorkflowDiff }
+  actions: { [key: string]: ActionDiff }
+}
+
+export class DiffCommand extends Command<Args, Opts, DiffResult> {
+  name = "diff"
+  help = "[EXPERIMENTAL] Compare the current working directory Garden project with the specified branch or commit."
+
+  override description = dedent`
+    **[EXPERIMENTAL] This command is still under development and may change in the future, including parameters and output format.**
+
+    Compare the current working directory Garden project with the specified branch or commit.
+
+    Use this to understand the impact of your changes on action versions.
+
+    In most cases you should use this with the --resolve flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.
+
+    Note that in the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
+  `
+
+  override arguments = diffArgs
+
+  override options = diffOpts
+
+  override printHeader({ log }) {
+    printHeader(log, "Diffing Garden project", "🔍")
+  }
+
+  async action({ garden: gardenA, log, args, opts }: CommandParams<Args, Opts>) {
+    log.info("")
+
+    let missingDiffParams = true
+
+    let environmentB = `${gardenA.environmentName}.${gardenA.namespace}`
+    if (opts["diff-env"]) {
+      environmentB = opts["diff-env"]
+      log.info({
+        msg: "Comparing with environment: " + environmentB,
+      })
+      missingDiffParams = false
+    }
+
+    let localEnvOverrides: StringMap = {}
+    if (opts["diff-local-env"]) {
+      localEnvOverrides = fromPairs(opts["diff-local-env"].flatMap((group) => group.map((t) => [t.key, t.value])))
+      log.info({
+        msg:
+          "Overriding local environment variables for comparison: " +
+          Object.entries(localEnvOverrides)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("\n - "),
+      })
+      missingDiffParams = false
+    }
+
+    let variableOverrides: StringMap = {}
+    if (opts["diff-var"]) {
+      variableOverrides = fromPairs(opts["diff-var"].flatMap((group) => group.map((t) => [t.key, t.value])))
+      log.info({
+        msg:
+          "Overriding variables for comparison: " +
+          Object.entries(variableOverrides)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("\n  - "),
+      })
+      missingDiffParams = false
+    }
+
+    if (missingDiffParams && !opts.branch && !opts.commit) {
+      throw new ParameterError({
+        message:
+          "No diff parameters specified. Please specify one or more of --branch, --commit, --diff-env, --diff-local-env, --diff-var.",
+      })
+    }
+
+    const actionsFilter = opts.action
+
+    if (actionsFilter) {
+      // Validate the actions
+      actionsFilter.map(parseActionReference)
+      log.info({ msg: "Filtering to actions: " + actionsFilter.join(", ") })
+    }
+
+    const gitCli = new GitCli({ log, cwd: gardenA.projectRoot })
+    const repoRoot = await gitCli.getRepositoryRoot()
+
+    // Check if the reference is a branch
+    let commitish: string | null = null
+    let projectRootB = gardenA.projectRoot
+
+    if (opts.branch && opts.commit) {
+      throw new ParameterError({ message: "Cannot specify both branch and commit" })
+    } else if (opts.branch || opts.commit) {
+      log.info({ msg: "Fetching repo origin" })
+
+      // Fetch the repo origin
+      await gitCli.exec("fetch", "origin")
+    }
+
+    if (opts.branch) {
+      log.info({ msg: "Comparing with branch " + chalk.white.bold(opts.branch) })
+      try {
+        await gitCli.exec("show-ref", "--verify", "--quiet", "refs/heads/" + opts.branch)
+        commitish = opts.branch
+      } catch (e) {
+        throw new ParameterError({ message: "Could not find branch " + chalk.white.bold(opts.branch) })
+      }
+    } else if (opts.commit) {
+      log.info({ msg: "Comparing with commit " + chalk.white.bold(opts.commit) })
+      try {
+        await gitCli.exec("rev-parse", "--verify", opts.commit)
+        commitish = opts.commit
+      } catch (e) {
+        throw new ParameterError({ message: "Could not find commit " + chalk.white.bold(opts.commit) })
+      }
+    }
+
+    // Clone the project repo into a temporary directory
+    if (commitish) {
+      log.info({
+        msg: "Cloning repo into temporary directory and checking out " + chalk.white.bold(commitish),
+      })
+      // TODO: ensure cleanup of the temporary directory
+      const tmpDir = await tmp.dir({ prefix: "garden-diff-" })
+      await gitCli.exec("clone", repoRoot, tmpDir.path)
+      projectRootB = tmpDir.path
+
+      const gitCliClone = new GitCli({ log, cwd: tmpDir.path })
+      await gitCliClone.exec("checkout", commitish)
+    }
+
+    // TODO: Handle remote sources
+    // -> Update the remote sources in the current project
+    // -> Fetch remote sources in the cloned project
+
+    // Resolve the actions in the current project
+    let graphA: ConfigGraph
+
+    if (opts.resolve) {
+      graphA = await gardenA.getResolvedConfigGraph({ log, emit: false, actionsFilter, statusOnly: true })
+    } else {
+      graphA = await gardenA.getConfigGraph({ log, emit: false, actionsFilter, statusOnly: true })
+    }
+
+    // Resolve the actions in the temporary project
+    const comparisonEnv = opts["diff-env"] || `${gardenA.namespace}.${gardenA.environmentName}`
+
+    const gardenB = await Garden.factory(projectRootB, {
+      environmentString: comparisonEnv,
+      commandInfo: {
+        name: "diff",
+        args,
+        opts,
+        rawArgs: [],
+        isCustomCommand: false,
+      },
+      localEnvOverrides,
+      variableOverrides,
+      sessionId: gardenA.sessionId,
+      parentSessionId: gardenA.parentSessionId,
+    })
+    let graphB: ConfigGraph
+
+    if (opts.resolve) {
+      graphB = await gardenB.getResolvedConfigGraph({ log, emit: false, actionsFilter, statusOnly: true })
+    } else {
+      graphB = await gardenB.getConfigGraph({ log, emit: false, actionsFilter, statusOnly: true })
+    }
+
+    // Compare project configuration
+    const projectConfigDiff = await compareProjectConfig(log, gardenA, gardenB)
+
+    // Compare Workflow configurations
+    const workflowDiffs: WorkflowDiff[] = await compareWorkflows(log, gardenA, gardenB)
+
+    // Compare module configurations
+    // TODO
+
+    const toposortedActions = graphA
+      .render()
+      .nodes.filter((node) => !actionsFilter || actionsFilter.includes(actionReferenceToString(node)))
+
+    // Compare actions (first pass)
+    const actionsPreliminary: ActionDiffPreliminary[] = await Promise.all(
+      toposortedActions.map((node) =>
+        actionDiffPreliminary({ log, gardenA, gardenB, graphA, graphB, node, resolve: opts.resolve })
+      )
+    )
+
+    // Handle actions that are removed in the current project
+    for (const action of graphB.getActions({ refs: actionsFilter })) {
+      if (!graphA.getActions({ refs: [action.reference()] })[0]) {
+        // Action is removed in the current project
+        actionsPreliminary.push({
+          status: "removed",
+          key: action.key(),
+          kind: action.kind,
+          name: action.name,
+          versionA: null,
+          versionB: action.getFullVersion(log),
+          diffDescriptions: [`Action ${chalk.white.bold(action.key())} removed`],
+          rawConfigDiff: null,
+          resolvedConfigDiff: null,
+          files: await computeFiles({ log, gardenA, gardenB, actionA: action, actionB: null }),
+        })
+      }
+    }
+
+    const indexedDiffs = fromPairs(actionsPreliminary.map((diff) => [diff.key, diff]))
+    const actions: ActionDiff[] = await Promise.all(
+      actionsPreliminary.map((diff) => actionDiffFinal(log, diff, indexedDiffs, graphA))
+    )
+
+    const unchangedActions = actions
+      .filter((action) => action.status === "unchanged")
+      .sort((a, b) => a.key.localeCompare(b.key))
+
+    if (unchangedActions.length > 0) {
+      log.info({
+        msg: `\n${unchangedActions.length} action(s) unchanged: ${unchangedActions.map((action) => action.key).join(", ")}`,
+      })
+    }
+
+    log.success("\nDone!")
+
+    return {
+      result: {
+        projectConfig: projectConfigDiff,
+        workflows: keyBy(workflowDiffs, "name"),
+        actions: keyBy(actions, "key"),
+      },
+    }
+  }
+}
+
+/**
+ * ACTIONS
+ */
+async function actionDiffPreliminary({
+  log,
+  gardenA,
+  gardenB,
+  graphA,
+  graphB,
+  node,
+  resolve,
+}: {
+  log: Log
+  gardenA: Garden
+  gardenB: Garden
+  graphA: ConfigGraph
+  graphB: ConfigGraph
+  node: RenderedNode
+  resolve: boolean
+}): Promise<ActionDiffPreliminary> {
+  const actionA = graphA.getActionByRef({ kind: node.kind, name: node.name })
+
+  log = actionA.createLog(log)
+  log.debug({ msg: "Comparison (phase 1)" })
+
+  const versionA = actionA.getFullVersion(log)
+  const actionB = graphB.getActions({ refs: [actionA.reference()] })[0]
+
+  if (!actionB) {
+    // Action is added in the current project
+    return {
+      status: "added",
+      key: actionA.key(),
+      kind: actionA.kind,
+      name: actionA.name,
+      versionA: actionA.getFullVersion(log),
+      versionB: null,
+      diffDescriptions: [`Action ${chalk.white.bold(actionA.key())} added`],
+      rawConfigDiff: null,
+      resolvedConfigDiff: null,
+      files: await computeFiles({ log, gardenA, gardenB, actionA, actionB: null }),
+    }
+  }
+
+  const versionB = actionB.getFullVersion(log)
+
+  // Version status
+  const status = versionA?.versionStringFull === versionB?.versionStringFull ? "unchanged" : "modified"
+
+  const diffDescriptions: string[] = []
+
+  // Raw config
+  log.debug({ msg: "Comparing raw configs" })
+  const configA = actionA.getConfig()
+  const configB = actionB.getConfig()
+
+  const rawConfigDiff = await computeRawConfigDiff(log, configB, configA)
+  if (rawConfigDiff) {
+    diffDescriptions.push(chalk.underline("Configuration modified directly") + `:\n${indentBlock(rawConfigDiff, 1)}`)
+  }
+
+  // Resolved config
+  let resolvedConfigDiff: string | null = null
+
+  // Note: It would be possible to resolve configs that don't require any execution, as an enhancement
+  if (resolve) {
+    log.debug({ msg: "Comparing resolved configs" })
+    const projectExcludeValuesA = await gardenA.getExcludeValuesForActionVersions()
+    const projectExcludeValuesB = await gardenB.getExcludeValuesForActionVersions()
+
+    const configFilteredA = replaceExcludeValues(configA, actionA.createLog(log), projectExcludeValuesA) as object
+    const configFilteredB = replaceExcludeValues(configB, actionB.createLog(log), projectExcludeValuesB) as object
+    resolvedConfigDiff = diffObjects(configFilteredB, configFilteredA)
+
+    if (resolvedConfigDiff) {
+      diffDescriptions.push(chalk.underline("Resolved configuration changed") + `:\n${resolvedConfigDiff}`)
+    }
+  }
+
+  // Detect dependency version changes
+  log.debug({ msg: "Comparing dependency versions" })
+  const versionChanges: VersionChange[] = []
+  for (const dep of Object.keys(versionA.dependencyVersions)) {
+    const depVersionA = versionA.dependencyVersions[dep]
+    const depVersionB = versionB.dependencyVersions[dep]
+    if (!depVersionB) {
+      versionChanges.push({
+        dependency: dep,
+        status: "added",
+        versionA: depVersionA,
+        versionB: null,
+      })
+    } else if (depVersionA !== depVersionB) {
+      versionChanges.push({
+        dependency: dep,
+        status: "modified",
+        versionA: depVersionA,
+        versionB: depVersionB,
+      })
+    }
+  }
+  for (const dep of Object.keys(versionB.dependencyVersions)) {
+    if (!versionA.dependencyVersions[dep]) {
+      versionChanges.push({
+        dependency: dep,
+        status: "removed",
+        versionA: null,
+        versionB: versionB.dependencyVersions[dep],
+      })
+    }
+  }
+
+  if (versionChanges.length > 0) {
+    const versionChangeStr =
+      chalk.underline("Dependency version changes:") +
+      "\n" +
+      versionChanges
+        .map((v) => {
+          if (v.status === "added") {
+            return chalk.green(`+  ${styles.bold(v.dependency)} (${v.versionB})`)
+          } else if (v.status === "removed") {
+            return chalk.red(`-  ${styles.bold(v.dependency)}`)
+          } else {
+            return chalk.yellow(`M  ${styles.bold(v.dependency)} (${v.versionA} -> ${v.versionB})`)
+          }
+        })
+        .join("\n")
+    diffDescriptions.push(versionChangeStr)
+  }
+
+  // Source files
+  log.debug({ msg: "Comparing source files" })
+  const files = await computeFiles({ log, gardenA, gardenB, actionA, actionB })
+  const changedFiles = files.filter((file) => file.status !== "unchanged")
+
+  if (changedFiles.length > 0) {
+    diffDescriptions.push(renderFileList(files, changedFiles))
+  } else {
+    diffDescriptions.push(chalk.gray(`Source files unchanged`))
+  }
+
+  return {
+    key: actionA.key(),
+    kind: actionA.kind,
+    name: actionA.name,
+    status,
+    versionA,
+    versionB,
+    diffDescriptions,
+    rawConfigDiff,
+    resolvedConfigDiff,
+    files,
+  }
+}
+
+export async function actionDiffFinal(
+  log: Log,
+  diff: ActionDiffPreliminary,
+  indexedDiffs: Record<string, ActionDiffPreliminary>,
+  graphA: ConfigGraph
+): Promise<ActionDiff> {
+  if (diff.status === "removed" || diff.status === "added") {
+    // Action is removed in the current project
+    return {
+      ...diff,
+      diffSummary: diff.diffDescriptions.join("\n"),
+      // TODO: Should we populate these for a removed/added action?
+      affectedDependants: [],
+    }
+  }
+
+  const actionA = graphA.getActionByRef({ kind: diff.kind, name: diff.name })
+  // const actionB = graphB.getActionByRef({ kind: diffB.kind, name: diffB.name })
+
+  const status = diff.status
+  const versionA = diff.versionA
+  const versionB = diff.versionB
+
+  let summaryHeading = `Action ${chalk.white.bold(actionA.key())} ${status}`
+  if (status === "modified") {
+    summaryHeading += ` (${versionA?.versionString} -> ${versionB?.versionString})`
+  }
+
+  const diffDescriptions = [summaryHeading, ...diff.diffDescriptions]
+
+  // If the action is modified, we need to compute the modified dependants
+  // We should also attempt to highlight possible reasons for the version change
+  const affectedDependants: AffectedDependantNode[] = []
+  const affectedDependantsDirect: ActionDependencyPathDetail[] = []
+  const affectedDependantsTransitive: AffectedDependantNode[] = []
+
+  if (status === "modified") {
+    const isModified = (key: string) => indexedDiffs[key]?.status === "modified"
+
+    // Work out the modified dependants
+    const dependantsRecursive = graphA.getDependants({ ...actionA.reference(), recursive: true })
+    const modifiedDependantsRecursive = dependantsRecursive.filter((d) => isModified(d.key()))
+
+    for (const dependant of modifiedDependantsRecursive) {
+      const paths = graphA
+        .findDependencyPaths(dependant.reference(), actionA.reference())
+        // We want to present this in terms of downstream effects, so we reverse the path
+        .map((path) => path.reverse())
+
+      const dependencyPaths: ActionDependencyPathDetail[][] = []
+
+      let directDependency: ActionDependencyPathDetail | null = null
+
+      for (const path of paths) {
+        // Check if each link (A->B) in the path is affecting the action. Either:
+        // -> Version A is in B's dependencyVersions
+        // -> B references outputs from A
+
+        const pathWithDetail: ActionDependencyPathDetail[] = []
+        let isAffected = true
+
+        // Loop over each pair (A->B, B->C, ...)in the path and check if the condition is met
+        for (let i = 0; i < path.length - 1; i++) {
+          const X = path[i]
+          const Y = path[i + 1]
+
+          const versionY = Y.getFullVersion(log)
+          // Note: This accounts for version.excludeDependencies
+          const isInVersion = !!versionY.dependencyVersions[X.key()]
+
+          const dep = Y.getDependencyReference(X.reference())
+
+          if (!dep) {
+            log.warn({
+              msg: `Dependency ${Y.key()} for action ${X.key()} not found`,
+            })
+            isAffected = false
+            break
+          }
+
+          // TODO: Would be nice to know if version.excludeFields/Values removes the effect of the outputs
+          //       but that's a lot of work to figure out properly.
+          if (!isInVersion && !dep.needsStaticOutputs && !dep.needsExecutedOutputs) {
+            isAffected = false
+            break
+          }
+
+          pathWithDetail.push({
+            by: Y.reference(),
+            on: dep,
+          })
+        }
+
+        if (isAffected && pathWithDetail.length > 0) {
+          if (path.length === 2) {
+            directDependency = pathWithDetail[0]
+          }
+
+          dependencyPaths.push(pathWithDetail)
+        }
+      }
+
+      if (dependencyPaths.length > 0) {
+        const affectedDependant: AffectedDependantNode = {
+          key: dependant.key(),
+          versionA: dependant.getFullVersion(log),
+          versionB: actionA.getFullVersion(log),
+          dependencyPaths,
+        }
+
+        if (directDependency) {
+          affectedDependantsDirect.push(directDependency)
+        } else {
+          affectedDependantsTransitive.push(affectedDependant)
+        }
+
+        affectedDependants.push(affectedDependant)
+      }
+    }
+  }
+
+  if (affectedDependants.length > 0) {
+    diffDescriptions.push(
+      `${affectedDependants.length} dependant(s) affected by modification (${affectedDependantsDirect.length} directly, ${affectedDependants.length - affectedDependantsDirect.length} transitively)`
+    )
+  } else {
+    diffDescriptions.push(chalk.gray(`${affectedDependants.length} dependants affected by modification`))
+  }
+
+  if (affectedDependantsDirect.length > 0) {
+    // TODO: Add more detail about the direct dependency
+    diffDescriptions.push(
+      chalk.underline("Directly affected dependants") +
+        ":\n" +
+        affectedDependantsDirect.map((d) => describeActionDependencyDetail(d)).join("\n")
+    )
+  }
+
+  if (affectedDependantsTransitive.length > 0) {
+    diffDescriptions.push(
+      chalk.underline("Transitively affected dependants") +
+        `:\n${affectedDependantsTransitive.map((d) => describeActionDependencyPaths(d)).join("\n")}`
+    )
+  }
+
+  // Summarize
+  let diffSummary = chalk.cyanBright(summaryHeading)
+  const separatorBar = getSeparatorBar(stringWidth(summaryHeading))
+
+  if (diffDescriptions.length > 1) {
+    const blocks = diffDescriptions.slice(1).map((d) => "→ " + indentBlock(d, 2).trimStart())
+    diffSummary += `\n${separatorBar}\n${blocks.join("\n\n")}\n${separatorBar}`
+  }
+
+  if (status !== "unchanged") {
+    log.info({
+      msg: "\n" + diffSummary,
+    })
+  }
+
+  return {
+    ...diff,
+    diffDescriptions,
+    diffSummary,
+    affectedDependants,
+  }
+}
+
+function renderFileList(files: FileDiff[], changedFiles: FileDiff[]): string {
+  const fileList = changedFiles.map((file) => {
+    let color = chalk.white
+    let marker = "="
+
+    if (file.status === "added") {
+      color = chalk.green
+      marker = "+"
+    } else if (file.status === "removed") {
+      color = chalk.red
+      marker = "-"
+    } else if (file.status === "modified") {
+      color = chalk.yellow
+      marker = "M"
+    }
+
+    return color(`${marker} ${file.path}`)
+  })
+  let detail = chalk.underline("Source files changed") + `:\n${fileList.join("\n")}`
+
+  if (files.length > changedFiles.length) {
+    detail += `\n${chalk.gray(`${files.length - changedFiles.length} files unchanged`)}`
+  }
+
+  return detail
+}
+
+async function computeFiles({
+  log,
+  gardenA,
+  gardenB,
+  actionA,
+  actionB,
+}: {
+  log: Log
+  gardenA: Garden
+  gardenB: Garden
+  actionA: BaseAction | null
+  actionB: BaseAction | null
+}): Promise<FileDiff[]> {
+  if (!actionA || !actionB) {
+    return []
+  }
+
+  let filesA: VcsFile[] = []
+  let filesB: VcsFile[] = []
+
+  if (actionA) {
+    const sourcePath = actionA.sourcePath()
+    filesA = await gardenA.vcs.getFiles({
+      log,
+      path: sourcePath,
+      // FIXME: We should use the minimal roots, as when resolving the graph
+      scanRoot: sourcePath,
+    })
+    filesA = filesA.map((file) => ({
+      ...file,
+      path: relative(sourcePath, file.path),
+    }))
+  }
+
+  if (actionB) {
+    const sourcePath = actionB.sourcePath()
+    filesB = await gardenB.vcs.getFiles({
+      log,
+      path: sourcePath,
+      // FIXME: We should use the minimal roots, as when resolving the graph
+      scanRoot: sourcePath,
+    })
+    filesB = filesB.map((file) => ({
+      ...file,
+      path: relative(sourcePath, file.path),
+    }))
+  }
+
+  const filesAByPath = fromPairs(filesA.map((file) => [file.path, file]))
+  const filesBByPath = fromPairs(filesB.map((file) => [file.path, file]))
+
+  const files: FileDiff[] = []
+
+  for (const file of filesA) {
+    const fileB = filesBByPath[file.path]
+    if (fileB) {
+      if (fileB.hash !== file.hash) {
+        // TODO: Maybe include the diff in the output?
+        files.push({
+          status: "modified",
+          path: file.path,
+        })
+      } else {
+        files.push({
+          status: "unchanged",
+          path: file.path,
+        })
+      }
+    } else {
+      files.push({
+        status: "added",
+        path: file.path,
+      })
+    }
+  }
+
+  for (const file of filesB) {
+    if (!filesAByPath[file.path]) {
+      files.push({
+        status: "removed",
+        path: file.path,
+      })
+    }
+  }
+
+  return files
+}
+
+function describeActionDependencyDetail(dependency: ActionDependencyPathDetail): string {
+  const ref = `${actionReferenceToString(dependency.by)}`
+  const detail: string[] = []
+
+  if (dependency.on.explicit) {
+    detail.push("explicit")
+  }
+
+  if (dependency.on.needsStaticOutputs || dependency.on.needsExecutedOutputs) {
+    detail.push("outputs")
+  }
+
+  if (detail.length > 0) {
+    return `${styles.bold(ref)} (${detail.join("+")})`
+  } else {
+    return styles.bold(ref)
+  }
+}
+
+function describeActionDependencyPaths(dependency: AffectedDependantNode): string {
+  // Pick the shortest path
+  const shortestPath = dependency.dependencyPaths.sort((a, b) => a.length - b.length)[0]
+
+  if (!shortestPath) {
+    return ""
+  }
+
+  const nodes = [
+    styles.bold(actionReferenceToString(shortestPath[0].on)),
+    ...shortestPath.map((d) => describeActionDependencyDetail(d)),
+  ]
+
+  let output = nodes.join(" -> ")
+
+  if (dependency.dependencyPaths.length > 1) {
+    output += ` [+${dependency.dependencyPaths.length - 1} paths]`
+  }
+
+  return output
+}
+
+/**
+ * PROJECT CONFIG
+ */
+async function compareProjectConfig(log: Log, gardenA: Garden, gardenB: Garden) {
+  log.info({
+    msg: styles.highlight(`\n${getSeparatorBar()}\nProject configuration\n${getSeparatorBar()}`),
+  })
+
+  const projectConfigA = gardenA.getProjectConfig()
+  const projectConfigB = gardenB.getProjectConfig()
+
+  const projectRawConfigDiff = await computeRawConfigDiff(log, projectConfigB, projectConfigA)
+
+  const projectConfigDiff: ProjectDiff = {
+    status: projectRawConfigDiff === null ? "unchanged" : "modified",
+    rawConfigDiff: projectRawConfigDiff,
+    resolvedVariablesDiff: null,
+  }
+
+  if (projectRawConfigDiff) {
+    log.info({
+      msg: chalk.underline("Configuration file modified directly") + `:\n${projectRawConfigDiff}`,
+    })
+  } else {
+    log.info({
+      msg: chalk.gray("Configuration file unchanged"),
+    })
+  }
+
+  // Compare resolved project variables
+  const variablesA = deepResolveContext("project variables A", gardenA.variables) as DeepPrimitiveMap
+  const variablesB = deepResolveContext("project variables B", gardenB.variables) as DeepPrimitiveMap
+
+  const variablesDiff = diffObjects(variablesB, variablesA)
+
+  if (variablesDiff) {
+    log.info({
+      msg: chalk.underline("Resolved project variables modified") + `:\n${variablesDiff}`,
+    })
+    projectConfigDiff.resolvedVariablesDiff = variablesDiff
+  }
+
+  log.info({
+    msg: getSeparatorBar(),
+  })
+
+  return projectConfigDiff
+}
+
+/**
+ * WORKFLOWS
+ */
+async function compareWorkflows(log: Log, gardenA: Garden, gardenB: Garden): Promise<WorkflowDiff[]> {
+  const workflowConfigsRawA = await gardenA.getRawWorkflowConfigs()
+  const workflowConfigsRawB = await gardenB.getRawWorkflowConfigs()
+
+  const workflowDiffs: WorkflowDiff[] = []
+
+  log.info({
+    msg: styles.highlight("\nWorkflows\n") + getSeparatorBar(),
+  })
+
+  if (workflowConfigsRawA.length === 0 && workflowConfigsRawB.length === 0) {
+    log.info({
+      msg: chalk.gray("No Workflows found\n") + getSeparatorBar(),
+    })
+    return []
+  }
+
+  log.info(chalk.gray(`${workflowConfigsRawA.length} workflows found`))
+
+  for (const configRawA of workflowConfigsRawA) {
+    const configRawB = workflowConfigsRawB.find((w) => w.name === configRawA.name)
+    if (!configRawB) {
+      workflowDiffs.push({ status: "added", rawConfigDiff: null })
+      log.info({
+        msg: chalk.bold(`\nWorkflow ${configRawA.name} added`),
+      })
+      continue
+    }
+
+    const rawConfigDiff = await computeRawConfigDiff(log, configRawB, configRawA)
+
+    let status: DiffStatus = "unchanged"
+
+    if (rawConfigDiff) {
+      log.info({
+        msg:
+          "\n" +
+          chalk.underline(`Workflow ${styles.highlight(configRawA.name)} configuration file modified directly`) +
+          `:\n${indentBlock(rawConfigDiff, 1)}`,
+      })
+      status = "modified"
+    }
+
+    if (status === "unchanged") {
+      log.info({
+        msg: chalk.gray(`\nWorkflow ${configRawA.name} unchanged`),
+      })
+    }
+
+    workflowDiffs.push({
+      status,
+      rawConfigDiff,
+    })
+  }
+
+  for (const configRawB of workflowConfigsRawB) {
+    if (!workflowConfigsRawA.find((w) => w.name === configRawB.name)) {
+      workflowDiffs.push({ status: "removed", rawConfigDiff: null })
+      log.info({
+        msg: chalk.bold(`\nWorkflow ${configRawB.name} removed`),
+      })
+    }
+  }
+
+  log.info({
+    msg: getSeparatorBar(),
+  })
+
+  return workflowDiffs
+}
+
+/**
+ * UTILS
+ */
+async function getRawConfig(log: Log, resource: BaseGardenResource | null): Promise<string | null> {
+  if (!resource) {
+    return null
+  }
+
+  // Using the YAML document when possible to avoid diffing the whole YAML file as opposed to the relevant doc
+  if (resource.internal.yamlDoc) {
+    return resource.internal.yamlDoc.toString()
+  }
+
+  const configPath = resource.internal.configFilePath
+  if (!configPath) {
+    log.warn({
+      msg: chalk.yellow(`No config file path found for resource ${resource.kind}.${resource.name}`),
+    })
+    return null
+  }
+
+  return await readFile(configPath, "utf-8")
+}
+
+async function computeRawConfigDiff(
+  log: Log,
+  configA: BaseGardenResource | null,
+  configB: BaseGardenResource | null
+): Promise<string | null> {
+  const rawDocA = await getRawConfig(log, configA)
+  const rawDocB = await getRawConfig(log, configB)
+
+  if (!rawDocA || !rawDocB) {
+    return null
+  }
+
+  const diff = diffLines(rawDocA, rawDocB)
+
+  const changed = diff.some((part) => part.added || part.removed)
+
+  return changed ? renderDiff(diff) : null
+}
+
+function renderDiff(diff: ChangeObject<string>[]): string {
+  // TODO: Show less of the unchanged lines
+  // TODO: Match indent level of unchanged parts to changed parts
+  return diff
+    .map((part) => {
+      if (part.added) {
+        return chalk.green(`+${part.value}`)
+      }
+      if (part.removed) {
+        return chalk.red(`-${part.value}`)
+      }
+      return chalk.gray(part.value)
+    })
+    .join("")
+}
+
+function diffObjects(objA: object, objB: object): string | null {
+  objA = sanitizeValue(objA)
+  objB = sanitizeValue(objB)
+
+  if (isEqual(objA, objB)) {
+    return null
+  }
+
+  const diff = diffJson(objA, objB)
+
+  return renderDiff(diff)
+}
+
+function getSeparatorBar(width: number = 40) {
+  return styles.accent(repeat("─", width))
+}

--- a/core/src/commands/diff.ts
+++ b/core/src/commands/diff.ts
@@ -48,6 +48,7 @@ const diffOpts = {
   }),
   "diff-env": new EnvironmentParameter({
     help: "Override the Garden environment for the comparison.",
+    aliases: [],
   }),
   "diff-local-env": new TagsOption({
     help: 'Override a local environment variable in the comparison (as templated using ${local.env.*}) with the specified value, formatted as <VAR_NAME>:<VALUE>, e.g. "MY_VAR=my-value". You can specify multiple variables by repeating the flag.',

--- a/core/src/commands/diff.ts
+++ b/core/src/commands/diff.ts
@@ -32,7 +32,7 @@ import fsExtra from "fs-extra"
 import { deepResolveContext } from "../config/template-contexts/base.js"
 import { sanitizeValue } from "../util/logging.js"
 import stringWidth from "string-width"
-import { relative } from "path"
+import { relative, resolve, sep } from "path"
 const { readFile } = fsExtra
 
 // TODO: Break this out into smaller files
@@ -217,6 +217,7 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
 
     const gitCli = new GitCli({ log, cwd: gardenA.projectRoot })
     const repoRoot = await gitCli.getRepositoryRoot()
+    const projectRootRelative = relative(repoRoot, gardenA.projectRoot)
 
     // Check if the reference is a branch
     let commitish: string | null = null
@@ -257,7 +258,7 @@ When setting the \`--diff-X\` flags, the values will be overridden in the compar
       // TODO: ensure cleanup of the temporary directory
       const tmpDir = await tmp.dir({ prefix: "garden-diff-" })
       await gitCli.exec("clone", repoRoot, tmpDir.path)
-      projectRootB = tmpDir.path
+      projectRootB = resolve(tmpDir.path, ...projectRootRelative.split(sep))
 
       const gitCliClone = new GitCli({ log, cwd: tmpDir.path })
       await gitCliClone.exec("checkout", commitish)

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import dotenv from "dotenv"
 import type { CommandResult, CommandParams, PrepareParams } from "./base.js"
 import { Command } from "./base.js"
 import { omit, sortBy } from "lodash-es"
@@ -15,7 +14,7 @@ import { LogLevel, parseLogLevel, VoidLogger } from "../logger/logger.js"
 import { StringsParameter, BooleanParameter, IntegerParameter, DurationParameter, TagsOption } from "../cli/params.js"
 import { printHeader, renderDivider } from "../logger/util.js"
 import { dedent, deline, naturalList } from "../util/string.js"
-import { CommandError, ParameterError } from "../exceptions.js"
+import { CommandError } from "../exceptions.js"
 import type { LogsTagOrFilter } from "../monitors/logs.js"
 import { LogMonitor } from "../monitors/logs.js"
 import { styles } from "../logger/styles.js"
@@ -134,20 +133,7 @@ export class LogsCommand extends Command<Args, Opts> {
     }
 
     if (tag && tag.length > 0) {
-      const parameterErrorMsg = `Unable to parse the given --tag flags. Format should be key=value.`
-      try {
-        tagFilters = tag.map((tagGroup: string) => {
-          return tagGroup.split(",").map((t: string) => {
-            const parsed = Object.entries(dotenv.parse(t))[0]
-            if (!parsed) {
-              throw new ParameterError({ message: `${parameterErrorMsg}. Got: '${tag}'` })
-            }
-            return parsed
-          })
-        })
-      } catch {
-        throw new ParameterError({ message: `${parameterErrorMsg}. Got: '${tag}'` })
-      }
+      tagFilters = tag.map((group) => group.map((t) => [t.key, t.value]))
     }
 
     const graph = await garden.getConfigGraph({ log, emit: false, statusOnly: true })

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -7,7 +7,7 @@
  */
 
 import { dedent, deline, naturalList } from "../util/string.js"
-import type { DeepPrimitiveMap, Primitive, PrimitiveMap } from "./common.js"
+import type { DeepPrimitiveMap, Primitive, PrimitiveMap, StringMap } from "./common.js"
 import {
   createSchema,
   includeGuideLink,
@@ -632,6 +632,7 @@ export const pickEnvironment = profileAsync(async function _pickEnvironment({
   secrets,
   commandInfo,
   projectContext,
+  localEnvOverrides,
 }: {
   projectContext: ProjectConfigContext
   variableOverrides: DeepPrimitiveMap
@@ -644,6 +645,7 @@ export const pickEnvironment = profileAsync(async function _pickEnvironment({
   cloudBackendDomain: string
   secrets: PrimitiveMap
   commandInfo: CommandInfo
+  localEnvOverrides: StringMap
 }) {
   const { environments, name: projectName, path: projectRoot } = projectConfig
   const parsed = parseEnvironment(envString)
@@ -686,6 +688,7 @@ export const pickEnvironment = profileAsync(async function _pickEnvironment({
     backendType: getBackendType(projectConfig),
     secrets,
     commandInfo,
+    localEnvOverrides,
   })
 
   // resolve project variables incl. varfiles

--- a/core/src/docs/common.ts
+++ b/core/src/docs/common.ts
@@ -85,11 +85,6 @@ export function flattenSchema(
   return items.filter((key) => !key.internal)
 }
 
-export function indent(lines: string[], level: number) {
-  const prefix = padEnd("", level * 2, " ")
-  return lines.map((line) => prefix + line)
-}
-
 export function renderMarkdownTable(data: { [heading: string]: string }) {
   const lengths = Object.entries(data).map(([k, v]) => max([k.length, v.length]))
   const paddedKeys = Object.keys(data).map((k, i) => padEnd(k, lengths[i], " "))

--- a/core/src/docs/config.ts
+++ b/core/src/docs/config.ts
@@ -16,7 +16,8 @@ import { get, isFunction, isString } from "lodash-es"
 import type { JoiDescription } from "../config/common.js"
 import { STATIC_DIR } from "../constants.js"
 import type { BaseKeyDescription, NormalizeOptions } from "./common.js"
-import { indent, renderMarkdownTable, convertMarkdownLinks, flattenSchema, isArrayType } from "./common.js"
+import { renderMarkdownTable, convertMarkdownLinks, flattenSchema, isArrayType } from "./common.js"
+import { indentLines } from "../util/string.js"
 import { JoiKeyDescription } from "./joi-schema.js"
 import { safeDumpYaml } from "../util/serialization.js"
 import stripAnsi from "strip-ansi"
@@ -217,7 +218,7 @@ export function renderSchemaDescriptionYaml(
           comment.push(`Example: ${example}`, "")
         } else {
           // Render example in a separate line
-          comment.push("Example:", ...indent(example.split("\n"), 1), "")
+          comment.push("Example:", ...indentLines(example.split("\n"), 1), "")
         }
       }
       renderRequired && comment.push(required ? "Required." : "Optional.")
@@ -247,7 +248,7 @@ export function renderSchemaDescriptionYaml(
 
     if (example && usingExampleForValue) {
       const levels = desc.type === "object" ? 2 : 1
-      formattedValue = isPrimitive || exceptionallyTreatAsPrimitive ? example : indent(example.split("\n"), levels)
+      formattedValue = isPrimitive || exceptionallyTreatAsPrimitive ? example : indentLines(example.split("\n"), levels)
     } else {
       // Non-primitive values get rendered in the line below, indented by one
       if (value === undefined) {
@@ -255,7 +256,7 @@ export function renderSchemaDescriptionYaml(
       } else if (isPrimitive || exceptionallyTreatAsPrimitive) {
         formattedValue = safeDumpYaml(value)
       } else {
-        formattedValue = indent(safeDumpYaml(value).trim().split("\n"), 1)
+        formattedValue = indentLines(safeDumpYaml(value).trim().split("\n"), 1)
       }
     }
 
@@ -299,9 +300,9 @@ export function renderSchemaDescriptionYaml(
         prefix = "#-"
       }
 
-      indented = indent([prefix + out[0], ...indent(out.slice(1), 1)], level - 1).map((line) => line.trimRight())
+      indented = indentLines([prefix + out[0], ...indentLines(out.slice(1), 1)], level - 1).map((line) => line.trimRight())
     } else {
-      indented = indent(out, level).map((line) => line.trimRight())
+      indented = indentLines(out, level).map((line) => line.trimRight())
     }
 
     return indented.join("\n")

--- a/core/src/docs/config.ts
+++ b/core/src/docs/config.ts
@@ -300,7 +300,9 @@ export function renderSchemaDescriptionYaml(
         prefix = "#-"
       }
 
-      indented = indentLines([prefix + out[0], ...indentLines(out.slice(1), 1)], level - 1).map((line) => line.trimRight())
+      indented = indentLines([prefix + out[0], ...indentLines(out.slice(1), 1)], level - 1).map((line) =>
+        line.trimRight()
+      )
     } else {
       indented = indentLines(out, level).map((line) => line.trimRight())
     }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -203,6 +203,7 @@ export interface GardenOpts {
   plugins?: RegisterPluginParam[]
   sessionId: string
   parentSessionId: string | undefined
+  localEnvOverrides?: StringMap
   variableOverrides?: PrimitiveMap
   // used in tests
   overrideCloudApiLegacyFactory?: GardenCloudApiLegacyFactory
@@ -240,6 +241,7 @@ export interface GardenParams {
   projectSources?: SourceConfig[]
   providerConfigs: UnresolvedProviderConfig[]
   variables: VariablesContext
+  localEnvOverrides?: StringMap
   variableOverrides: DeepPrimitiveMap
   secrets: StringMap
   sessionId: string
@@ -332,6 +334,7 @@ export class Garden {
    */
   public readonly namespace: string
   public readonly variables: VariablesContext
+  public readonly localEnvOverrides: StringMap
   // Any variables passed via the `--var` CLI option (maintained here so that they can be used during module resolution
   // to override module variables and module varfiles).
   public readonly variableOverrides: DeepPrimitiveMap
@@ -386,6 +389,7 @@ export class Garden {
     this.projectSources = params.projectSources || []
     this.providerConfigs = params.providerConfigs
     this.variables = params.variables
+    this.localEnvOverrides = params.localEnvOverrides || {}
     this.variableOverrides = params.variableOverrides
     this.secrets = params.secrets
     this.workingCopyId = params.workingCopyId
@@ -1972,6 +1976,7 @@ export async function resolveGardenParamsPartial(currentDirectory: string, opts:
       vcsInfo,
       username: _username,
       commandInfo,
+      localEnvOverrides: opts.localEnvOverrides || {},
     }),
     opts: {},
   }) as string
@@ -2102,6 +2107,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       backendType: getBackendType(projectConfig),
       secrets,
       commandInfo,
+      localEnvOverrides: opts.localEnvOverrides || {},
     })
 
     projectConfig = resolveProjectConfig({
@@ -2125,6 +2131,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       cloudBackendDomain,
       secrets,
       commandInfo,
+      localEnvOverrides: opts.localEnvOverrides || {},
     })
 
     const { providers, production } = pickedEnv
@@ -2177,6 +2184,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       environmentName,
       resolvedDefaultNamespace: pickedEnv.defaultNamespace,
       namespace,
+      localEnvOverrides: opts.localEnvOverrides || {},
       variables,
       variableOverrides,
       secrets,

--- a/core/src/util/string.ts
+++ b/core/src/util/string.ts
@@ -15,6 +15,7 @@ import type { Options as CliTruncateOptions } from "cli-truncate"
 import cliTruncate from "cli-truncate"
 import { getTerminalWidth } from "../logger/util.js"
 import wrapAnsi from "wrap-ansi"
+import { padEnd } from "lodash-es"
 
 // Exporting these here for convenience and ease of imports (otherwise we need to require modules instead of using
 // the import syntax, and it for some reason doesn't play nice with IDEs).
@@ -198,4 +199,13 @@ export function splitLast(s: string, delimiter: string) {
   }
 
   return [s.slice(0, lastIndex), s.slice(lastIndex + delimiter.length)]
+}
+
+export function indentLines(lines: string[], level: number) {
+  const prefix = padEnd("", level * 2, " ")
+  return lines.map((line) => prefix + line)
+}
+
+export function indentBlock(block: string, level: number) {
+  return indentLines(splitLines(block), level).join("\n")
 }

--- a/core/test/data/test-projects/diff/garden.yml
+++ b/core/test/data/test-projects/diff/garden.yml
@@ -8,6 +8,8 @@ variables:
   build-b: build-b
   deploy-a: deploy-a
   test-a: test-a
+providers:
+  - name: exec
 
 ---
 

--- a/core/test/data/test-projects/diff/garden.yml
+++ b/core/test/data/test-projects/diff/garden.yml
@@ -1,0 +1,61 @@
+apiVersion: garden.io/v2
+kind: Project
+name: test-project-diff
+environments:
+  - name: local
+variables:
+  build-a: build-a
+  build-b: build-b
+  deploy-a: deploy-a
+  test-a: test-a
+
+---
+
+kind: Workflow
+name: workflow-a
+steps:
+  - script: echo ${var.workflow-a}
+
+---
+
+kind: Build
+type: exec
+name: build-a
+spec:
+  command: ["echo", "${var.build-a}"]
+  env:
+    FOO: "${local.env.TEST_ENV_VAR_BUILD_A || 'A'}"
+
+---
+
+kind: Build
+type: exec
+name: build-b
+spec:
+  command: ["echo", "${var.build-b}"]
+  env:
+    FOO: "${local.env.TEST_ENV_VAR_BUILD_B || 'B'}"
+
+---
+
+kind: Deploy
+type: exec
+name: deploy-a
+dependencies:
+  - build.build-a
+spec:
+  deployCommand: ["echo", "${var.deploy-a}"]
+  statusCommand: ["echo", "${local.env.TEST_ENV_VAR_DEPLOY_A || 'A'}"]
+
+---
+
+kind: Test
+type: exec
+name: test-a
+dependencies:
+  - deploy.deploy-a
+spec:
+  command: ["echo", "${var.test-a}"]
+  env:
+    FOO: "${local.env.TEST_ENV_VAR_TEST_A || 'A'}"
+    NAMESPACE: "${environment.namespace}"

--- a/core/test/integ/src/commands/diff.ts
+++ b/core/test/integ/src/commands/diff.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { DiffCommand } from "../../../../src/commands/diff.js"
+import type { TempDirectory, TestGarden } from "../../../helpers.js"
+import { makeTempDir, makeTestGarden, withDefaultGlobalOpts } from "../../../helpers.js"
+import stripAnsi from "strip-ansi"
+import { GitCli } from "../../../../src/vcs/git.js"
+import { getRootLogger } from "../../../../src/logger/logger.js"
+
+describe("DiffCommand", () => {
+  const cmd = new DiffCommand()
+  const defaultOpts = withDefaultGlobalOpts({
+    "commit": undefined,
+    "branch": undefined,
+    "diff-env": undefined,
+    "diff-local-env": undefined,
+    "diff-var": undefined,
+    // Note: Defaulting to --resolve=true to ensure that the actions are fully resolved before comparing.
+    "resolve": true,
+    "action": undefined,
+  })
+
+  let tmpDir: TempDirectory
+  let quickstartGarden: TestGarden
+
+  const log = getRootLogger().createLog({})
+
+  before(async () => {
+    tmpDir = await makeTempDir()
+    let gitCli = new GitCli({ log, cwd: tmpDir.path })
+    await gitCli.exec("clone", "https://github.com/garden-io/quickstart-example.git", tmpDir.path)
+    gitCli = new GitCli({ log, cwd: tmpDir.path })
+    await gitCli.exec("checkout", "diff-test-base")
+    await gitCli.exec("checkout", "diff-test-changes")
+    quickstartGarden = await makeTestGarden(tmpDir.path, { noTempDir: true, noCache: true })
+  })
+
+  after(async () => {
+    await tmpDir.cleanup()
+  })
+
+  it("compares with a different branch", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('+  "postgresPassword": "foo"')
+  })
+
+  it("compares with a different commit", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, commit: "58afed93698054ac47cd56223c7b37c4c496de0e" },
+    })
+
+    expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('+  "postgresPassword": "foo"')
+  })
+
+  it("skips resolving the actions with --resolve=false", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: {
+        ...defaultOpts,
+        "resolve": false,
+        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+      },
+    })
+
+    for (const action of Object.values(result.actions)) {
+      expect(action.resolvedConfigDiff).to.be.null
+    }
+  })
+
+  it("picks up direct project config changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.projectConfig.rawConfigDiff ?? "")).to.include("+  postgresPassword: foo")
+  })
+
+  it("picks up direct action config changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.actions["test.unit-vote"].rawConfigDiff ?? "")).to.include("+  env:")
+    expect(stripAnsi(result.actions["test.unit-vote"].diffSummary)).to.include("Configuration file modified directly")
+    expect(stripAnsi(result.actions["test.unit-vote"].diffSummary)).to.include("+  env:")
+  })
+
+  it("picks up direct workflow config changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.workflows["test-a"].rawConfigDiff ?? "")).to.include("+    script: echo changed")
+    expect(stripAnsi(result.workflows["test-b"].status)).to.equal("removed")
+    expect(stripAnsi(result.workflows["test-c"].status)).to.equal("added")
+  })
+
+  it("picks up source file changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    const summary = stripAnsi(result.actions["build.api"].diffSummary)
+    expect(summary).to.include("Source files changed")
+    expect(summary).to.include("M Dockerfile")
+    expect(summary).to.include("+ test.txt")
+    expect(summary).to.include("8 files unchanged")
+
+    const files = result.actions["build.api"].files
+    const changedFiles = files.filter((file) => file.status === "modified")
+    expect(changedFiles).to.have.length(1)
+    expect(changedFiles[0].path).to.equal("Dockerfile")
+    const addedFiles = files.filter((file) => file.status === "added")
+    expect(addedFiles).to.have.length(1)
+    expect(addedFiles[0].path).to.equal("test.txt")
+  })
+})

--- a/core/test/integ/src/commands/diff.ts
+++ b/core/test/integ/src/commands/diff.ts
@@ -18,11 +18,11 @@ import { join } from "node:path"
 describe("DiffCommand", () => {
   const cmd = new DiffCommand()
   const defaultOpts = withDefaultGlobalOpts({
-    "commit": undefined,
-    "branch": undefined,
-    "diff-env": undefined,
-    "diff-local-env": undefined,
-    "diff-var": undefined,
+    "b-commit": undefined,
+    "b-branch": undefined,
+    "b-env": undefined,
+    "b-local-env-var": undefined,
+    "b-var": undefined,
     // Note: Defaulting to --resolve=true to ensure that the actions are fully resolved before comparing.
     "resolve": true,
     "action": undefined,
@@ -52,7 +52,7 @@ describe("DiffCommand", () => {
       garden: quickstartGarden,
       log: quickstartGarden.log,
       args: {},
-      opts: { ...defaultOpts, branch: "diff-test-base" },
+      opts: { ...defaultOpts, "b-branch": "diff-test-base" },
     })
 
     expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('+  "postgresPassword": "foo"')
@@ -63,7 +63,7 @@ describe("DiffCommand", () => {
       garden: quickstartGarden,
       log: quickstartGarden.log,
       args: {},
-      opts: { ...defaultOpts, commit: "58afed93698054ac47cd56223c7b37c4c496de0e" },
+      opts: { ...defaultOpts, "b-commit": "58afed93698054ac47cd56223c7b37c4c496de0e" },
     })
 
     expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('+  "postgresPassword": "foo"')
@@ -77,7 +77,7 @@ describe("DiffCommand", () => {
       opts: {
         ...defaultOpts,
         "resolve": false,
-        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+        "b-local-env-var": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
       },
     })
 
@@ -91,7 +91,7 @@ describe("DiffCommand", () => {
       garden: quickstartGarden,
       log: quickstartGarden.log,
       args: {},
-      opts: { ...defaultOpts, branch: "diff-test-base" },
+      opts: { ...defaultOpts, "b-branch": "diff-test-base" },
     })
 
     expect(stripAnsi(result.projectConfig.rawConfigDiff ?? "")).to.include("+  postgresPassword: foo")
@@ -102,7 +102,7 @@ describe("DiffCommand", () => {
       garden: quickstartGarden,
       log: quickstartGarden.log,
       args: {},
-      opts: { ...defaultOpts, branch: "diff-test-base" },
+      opts: { ...defaultOpts, "b-branch": "diff-test-base" },
     })
 
     expect(stripAnsi(result.actions["test.unit-vote"].rawConfigDiff ?? "")).to.include("+  env:")
@@ -115,7 +115,7 @@ describe("DiffCommand", () => {
       garden: quickstartGarden,
       log: quickstartGarden.log,
       args: {},
-      opts: { ...defaultOpts, branch: "diff-test-base" },
+      opts: { ...defaultOpts, "b-branch": "diff-test-base" },
     })
 
     expect(stripAnsi(result.workflows["test-a"].rawConfigDiff ?? "")).to.include("+    script: echo changed")
@@ -128,7 +128,7 @@ describe("DiffCommand", () => {
       garden: quickstartGarden,
       log: quickstartGarden.log,
       args: {},
-      opts: { ...defaultOpts, branch: "diff-test-base" },
+      opts: { ...defaultOpts, "b-branch": "diff-test-base" },
     })
 
     const summary = stripAnsi(result.actions["build.api"].diffSummary)
@@ -170,7 +170,7 @@ describe("DiffCommand", () => {
         garden,
         log: garden.log,
         args: {},
-        opts: { ...defaultOpts, branch: "diff-test-sub-base" },
+        opts: { ...defaultOpts, "b-branch": "diff-test-sub-base" },
       })
 
       expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('+  "postgresPassword": "foo"')

--- a/core/test/unit/src/commands/diff.ts
+++ b/core/test/unit/src/commands/diff.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { DiffCommand } from "../../../../src/commands/diff.js"
+import type { TempDirectory, TestGarden } from "../../../helpers.js"
+import { getDataDir, makeTempDir, makeTestGarden, withDefaultGlobalOpts } from "../../../helpers.js"
+import stripAnsi from "strip-ansi"
+import { GitCli } from "../../../../src/vcs/git.js"
+
+describe("DiffCommand", () => {
+  const cmd = new DiffCommand()
+  const projectRoot = getDataDir("test-projects", "diff")
+  const defaultOpts = withDefaultGlobalOpts({
+    "commit": undefined,
+    "branch": undefined,
+    "diff-env": undefined,
+    "diff-local-env": undefined,
+    "diff-var": undefined,
+    // Note: Defaulting to --resolve=true to ensure that the actions are fully resolved before comparing.
+    "resolve": true,
+    "action": undefined,
+  })
+
+  let diffGarden: TestGarden
+
+  let tmpDir: TempDirectory
+  let quickstartGarden: TestGarden
+
+  before(async () => {
+    diffGarden = await makeTestGarden(projectRoot)
+
+    tmpDir = await makeTempDir()
+    const gitCli = new GitCli({ log: diffGarden.log, cwd: tmpDir.path })
+    await gitCli.exec("clone", "https://github.com/garden-io/quickstart-example.git", tmpDir.path)
+    quickstartGarden = await makeTestGarden(tmpDir.path)
+    await gitCli.exec("checkout", "diff-test-changes")
+  })
+
+  after(async () => {
+    await tmpDir.cleanup()
+  })
+
+  // TODO: split this into multiple tests
+  it("compares with an overridden variable", async () => {
+    const { result } = await cmd.action({
+      garden: diffGarden,
+      log: diffGarden.log,
+      args: {},
+      opts: { ...defaultOpts, "diff-var": [[{ key: "build-a", value: "override-a" }]] },
+    })
+
+    expect(result.projectConfig.status).to.equal("unchanged")
+    expect(result.projectConfig.rawConfigDiff).to.be.null
+    expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('-  "build-a": "override-a"')
+    expect(stripAnsi(result.projectConfig.resolvedVariablesDiff ?? "")).to.include('+  "build-a": "build-a"')
+
+    expect(result.actions["test.test-a"].status).to.equal("modified")
+    const testADiffSummary = stripAnsi(result.actions["test.test-a"].diffSummary)
+    expect(testADiffSummary).to.include("M  deploy.deploy-a")
+    expect(testADiffSummary).to.include("Source files unchanged")
+    expect(testADiffSummary).to.include("0 dependants affected by modification")
+
+    expect(result.actions["deploy.deploy-a"].status).to.equal("modified")
+    const deployADiffSummary = stripAnsi(result.actions["deploy.deploy-a"].diffSummary)
+    expect(deployADiffSummary).to.include("M  build.build-a")
+    expect(deployADiffSummary).to.include("Source files unchanged")
+    expect(deployADiffSummary).to.include("1 dependant(s) affected by modification")
+    expect(result.actions["deploy.deploy-a"].affectedDependants.length).to.equal(1)
+    expect(result.actions["deploy.deploy-a"].affectedDependants[0].key).to.equal("test.test-a")
+
+    expect(result.actions["build.build-a"].status).to.equal("modified")
+    expect(result.actions["build.build-a"].rawConfigDiff).to.be.null
+    expect(result.actions["build.build-a"].resolvedConfigDiff).to.include("override-a")
+    const buildADiffSummary = stripAnsi(result.actions["build.build-a"].diffSummary)
+    expect(buildADiffSummary).to.include("Source files unchanged")
+    expect(buildADiffSummary).to.include("2 dependant(s) affected by modification (1 directly, 1 transitively)")
+    expect(result.actions["build.build-a"].affectedDependants.length).to.equal(2)
+  })
+
+  it("compares with an overridden local environment variable", async () => {
+    const { result } = await cmd.action({
+      garden: diffGarden,
+      log: diffGarden.log,
+      args: {},
+      opts: {
+        ...defaultOpts,
+        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+      },
+    })
+
+    const testAResult = result.actions["test.test-a"]
+    expect(testAResult.status).to.equal("modified")
+    expect(testAResult.rawConfigDiff).to.be.null
+    expect(testAResult.resolvedConfigDiff).to.include("override-a")
+  })
+
+  it("compares with a different environment", async () => {
+    const { result } = await cmd.action({
+      garden: diffGarden,
+      log: diffGarden.log,
+      args: {},
+      opts: { ...defaultOpts, "diff-env": "other.local" },
+    })
+
+    const testAResult = result.actions["test.test-a"]
+    expect(testAResult.status).to.equal("modified")
+    expect(testAResult.rawConfigDiff).to.be.null
+    expect(testAResult.resolvedConfigDiff).to.include("other")
+  })
+
+  it("compares workflows", async () => {
+    const { result } = await cmd.action({
+      garden: diffGarden,
+      log: diffGarden.log,
+      args: {},
+      opts: { ...defaultOpts, "diff-var": [[{ key: "workflow-a", value: "override-a" }]] },
+    })
+
+    expect(result.workflows["workflow-a"].status).to.equal("modified")
+    expect(result.workflows["workflow-a"].rawConfigDiff).to.be.null
+  })
+
+  it("compares with a different branch", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(result.projectConfig.resolvedVariablesDiff).to.include('+  "postgresPassword": "foo"')
+  })
+
+  it("compares with a different commit", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, commit: "58afed93698054ac47cd56223c7b37c4c496de0e" },
+    })
+
+    expect(result.projectConfig.resolvedVariablesDiff).to.include('+  "postgresPassword": "foo"')
+  })
+
+  it("filters to specific actions", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: {
+        ...defaultOpts,
+        "action": ["test.test-a"],
+        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+      },
+    })
+
+    expect(result.actions["test.test-a"]).to.exist
+    expect(Object.keys(result.actions)).to.have.length(1)
+  })
+
+  it("skips resolving the actions with --resolve=false", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: {
+        ...defaultOpts,
+        "resolve": false,
+        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+      },
+    })
+
+    for (const action of Object.values(result.actions)) {
+      expect(action.resolvedConfigDiff).to.be.null
+    }
+  })
+
+  it("picks up direct project config changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.actions["test.test-a"].rawConfigDiff ?? "")).to.include("+  postgresPassword: foo")
+    expect(stripAnsi(result.actions["test.test-a"].diffSummary)).to.include("+  postgresPassword: foo")
+  })
+
+  it("picks up direct action config changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.actions["test.test-a"].rawConfigDiff ?? "")).to.include("+  env:")
+    expect(stripAnsi(result.actions["test.test-a"].diffSummary)).to.include("+  env:")
+  })
+
+  it("picks up direct workflow config changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    expect(stripAnsi(result.workflows["test-a"].rawConfigDiff ?? "")).to.include("+    script: echo changed")
+    expect(stripAnsi(result.workflows["test-b"].status)).to.equal("removed")
+    expect(stripAnsi(result.workflows["test-c"].status)).to.equal("added")
+  })
+
+  it("picks up source file changes", async () => {
+    const { result } = await cmd.action({
+      garden: quickstartGarden,
+      log: quickstartGarden.log,
+      args: {},
+      opts: { ...defaultOpts, branch: "diff-test-base" },
+    })
+
+    const summary = stripAnsi(result.actions["build.api"].diffSummary)
+    expect(summary).to.include("Source files changed")
+    expect(summary).to.include("M Dockerfile")
+    expect(summary).to.include("+ test.txt")
+    expect(summary).to.include("8 files unchanged")
+
+    const files = result.actions["build.api"].files
+    const changedFiles = files.filter((file) => file.status === "modified")
+    expect(changedFiles).to.have.length(1)
+    expect(changedFiles[0].path).to.equal("Dockerfile")
+    const addedFiles = files.filter((file) => file.status === "added")
+    expect(addedFiles).to.have.length(1)
+    expect(addedFiles[0].path).to.equal("test.txt")
+  })
+})

--- a/core/test/unit/src/commands/diff.ts
+++ b/core/test/unit/src/commands/diff.ts
@@ -16,11 +16,11 @@ describe("DiffCommand", () => {
   const cmd = new DiffCommand()
   const projectRoot = getDataDir("test-projects", "diff")
   const defaultOpts = withDefaultGlobalOpts({
-    "commit": undefined,
-    "branch": undefined,
-    "diff-env": undefined,
-    "diff-local-env": undefined,
-    "diff-var": undefined,
+    "b-commit": undefined,
+    "b-branch": undefined,
+    "b-env": undefined,
+    "b-local-env-var": undefined,
+    "b-var": undefined,
     // Note: Defaulting to --resolve=true to ensure that the actions are fully resolved before comparing.
     "resolve": true,
     "action": undefined,
@@ -38,7 +38,7 @@ describe("DiffCommand", () => {
       garden: diffGarden,
       log: diffGarden.log,
       args: {},
-      opts: { ...defaultOpts, "diff-var": [[{ key: "build-a", value: "override-a" }]] },
+      opts: { ...defaultOpts, "b-var": [[{ key: "build-a", value: "override-a" }]] },
     })
 
     expect(result.projectConfig.status).to.equal("unchanged")
@@ -76,7 +76,7 @@ describe("DiffCommand", () => {
       args: {},
       opts: {
         ...defaultOpts,
-        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+        "b-local-env-var": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
       },
     })
 
@@ -91,7 +91,7 @@ describe("DiffCommand", () => {
       garden: diffGarden,
       log: diffGarden.log,
       args: {},
-      opts: { ...defaultOpts, "diff-env": "other.local" },
+      opts: { ...defaultOpts, "b-env": "other.local" },
     })
 
     const testAResult = result.actions["test.test-a"]
@@ -108,7 +108,7 @@ describe("DiffCommand", () => {
       opts: {
         ...defaultOpts,
         "action": ["test.test-a"],
-        "diff-local-env": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
+        "b-local-env-var": [[{ key: "TEST_ENV_VAR_TEST_A", value: "override-a" }]],
       },
     })
 

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -82,6 +82,7 @@ describe("resolveProjectConfig", () => {
           backendType: "v1",
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       })
     await expectError(processConfigAction, {
@@ -113,6 +114,7 @@ describe("resolveProjectConfig", () => {
           backendType: "v1",
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       })
     ).to.eql({
@@ -179,6 +181,7 @@ describe("resolveProjectConfig", () => {
             backendType: "v1",
             secrets: { foo: "banana" },
             commandInfo,
+            localEnvOverrides: {},
           }),
         })
       )
@@ -259,6 +262,7 @@ describe("resolveProjectConfig", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
         })
       )
@@ -323,6 +327,7 @@ describe("resolveProjectConfig", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
     })
 
@@ -362,6 +367,7 @@ describe("resolveProjectConfig", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
         })
       )
@@ -416,6 +422,7 @@ describe("resolveProjectConfig", () => {
           backendType: "v1",
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       })
     ).to.eql({
@@ -455,6 +462,7 @@ describe("resolveProjectConfig", () => {
           backendType: "v1",
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       })
     ).to.eql({
@@ -510,6 +518,7 @@ describe("resolveProjectConfig", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
     })
     expect(resolvedConfig).to.eql({
@@ -581,6 +590,7 @@ describe("pickEnvironment", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
           projectConfig: config,
           variableOverrides: {},
@@ -592,6 +602,7 @@ describe("pickEnvironment", () => {
           cloudBackendDomain,
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       "parameter"
     )
@@ -615,6 +626,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
       projectConfig: config,
       variableOverrides: {},
@@ -626,6 +638,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const providerNames = res.providers.map((p) => p.name)
@@ -659,6 +672,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -671,6 +685,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     expect(omit(env, "providers", "variables")).to.eql({
@@ -740,6 +755,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -752,6 +768,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -805,6 +822,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -817,6 +835,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -865,6 +884,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -877,6 +897,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -925,6 +946,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -937,6 +959,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -986,6 +1009,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -998,6 +1022,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -1057,6 +1082,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1069,6 +1095,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -1129,6 +1156,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1141,6 +1169,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -1173,6 +1202,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1185,6 +1215,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: { foo: "banana" },
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -1216,6 +1247,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1228,6 +1260,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
   })
 
@@ -1251,6 +1284,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1263,6 +1297,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -1323,6 +1358,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1335,6 +1371,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     const variables = deepResolveContext("resolved env variables", result.variables)
@@ -1377,6 +1414,7 @@ describe("pickEnvironment", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
 
           projectConfig: config,
@@ -1389,6 +1427,7 @@ describe("pickEnvironment", () => {
           cloudBackendDomain,
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       { contains: ["Error validating environment default", "defaultNamespace must be a string"] }
     )
@@ -1422,6 +1461,7 @@ describe("pickEnvironment", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
 
           projectConfig: config,
@@ -1434,6 +1474,7 @@ describe("pickEnvironment", () => {
           cloudBackendDomain,
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       { contains: "Could not find varfile at path 'foo.env'" }
     )
@@ -1467,6 +1508,7 @@ describe("pickEnvironment", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
 
           projectConfig: config,
@@ -1479,6 +1521,7 @@ describe("pickEnvironment", () => {
           cloudBackendDomain,
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       { contains: "Could not find varfile at path 'foo.env'" }
     )
@@ -1502,6 +1545,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1514,6 +1558,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     expect(res.environmentName).to.equal("default")
@@ -1538,6 +1583,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1550,6 +1596,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     expect(res.environmentName).to.equal("default")
@@ -1574,6 +1621,7 @@ describe("pickEnvironment", () => {
         backendType: "v1",
         secrets: {},
         commandInfo,
+        localEnvOverrides: {},
       }),
 
       projectConfig: config,
@@ -1586,6 +1634,7 @@ describe("pickEnvironment", () => {
       cloudBackendDomain,
       secrets: {},
       commandInfo,
+      localEnvOverrides: {},
     })
 
     expect(res.environmentName).to.equal("default")
@@ -1612,6 +1661,7 @@ describe("pickEnvironment", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
 
           projectConfig: config,
@@ -1624,6 +1674,7 @@ describe("pickEnvironment", () => {
           cloudBackendDomain,
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       { contains: "Invalid environment specified ($.%): must be a valid environment name or <namespace>.<environment>" }
     )
@@ -1650,6 +1701,7 @@ describe("pickEnvironment", () => {
             backendType: "v1",
             secrets: {},
             commandInfo,
+            localEnvOverrides: {},
           }),
           projectConfig: config,
           variableOverrides: {},
@@ -1661,6 +1713,7 @@ describe("pickEnvironment", () => {
           cloudBackendDomain,
           secrets: {},
           commandInfo,
+          localEnvOverrides: {},
         }),
       {
         contains:

--- a/core/test/unit/src/config/template-contexts/module.ts
+++ b/core/test/unit/src/config/template-contexts/module.ts
@@ -30,6 +30,8 @@ describe("ModuleConfigContext", () => {
     const modules = graph.getModules()
     module = graph.getModule("module-b")
 
+    garden.localEnvOverrides.TEST_VARIABLE = "foo"
+
     c = new ModuleConfigContext({
       garden,
       resolvedProviders: keyBy(await garden.resolveProviders({ log: garden.log }), "name"),
@@ -45,7 +47,6 @@ describe("ModuleConfigContext", () => {
   })
 
   it("should resolve local env variables", async () => {
-    process.env.TEST_VARIABLE = "foo"
     expect(c.resolve({ nodePath: [], key: ["local", "env", "TEST_VARIABLE"], opts: {} })).to.eql({
       found: true,
       resolved: "foo",
@@ -156,16 +157,15 @@ describe("WorkflowConfigContext", () => {
   before(async () => {
     garden = await makeTestGardenA()
     garden["secrets"] = { someSecret: "someSecretValue" }
+    garden.localEnvOverrides.TEST_VARIABLE = "foo"
     c = new WorkflowConfigContext(garden, garden.variables)
   })
 
   it("should resolve local env variables", async () => {
-    process.env.TEST_VARIABLE = "foo"
     expect(c.resolve({ nodePath: [], key: ["local", "env", "TEST_VARIABLE"], opts: {} })).to.eql({
       found: true,
       resolved: "foo",
     })
-    delete process.env.TEST_VARIABLE
   })
 
   it("should resolve the local platform", async () => {

--- a/core/test/unit/src/config/template-contexts/project.ts
+++ b/core/test/unit/src/config/template-contexts/project.ts
@@ -94,6 +94,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["local", "env", "TEST_VARIABLE"], opts: {} })).to.eql({
       found: true,
@@ -114,6 +115,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["git", "branch"], opts: {} })).to.eql({
       found: true,
@@ -133,6 +135,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: { foo: "banana" },
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["secrets", "foo"], opts: {} })).to.eql({
       found: true,
@@ -153,6 +156,7 @@ describe("ProjectConfigContext", () => {
         backendType: "v1",
         secrets: { foo: "banana" },
         commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+        localEnvOverrides: {},
       })
 
       const result = c.resolve({ nodePath: [], key: ["secrets", "bar"], opts: {} })
@@ -175,6 +179,7 @@ describe("ProjectConfigContext", () => {
           backendType: "v1",
           secrets: {}, // <-----
           commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+          localEnvOverrides: {},
         })
 
         const result = c.resolve({ nodePath: [], key: ["secrets", "bar"], opts: {} })
@@ -197,6 +202,7 @@ describe("ProjectConfigContext", () => {
           backendType: "v1",
           secrets: { foo: "banana " }, // <-----
           commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+          localEnvOverrides: {},
         })
 
         const result = c.resolve({ nodePath: [], key: ["secrets", "bar"], opts: {} })
@@ -220,6 +226,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     const key = "fiaogsyecgbsjyawecygaewbxrbxajyrgew"
 
@@ -241,6 +248,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
 
     const result = c.resolve({ nodePath: [], key: ["var", "foo"], opts: {} })
@@ -261,6 +269,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["local", "arch"], opts: {} })).to.eql({
       found: true,
@@ -280,6 +289,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["local", "platform"], opts: {} })).to.eql({
       found: true,
@@ -299,6 +309,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["local", "username"], opts: {} })).to.eql({
       found: true,
@@ -322,6 +333,7 @@ describe("ProjectConfigContext", () => {
       backendType: "v1",
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {}, rawArgs: [], isCustomCommand: false },
+      localEnvOverrides: {},
     })
     expect(c.resolve({ nodePath: [], key: ["command", "name"], opts: {} })).to.eql({
       found: true,
@@ -347,6 +359,7 @@ describe("ProjectConfigContext", () => {
         rawArgs: ["--sync", "my-service"],
         isCustomCommand: false,
       },
+      localEnvOverrides: {},
     })
 
     const result = legacyResolveTemplateString({
@@ -358,6 +371,7 @@ describe("ProjectConfigContext", () => {
 
   it("should resolve command params (negative)", () => {
     const c = new ProjectConfigContext({
+      localEnvOverrides: {},
       projectName: "some-project",
       projectRoot: "/tmp",
       artifactsPath: "/tmp",

--- a/core/test/unit/src/config/template-contexts/workflow.ts
+++ b/core/test/unit/src/config/template-contexts/workflow.ts
@@ -24,11 +24,11 @@ describe("WorkflowConfigContext", () => {
   before(async () => {
     garden = await makeTestGardenA()
     garden["secrets"] = { someSecret: "someSecretValue" }
+    garden.localEnvOverrides.TEST_VARIABLE = "foo"
     c = new WorkflowConfigContext(garden, garden.variables)
   })
 
   it("should resolve local env variables", async () => {
-    process.env.TEST_VARIABLE = "foo"
     expect(c.resolve({ nodePath: [], key: ["local", "env", "TEST_VARIABLE"], opts: {} })).to.eql({
       found: true,
       resolved: "foo",

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1392,9 +1392,11 @@ Compare the current working directory Garden project with the specified branch o
 
 Use this to understand the impact of your changes on action versions.
 
-In most cases you should use this with the --resolve flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.
+In most cases you should use this with the `--resolve` flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the `--action` flag to only diff specific actions.
 
 Note that in the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
+
+When setting the `--diff-X` flags, the values will be overridden in the comparison project (B). If you want to change variables or set a different environment in the _current_ project (A), you can use the normal `--var`, `--env` etc. flags. For example, if you want to test the impact of overriding a variable value for both sides, you can use the `--var` flag to override the value in the current project (A), and then use the `--diff-var` flag to override the value in the comparison project (B), e.g. `--diff-var some-var=foo --var some-var=bar`.
 
 #### Usage
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1382,6 +1382,37 @@ tasks:
     log:
 ```
 
+### garden diff
+
+**[EXPERIMENTAL] Compare the current working directory Garden project with the specified branch or commit.**
+
+**[EXPERIMENTAL] This command is still under development and may change in the future, including parameters and output format.**
+
+Compare the current working directory Garden project with the specified branch or commit.
+
+Use this to understand the impact of your changes on action versions.
+
+In most cases you should use this with the --resolve flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.
+
+Note that in the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
+
+#### Usage
+
+    garden diff [options]
+
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--commit` |  | string | A commit ID to compare with.
+  | `--branch` |  | string | A branch to compare with.
+  | `--diff-env` |  | string | Override the Garden environment for the comparison.
+  | `--diff-local-env` |  | array:tag | Override a local environment variable in the comparison (as templated using ${local.env.*}) with the specified value, formatted as &lt;VAR_NAME&gt;:&lt;VALUE&gt;, e.g. &quot;MY_VAR&#x3D;my-value&quot;. You can specify multiple variables by repeating the flag.
+  | `--diff-var` |  | array:tag | Override a variable in the comparison with the specified value, formatted as &lt;VAR_NAME&gt;:&lt;VALUE&gt;, e.g. &quot;MY_VAR&#x3D;my-value&quot;. Analogous to the --var global flag in the Garden CLI. You can specify multiple variables by repeating the flag.
+  | `--resolve` |  | boolean | Fully resolve each action before comparing. Note that this may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.
+  | `--action` |  | array:string | Specify an action to diff, as &lt;kind&gt;.&lt;name&gt;. Can be specified multiple times. If none is specified, all actions will be diffed.
+
+
 ### garden exec
 
 **Executes a command (such as an interactive shell) in a running service.**

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1388,15 +1388,17 @@ tasks:
 
 **[EXPERIMENTAL] This command is still under development and may change in the future, including parameters and output format.**
 
-Compare the current working directory Garden project with the specified branch or commit.
+Compare the current working directory Garden project with the specified branch/commit, or with other differences (all specified via `--b-X` flags).
 
 Use this to understand the impact of your changes on action versions.
 
+In the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
+
+The different `--b-X` flags define the comparison project (B). At least one of these flags must be specified, and they can be combined in any number of ways.
+
+When setting the `--b-X` flags, the values will be overridden in the comparison project (B). If you want to change variables or set a different environment in the _current_ project (A), you can use the normal `--var`, `--env` etc. flags. For example, if you want to test the impact of overriding a variable value for both sides, you can use the `--var` flag to override the value in the current project (A), and then use the `--b-var` flag to override the value in the comparison project (B), e.g. `--b-var some-var=foo --var some-var=bar`.
+
 In most cases you should use this with the `--resolve` flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the `--action` flag to only diff specific actions.
-
-Note that in the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.
-
-When setting the `--diff-X` flags, the values will be overridden in the comparison project (B). If you want to change variables or set a different environment in the _current_ project (A), you can use the normal `--var`, `--env` etc. flags. For example, if you want to test the impact of overriding a variable value for both sides, you can use the `--var` flag to override the value in the current project (A), and then use the `--diff-var` flag to override the value in the comparison project (B), e.g. `--diff-var some-var=foo --var some-var=bar`.
 
 #### Usage
 
@@ -1406,13 +1408,13 @@ When setting the `--diff-X` flags, the values will be overridden in the comparis
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--commit` |  | string | A commit ID to compare with.
-  | `--branch` |  | string | A branch to compare with.
-  | `--diff-env` |  | string | Override the Garden environment for the comparison.
-  | `--diff-local-env` |  | array:tag | Override a local environment variable in the comparison (as templated using ${local.env.*}) with the specified value, formatted as &lt;VAR_NAME&gt;:&lt;VALUE&gt;, e.g. &quot;MY_VAR&#x3D;my-value&quot;. You can specify multiple variables by repeating the flag.
-  | `--diff-var` |  | array:tag | Override a variable in the comparison with the specified value, formatted as &lt;VAR_NAME&gt;:&lt;VALUE&gt;, e.g. &quot;MY_VAR&#x3D;my-value&quot;. Analogous to the --var global flag in the Garden CLI. You can specify multiple variables by repeating the flag.
+  | `--b-commit` |  | string | Check out the specified commit in the comparison project (B).
+  | `--b-branch` |  | string | Check out the specified branch in the comparison project (B).
+  | `--b-env` |  | string | Override the Garden environment for the comparison project (B).
+  | `--b-local-env-var` |  | array:tag | Override a local environment variable in the comparison project (B), as templated using ${local.env.*}, with the specified value. This should be formatted as &lt;VAR_NAME&gt;:&lt;VALUE&gt;, e.g. &quot;MY_VAR&#x3D;my-value&quot;. You can specify multiple variables by repeating the flag.
+  | `--b-var` |  | array:tag | Override a Garden variable in the comparison project (B) with the specified value, formatted as &lt;VAR_NAME&gt;:&lt;VALUE&gt;, e.g. &quot;MY_VAR&#x3D;my-value&quot;. Analogous to the --var global flag in the Garden CLI. You can specify multiple variables by repeating the flag.
   | `--resolve` |  | boolean | Fully resolve each action before comparing. Note that this may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.
-  | `--action` |  | array:string | Specify an action to diff, as &lt;kind&gt;.&lt;name&gt;. Can be specified multiple times. If none is specified, all actions will be diffed.
+  | `--action` |  | array:string | Specify an action to diff, as &lt;kind&gt;.&lt;name&gt;. Can be specified multiple times. If none is specified, all actions will be compared.
 
 
 ### garden exec

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1400,6 +1400,24 @@ When setting the `--b-X` flags, the values will be overridden in the comparison 
 
 In most cases you should use this with the `--resolve` flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the `--action` flag to only diff specific actions.
 
+Examples:
+# compare the current default environment to the ci environment (assuming one is defined in the project configuration)
+garden diff --b-env ci
+# compare the current default environment to the ci environment and fully resolve values for a complete comparison (note that this may trigger actions being executed)
+garden diff --b-env ci --resolve
+# compare the staging env to the ci env
+garden diff --env staging --b-env ci
+# compare the current branch to other-branch (using the default environment in both cases)
+garden diff --b-branch other-branch
+# compare the current branch's default environment to other-branch's ci environment
+garden diff --b-branch other-branch --b-env ci
+# compare the resolved api Build action between the default environment and ci
+garden diff --b-env ci --action build.api --resolve
+# compare the current default environment to the ci environment and override the HOSTNAME variable in the ci environment
+garden diff --b-env ci --b-var HOSTNAME=remote.acme
+# compare the current default environment to the ci environment and override the HOSTNAME variable in both environments
+garden diff --var HOSTNAME=local.acme --b-env ci --b-var HOSTNAME=remote.acme
+
 #### Usage
 
     garden diff [options]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,6 +1071,7 @@
         "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
         "@jsdevtools/readdir-enhanced": "^6.0.4",
         "@kubernetes/client-node": "1.3.0",
+        "@langchain/core": "^0.3.72",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.203.0",
@@ -1102,6 +1103,7 @@
         "dedent": "^1.6.0",
         "deline": "^1.0.4",
         "dependency-graph": "^0.11.0",
+        "diff": "^8.0.2",
         "directory-tree": "^3.5.2",
         "docker-file-parser": "^1.0.7",
         "dotenv": "^16.6.1",
@@ -2950,6 +2952,310 @@
         "b4a": "^1.6.4"
       }
     },
+    "core/node_modules/@langchain/core": {
+      "version": "0.3.72",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.72.tgz",
+      "integrity": "sha512-WsGWVZYnlKffj2eEfDocPNiaTRoxyYiLSQdQ7oxZvxGZBqo/90vpjbC33UGK1uPNBM4kT+pkdaol/MnvKUh8TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.3.46",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.25.32",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "core/node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/js-tiktoken/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith": {
+      "version": "0.3.66",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.66.tgz",
+      "integrity": "sha512-d50FJ25HPAT2e/6u7oPAYFYH7uvVhxf7vThAOE5tP6YFIUHwLMBmJj8R4Z7APp5jF4/m8upvbK4J4jP5UIN+Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/chalk/node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/chalk/node_modules/ansi-styles/node_modules/color-convert/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/chalk/node_modules/supports-color/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/console-table-printer": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
+      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.0.1"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/langsmith/node_modules/console-table-printer/node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "license": "MIT"
+    },
+    "core/node_modules/@langchain/core/node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "core/node_modules/@langchain/core/node_modules/p-queue/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/p-queue/node_modules/p-timeout/node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "core/node_modules/@langchain/core/node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "core/node_modules/@langchain/core/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "core/node_modules/@opentelemetry/core": {
       "version": "2.0.1",
       "license": "Apache-2.0",
@@ -3739,6 +4045,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "core/node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "core/node_modules/docker-file-parser": {
@@ -18451,7 +18766,6 @@
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/write-file-atomic": {


### PR DESCRIPTION
Adds an experimental command to compare the current project to a given branch,
commit, different variables, environment etc.

This is experimental for now, but should be good enough to ship and get
feedback.

From the command help text:

---

**[EXPERIMENTAL] This command is still under development and may change in the future, including parameters and output format.**

Compare the current working directory Garden project with the specified branch or commit.

Use this to understand the impact of your changes on action versions.

In most cases you should use this with the --resolve flag to ensure that the comparison is complete, but take caution as it may result in actions being executed during resolution (e.g. if a runtime output is referenced by another action, it will be executed in order to fully resolve the config). In such cases, you may want to avoid this option or use the --action flag to only diff specific actions.

Note that in the output, "A" (e.g. "version A") refers to the current working directory project, and "B" refers to the project at the specified branch or commit. When something is reported as "added" (such as an action, file, new lines in a config etc.), it means it's present in the current project but not in the comparison project. Similarly, "removed" means it's present in the comparison project but not in the current project.

---

TODO:
- [x] Fix tests (seems the tests are broken, not the code itself, but will verify)
- [x] Clarify a few more things in the docs (easy to get confused about the `--diff-X` params, for example)