### PR TITLE
fix(k8s): don't log tar availability check output to console

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -578,8 +578,6 @@ async function runWithArtifacts({
         command: ["sh", "-c", "tar --help"],
         containerName: mainContainerName,
         log,
-        stdout,
-        stderr,
         // Anything above 10 minutes for this would be unusual
         timeoutSec: 600,
         buffer: true,


### PR DESCRIPTION
This confused a user of ours, justifiably.