### PR TITLE
chore: remove GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES feature flag

### DIFF
--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -490,7 +490,7 @@ export const projectSchema = createSchema({
     remoteVariables: getRemoteVariablesBaseSchema()
       .description(
         dedent`
-      EXPERIMENTAL: This is an experimental feature that requires setting "GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES=true" and enabling variables for your organization in Garden Cloud (currenty only
+      EXPERIMENTAL: This is an experimental feature that requires enabling variables for your organization in Garden Cloud (currenty only
       available in early access).
 
       Specify a variable list (or array of variable lists) from which to load variables/secrets. The lists and their variables/secrets are created in [Garden Cloud](https://app.garden.io/variables).

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -116,9 +116,4 @@ export const gardenEnv = {
     .required(false)
     .default("false")
     .asBool(),
-  GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES: env
-    .get("GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES")
-    .required(false)
-    .default("false")
-    .asBool(),
 }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -2140,7 +2140,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
         skipCloudConnect,
       })
       secrets = initRes.secrets
-    } else if (cloudApi && gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES) {
+    } else if (cloudApi) {
       const cloudLog = log.createLog({ name: getCloudLogSectionName("Garden Cloud") })
       secrets = await cloudApi.getVariables({
         remoteVariables: projectConfig.remoteVariables,

--- a/core/test/unit/src/commands/get/get-variables.ts
+++ b/core/test/unit/src/commands/get/get-variables.ts
@@ -13,7 +13,6 @@ import { GetVariablesCommand } from "../../../../../src/commands/get/get-variabl
 import type { ApiTrpcClient } from "../../../../../src/cloud/api/trpc.js"
 import { getRootLogger } from "../../../../../src/logger/logger.js"
 import type { DeepPartial } from "../../../../../src/util/util.js"
-import { gardenEnv } from "../../../../../src/constants.js"
 import { makeFakeCloudApi } from "../../../../helpers/api.js"
 
 function makeFakeTrpcClient(overrides?: DeepPartial<ApiTrpcClient>): ApiTrpcClient {
@@ -66,20 +65,16 @@ function makeFakeTrpcClient(overrides?: DeepPartial<ApiTrpcClient>): ApiTrpcClie
 
 describe("GetVariablesCommand", () => {
   const varProjectRoot = getDataDir("test-projects", "get-variables-command")
-  // TODO: Remove this once variables are GA
-  const originalEnvVal = gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES
   let configStoreTmpDir: tmp.DirectoryResult
   const command = new GetVariablesCommand()
   const log = getRootLogger().createLog()
 
   before(async () => {
-    gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES = true
     configStoreTmpDir = await makeTempDir()
   })
 
   after(async () => {
     await configStoreTmpDir.cleanup()
-    gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES = originalEnvVal
   })
 
   it("returns all variables for project, leaving action-level template strings unresolved", async () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -911,93 +911,83 @@ describe("Garden", () => {
         expect(garden.secrets).to.eql({})
       })
 
-      // TODO: Remove this context block once variables are GA
-      context("GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES=true", () => {
-        const originalVal = gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES
-        before(() => {
-          gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES = true
-        })
-        after(() => {
-          gardenEnv.GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES = originalVal
-        })
-
-        it("should have an empty secrets map if 'remoteVariables' is not set", async () => {
-          const fakeTrpcClient: DeepPartial<ApiTrpcClient> = {
-            variableList: {
-              getValues: {
-                query: async () => {
-                  return {
-                    variableA: {
-                      value: "variable-a-val",
-                      isSecret: true,
-                      scopedAccountId: null,
-                      scopedEnvironmentId: null,
-                    },
-                  }
-                },
+      it("should have an empty secrets map if 'remoteVariables' is not set", async () => {
+        const fakeTrpcClient: DeepPartial<ApiTrpcClient> = {
+          variableList: {
+            getValues: {
+              query: async () => {
+                return {
+                  variableA: {
+                    value: "variable-a-val",
+                    isSecret: true,
+                    scopedAccountId: null,
+                    scopedEnvironmentId: null,
+                  },
+                }
               },
             },
-          }
-          const overrideCloudApiFactory = async () =>
-            await makeFakeCloudApi({
-              trpcClient: fakeTrpcClient as ApiTrpcClient,
-              configStoreTmpDir,
-              log,
-            })
-
-          const garden = await TestGarden.factory(pathFoo, {
-            config, // remoteVariables is not set
-            environmentString: envName,
-            overrideCloudApiFactory,
+          },
+        }
+        const overrideCloudApiFactory = async () =>
+          await makeFakeCloudApi({
+            trpcClient: fakeTrpcClient as ApiTrpcClient,
+            configStoreTmpDir,
+            log,
           })
 
-          expect(garden.secrets).to.eql({})
+        const garden = await TestGarden.factory(pathFoo, {
+          config, // remoteVariables is not set
+          environmentString: envName,
+          overrideCloudApiFactory,
         })
 
-        it("should fetch variables if 'remoteVariables' is set", async () => {
-          const fakeTrpcClient: DeepPartial<ApiTrpcClient> = {
-            variableList: {
-              getValues: {
-                query: async () => {
-                  return {
-                    variableA: {
-                      value: "variable-a-val",
-                      isSecret: true,
-                      scopedAccountId: null,
-                      scopedEnvironmentId: null,
-                    },
-                    variableB: {
-                      value: "variable-b-val",
-                      isSecret: true,
-                      scopedAccountId: null,
-                      scopedEnvironmentId: null,
-                    },
-                  }
-                },
+        expect(garden.secrets).to.eql({})
+      })
+
+      it("should fetch variables if 'remoteVariables' is set", async () => {
+        const fakeTrpcClient: DeepPartial<ApiTrpcClient> = {
+          variableList: {
+            getValues: {
+              query: async () => {
+                return {
+                  variableA: {
+                    value: "variable-a-val",
+                    isSecret: true,
+                    scopedAccountId: null,
+                    scopedEnvironmentId: null,
+                  },
+                  variableB: {
+                    value: "variable-b-val",
+                    isSecret: true,
+                    scopedAccountId: null,
+                    scopedEnvironmentId: null,
+                  },
+                }
               },
             },
-          }
-          const overrideCloudApiFactory = async () =>
-            await makeFakeCloudApi({
-              trpcClient: fakeTrpcClient as ApiTrpcClient,
-              configStoreTmpDir,
-              log,
-            })
-
-          const garden = await TestGarden.factory(pathFoo, {
-            config: {
-              ...config,
-              remoteVariables: "varlist_1",
-            },
-            environmentString: envName,
-            overrideCloudApiFactory,
+          },
+        }
+        const overrideCloudApiFactory = async () =>
+          await makeFakeCloudApi({
+            trpcClient: fakeTrpcClient as ApiTrpcClient,
+            configStoreTmpDir,
+            log,
           })
 
-          expect(garden.secrets).to.eql({
-            variableA: "variable-a-val",
-            variableB: "variable-b-val",
-          })
+        const garden = await TestGarden.factory(pathFoo, {
+          config: {
+            ...config,
+            remoteVariables: "varlist_1",
+          },
+          environmentString: envName,
+          overrideCloudApiFactory,
         })
+
+        expect(garden.secrets).to.eql({
+          variableA: "variable-a-val",
+          variableB: "variable-b-val",
+        })
+
         it("should log an error and throw if fetching variables fails", async () => {
           const fakeTrpcClientThatThrowsTrpcError: DeepPartial<ApiTrpcClient> = {
             variableList: {

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -297,8 +297,8 @@ varfile: garden.env
 # permitted, including arrays and objects of any nesting.
 variables: {}
 
-# EXPERIMENTAL: This is an experimental feature that requires setting "GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES=true"
-# and enabling variables for your organization in Garden Cloud (currenty only
+# EXPERIMENTAL: This is an experimental feature that requires enabling variables for your organization in Garden Cloud
+# (currenty only
 # available in early access).
 #
 # Specify a variable list (or array of variable lists) from which to load variables/secrets. The lists and their
@@ -956,7 +956,7 @@ Key/value map of variables to configure for all environments. Keys may contain l
 
 ### `remoteVariables`
 
-EXPERIMENTAL: This is an experimental feature that requires setting "GARDEN_EXPERIMENTAL_USE_CLOUD_VARIABLES=true" and enabling variables for your organization in Garden Cloud (currenty only
+EXPERIMENTAL: This is an experimental feature that requires enabling variables for your organization in Garden Cloud (currenty only
 available in early access).
 
 Specify a variable list (or array of variable lists) from which to load variables/secrets. The lists and their variables/secrets are created in [Garden Cloud](https://app.garden.io/variables).


### PR DESCRIPTION
What it says on the tin. Figure the feature flag isn't necessary since it's effectively controlled by the `variablesFrom` field and the early access controls on the cloud side.