### PR TITLE
feat: allow module-based services+tasks to depend on Deploy+Run actions

### DIFF
--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -192,6 +192,8 @@ interface ActionReferenceSchema extends Joi.AnySchema {
   kind(kind: ActionKind): this
 
   name(type: string): this
+
+  returnString(): this
 }
 
 export interface Schema extends Joi.Root {
@@ -720,6 +722,7 @@ joi = joi.extend({
   flags: {
     kind: { default: undefined },
     name: { default: undefined },
+    returnString: { default: false },
   },
   messages: {
     validation: "<not used>",
@@ -735,6 +738,10 @@ joi = joi.extend({
         const error = opts.error("wrongKind")
         error.message += ` Expected '${expectedKind}', got '${value.kind}'`
         return { value, errors: error }
+      }
+
+      if (opts.schema.$_getFlag("returnString")) {
+        return { value: `${value.kind.toLowerCase()}.${value.name}` }
       }
 
       return { value }
@@ -779,6 +786,15 @@ joi = joi.extend({
       },
       validate(value) {
         // Note: This is currently only advisory, and must be validated elsewhere!
+        return value
+      },
+    },
+    returnString: {
+      method() {
+        return this.$_setFlag("returnString", true)
+      },
+      validate(value) {
+        // This is validated above ^
         return value
       },
     },

--- a/core/src/config/service.ts
+++ b/core/src/config/service.ts
@@ -24,9 +24,11 @@ export interface CommonServiceSpec {
 export const serviceOutputsSchema = joiVariables()
 
 export const dependenciesSchema = memoize(() =>
-  joiSparseArray(joiIdentifier()).description(deline`
+  joiSparseArray(joi.alternatives().try(joiIdentifier(), joi.actionReference().returnString())).description(deline`
     The names of any services that this service depends on at runtime, and the names of any
     tasks that should be executed before this service is deployed.
+
+    You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
   `)
 )
 

--- a/core/src/config/task.ts
+++ b/core/src/config/task.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { joiUserIdentifier, joi, joiSparseArray, createSchema } from "./common.js"
+import { joiUserIdentifier, joi, joiSparseArray, createSchema, joiIdentifier } from "./common.js"
 import { deline, dedent } from "../util/string.js"
 import { memoize } from "lodash-es"
 import { DEFAULT_RUN_TIMEOUT_SEC } from "../constants.js"
@@ -38,8 +38,11 @@ export const baseTaskSpecSchema = createSchema({
   keys: () => ({
     name: joiUserIdentifier().required().description("The name of the task."),
     description: joi.string().optional().description("A description of the task."),
-    dependencies: joiSparseArray(joi.string()).description(deline`
+    dependencies: joiSparseArray(joi.alternatives().try(joiIdentifier(), joi.actionReference().returnString()))
+      .description(deline`
       The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
+
+      You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
     `),
     disabled: joi
       .boolean()

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -158,7 +158,7 @@ describe("util", () => {
     const modules = helmGraph.getModules()
     const graph = helmGraph
     const router = await helmGarden.getActionRouter()
-    const { actions } = await convertModules(helmGarden, helmGarden.log, modules, graph.moduleGraph)
+    const { actions } = await convertModules(helmGarden, helmGarden.log, modules, graph.moduleGraph, new Set())
 
     const tasks = await Promise.all(
       actions.map(async (rawAction) => {

--- a/core/test/unit/src/graph/common.ts
+++ b/core/test/unit/src/graph/common.ts
@@ -37,7 +37,7 @@ describe("graph common", () => {
           spec: {},
         },
       ]
-      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
+      expect(() => detectMissingDependencies({ moduleConfigs })).to.throw()
     })
 
     it("should return an error when a service dependency is missing", async () => {
@@ -64,7 +64,7 @@ describe("graph common", () => {
           spec: {},
         },
       ]
-      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
+      expect(() => detectMissingDependencies({ moduleConfigs })).to.throw()
     })
 
     it("should return an error when a task dependency is missing", async () => {
@@ -92,7 +92,7 @@ describe("graph common", () => {
           spec: {},
         },
       ]
-      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
+      expect(() => detectMissingDependencies({ moduleConfigs })).to.throw()
     })
 
     it("should return an error when a test dependency is missing", async () => {
@@ -119,7 +119,7 @@ describe("graph common", () => {
           spec: {},
         },
       ]
-      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
+      expect(() => detectMissingDependencies({ moduleConfigs })).to.throw()
     })
 
     it("should return null when no dependencies are missing", async () => {
@@ -138,7 +138,7 @@ describe("graph common", () => {
           spec: {},
         },
       ]
-      expect(() => detectMissingDependencies(moduleConfigs)).to.not.throw
+      expect(() => detectMissingDependencies({ moduleConfigs })).to.not.throw
     })
   })
 

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -1409,7 +1409,7 @@ describe("exec plugin", () => {
           const tmpGraph = await garden.getConfigGraph({ log: garden.log, emit: false })
           const module = tmpGraph.getModule(moduleA)
 
-          const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const group = findGroupConfig(result, moduleA)!
@@ -1442,7 +1442,7 @@ describe("exec plugin", () => {
           const tmpGraph = await garden.getConfigGraph({ log: garden.log, emit: false })
           const module = tmpGraph.getModule(moduleA)
 
-          const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const group = findGroupConfig(result, moduleA)!
@@ -1512,7 +1512,7 @@ describe("exec plugin", () => {
           const tmpGraph = await garden.getConfigGraph({ log: garden.log, emit: false })
           const moduleB = tmpGraph.getModule(moduleNameB)
 
-          const result = await convertModules(garden, garden.log, [moduleB], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleB], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupB = findGroupConfig(result, moduleNameB)!
@@ -1575,7 +1575,7 @@ describe("exec plugin", () => {
             const moduleA = "module-a"
             const tmpGraph = await getGraph(moduleA, true)
             const module = tmpGraph.getModule(moduleA)
-            const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph)
+            const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph, new Set())
 
             assertBuildAtSource(module.name, result, true)
           })
@@ -1584,7 +1584,7 @@ describe("exec plugin", () => {
             const moduleA = "module-a"
             const tmpGraph = await getGraph(moduleA, false)
             const module = tmpGraph.getModule(moduleA)
-            const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph)
+            const result = await convertModules(garden, garden.log, [module], tmpGraph.moduleGraph, new Set())
 
             assertBuildAtSource(module.name, result, false)
           })
@@ -1633,7 +1633,7 @@ describe("exec plugin", () => {
           const moduleA = tmpGraph.getModule(moduleNameA)
 
           // this will use `serviceConfigs` defined in modules
-          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupA = findGroupConfig(result, moduleNameA)!
@@ -1690,7 +1690,7 @@ describe("exec plugin", () => {
           const moduleA = tmpGraph.getModule(moduleNameA)
 
           // this will use `serviceConfigs` defined in modules
-          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupA = findGroupConfig(result, moduleNameA)!
@@ -1750,7 +1750,7 @@ describe("exec plugin", () => {
           const moduleA = tmpGraph.getModule(moduleNameA)
 
           // this will use `taskConfigs` defined in modules
-          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupA = findGroupConfig(result, moduleNameA)!
@@ -1811,7 +1811,7 @@ describe("exec plugin", () => {
           const moduleA = tmpGraph.getModule(moduleNameA)
 
           // this will use `taskConfigs` defined in modules
-          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupA = findGroupConfig(result, moduleNameA)!
@@ -1874,7 +1874,7 @@ describe("exec plugin", () => {
           const moduleA = tmpGraph.getModule(moduleNameA)
 
           // this will use `testConfigs` defined in modules
-          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupA = findGroupConfig(result, moduleNameA)!
@@ -1936,7 +1936,7 @@ describe("exec plugin", () => {
           const moduleA = tmpGraph.getModule(moduleNameA)
 
           // this will use `testConfigs` defined in modules
-          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph)
+          const result = await convertModules(garden, garden.log, [moduleA], tmpGraph.moduleGraph, new Set())
           expect(result.groups).to.exist
 
           const groupA = findGroupConfig(result, moduleNameA)!

--- a/docs/misc/migrating-to-bonsai.md
+++ b/docs/misc/migrating-to-bonsai.md
@@ -69,8 +69,9 @@ The general flow of the Garden runtime is as follows:
 
 However, there are some caveats:
 
-- Modules cannot depend on actions
-- Modules cannot reference actions
+- Modules cannot depend on actions, with the following exception (as of release 0.14.9):
+  - Services and tasks defined in modules may depend on Deploy and Run actions. They can however not reference those actions in template strings.
+- Modules cannot reference actions in template strings.
 - Actions can reference and depend on modules, by referencing the actions that are generated from modules.
 - Deploy actions should explicitly add their corresponding Build action to their `dependency` array (see examples below)
 - Deploy `container` actions should explicitly reference the output of their corresponding Build action in the `spec.image` field (see examples below)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1716,6 +1716,8 @@ providers:
 
             # The names of any services that this service depends on at runtime, and the names of any tasks that
             # should be executed before this service is deployed.
+            # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions
+            # in template strings.
             dependencies:
 
             # Set this to `true` to disable the service. You can use this with conditional template strings to
@@ -1750,6 +1752,8 @@ providers:
 
             # The names of any tasks that must be executed, and the names of any services that must be running, before
             # this task is executed.
+            # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions
+            # in template strings.
             dependencies:
 
             # Set this to `true` to disable the task. You can use this with conditional template strings to
@@ -3019,6 +3023,8 @@ moduleConfigs:
 
         # The names of any services that this service depends on at runtime, and the names of any tasks that should be
         # executed before this service is deployed.
+        # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+        # template strings.
         dependencies:
 
         # Set this to `true` to disable the service. You can use this with conditional template strings to
@@ -3052,6 +3058,8 @@ moduleConfigs:
 
         # The names of any tasks that must be executed, and the names of any services that must be running, before
         # this task is executed.
+        # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+        # template strings.
         dependencies:
 
         # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
@@ -3571,6 +3579,8 @@ modules:
 
         # The names of any services that this service depends on at runtime, and the names of any tasks that should be
         # executed before this service is deployed.
+        # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+        # template strings.
         dependencies:
 
         # Set this to `true` to disable the service. You can use this with conditional template strings to
@@ -3604,6 +3614,8 @@ modules:
 
         # The names of any tasks that must be executed, and the names of any services that must be running, before
         # this task is executed.
+        # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+        # template strings.
         dependencies:
 
         # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -222,6 +222,8 @@ services:
 
     # The names of any services that this service depends on at runtime, and the names of any tasks that should be
     # executed before this service is deployed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable
@@ -595,6 +597,8 @@ tasks:
 
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
@@ -1107,10 +1111,11 @@ Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and da
 [services](#services) > dependencies
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `services[].disabled`
 
@@ -2283,10 +2288,11 @@ A description of the task.
 [tasks](#tasks) > dependencies
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `tasks[].disabled`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -200,6 +200,8 @@ services:
 
     # The names of any services that this service depends on at runtime, and the names of any tasks that should be
     # executed before this service is deployed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable
@@ -279,6 +281,8 @@ tasks:
 
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
@@ -744,10 +748,11 @@ Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and da
 [services](#services) > dependencies
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `services[].disabled`
 
@@ -913,10 +918,11 @@ A description of the task.
 [tasks](#tasks) > dependencies
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `tasks[].disabled`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -357,6 +357,8 @@ tasks:
 
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
@@ -1342,10 +1344,11 @@ A description of the task.
 [tasks](#tasks) > dependencies
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `tasks[].disabled`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -290,6 +290,8 @@ services:
 
     # The names of any services that this service depends on at runtime, and the names of any tasks that should be
     # executed before this service is deployed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable
@@ -663,6 +665,8 @@ tasks:
 
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
@@ -1322,10 +1326,11 @@ Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and da
 [services](#services) > dependencies
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `services[].disabled`
 
@@ -2498,10 +2503,11 @@ A description of the task.
 [tasks](#tasks) > dependencies
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `tasks[].disabled`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -267,6 +267,8 @@ waitForJobs: true
 
 # The names of any services that this service depends on at runtime, and the names of any tasks that should be
 # executed before this service is deployed.
+# You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template
+# strings.
 dependencies: []
 
 # Specifies which files or directories to sync to which paths inside the running containers of the service when it's
@@ -371,6 +373,8 @@ tasks:
 
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
+    # You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in
+    # template strings.
     dependencies: []
 
     # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
@@ -1108,10 +1112,11 @@ Wait until the jobs have been completed. Garden will wait for as long as `timeou
 ### `dependencies[]`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `sync`
 
@@ -1384,10 +1389,11 @@ A description of the task.
 [tasks](#tasks) > dependencies
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `tasks[].disabled`
 

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -169,6 +169,8 @@ varfile:
 
 # The names of any services that this service depends on at runtime, and the names of any tasks that should be
 # executed before this service is deployed.
+# You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template
+# strings.
 dependencies: []
 
 # If set to true, Garden will destroy the stack when calling `garden cleanup namespace` or `garden cleanup deploy
@@ -576,10 +578,11 @@ varfile: "my-module.env"
 ### `dependencies[]`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `allowDestroy`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -175,6 +175,8 @@ varfile:
 
 # The names of any services that this service depends on at runtime, and the names of any tasks that should be
 # executed before this service is deployed.
+# You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template
+# strings.
 dependencies: []
 
 # If set to true, Garden will run `terraform destroy` on the stack when calling `garden delete namespace` or `garden
@@ -520,10 +522,11 @@ varfile: "my-module.env"
 ### `dependencies[]`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+You may also depend on Deploy and Run actions, but please note that you cannot reference those actions in template strings.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 ### `allowDestroy`
 


### PR DESCRIPTION
This helps mitigate some struggles with gradual config migrations. The caveat is that actions cannot be referenced in template strings in modules at all, and this only applies across module-based services and tasks, and Deploy and Run actions.
