### PR TITLE
fix(cloudbuild): attempt to prevent uncaught exception crash during build

### DIFF
--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -173,6 +173,7 @@ export abstract class CliWrapper {
       stdout,
       stderr,
       tty,
+      log,
     })
   }
 }

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -265,6 +265,7 @@ export interface SpawnOpts {
   stderr?: Writable
   tty?: boolean
   wait?: boolean
+  log?: Log
 }
 
 export interface SpawnOutput {
@@ -296,6 +297,7 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
     stderr,
     tty,
     wait = true,
+    log,
   } = opts
 
   const stdio = tty ? "inherit" : "pipe"
@@ -355,7 +357,11 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
 
     if (timeout > 0) {
       _timeout = setTimeout(() => {
-        proc.kill("SIGKILL")
+        try {
+          proc.kill("SIGKILL")
+        } catch (err) {
+          log?.warn(`Error killing process after timeout: ${err}`)
+        }
         reject(new TimeoutError({ message: `${cmd} timed out after ${timeout} seconds.` }))
       }, timeout * 1000)
     }


### PR DESCRIPTION
This attempts to address an uncaught exception crash reported by a customer. It's not certain that their issue came up due to this fault in the code, but at least it's good to plug it.

Reviewer note: I've tested this manually as well, but I'd feel better if you do the same.