### PR TITLE
chore(ci): fix apt-get command missing '-y' flag

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -688,6 +688,7 @@ jobs:
       - *attach-workspace
       - run:
           name: Create a release on GitHub. If the release is a pre-release we publish it right away, otherwise we make a draft.
+          # NOTE: The GITHUB_TOKEN expires 2026-09-07
           command: |
             VERSION="$(cat package.json | jq -r .version)"
             PRERELEASE=""
@@ -1395,7 +1396,7 @@ workflows:
           k3sVersion: v1.31.1+k3s1
       - test-minikube:
           name: vm-1.31-minikube
-          requires: [ build ]
+          requires: [build]
           kubernetesVersion: "v1.31.0"
           minikubeVersion: "v1.34.0"
       - test-kind:
@@ -1404,7 +1405,7 @@ workflows:
           kindNodeImage: kindest/node:v1.32.3@sha256:b36e76b4ad37b88539ce5e07425f77b29f73a8eaaebf3f1a8bc9c764401d118c
       - test-microk8s:
           name: vm-1.33-microk8s
-          requires: [ build ]
+          requires: [build]
           kubernetesVersion: "1.33"
 
       - test-plugins:

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -222,8 +222,8 @@ async function release() {
     If this is not a pre-release, create a pull request for ${branchName} on Github by visiting:
       https://github.com/garden-io/garden/pull/new/${branchName}\n
 
-    Please refer to our contributing docs for the next steps:
-    https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md
+    Please refer to our release process docs for the next steps:
+    https://github.com/garden-io/garden/blob/main/RELEASE_PROCESS.md
   `)
   }
 }

--- a/support/debian.Dockerfile
+++ b/support/debian.Dockerfile
@@ -97,7 +97,7 @@ FROM garden-base-root as garden-azure-base
 ENV AZURE_CLI_VERSION=2.76.0
 
 RUN apt-get update
-RUN apt-get install ca-certificates curl apt-transport-https lsb-release gnupg
+RUN apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
     gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null
@@ -105,7 +105,7 @@ RUN chmod go+r /etc/apt/keyrings/microsoft.gpg
 RUN echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | \
     tee /etc/apt/sources.list.d/azure-cli.list
 RUN apt-get update
-RUN apt-get install azure-cli=${AZURE_CLI_VERSION}-1~bookworm
+RUN apt-get install azure-cli=${AZURE_CLI_VERSION}-1~bookworm -y
 RUN az aks install-cli
 
 #


### PR DESCRIPTION
This commit fixes a couple of things I bumped into when releasing 0.14.8.

One was that there's apt-get install command that's missing the "-y" flag and timing out in CI.

I'm assuming this is coming up now because we merged a dependabot PR that updated the Dockerfile base image. Not sure why this hasn't come up before though.

Another issue was with an expired token and simply add a comment in the relevant place.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
