### PR TITLE
improvement(cli): print graph status message on interval during solve

### DIFF
--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -122,7 +122,7 @@ export class BuildCommand extends Command<Args, Opts> {
         })
     )
 
-    const result = await garden.processTasks({ tasks })
+    const result = await garden.processTasks({ tasks, logProgressStatus: true })
 
     return handleProcessResults(garden, log, "build", result)
   }

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -309,7 +309,7 @@ export class DeployCommand extends Command<Args, Opts> {
       return task
     })
 
-    const results = await garden.processTasks({ tasks })
+    const results = await garden.processTasks({ tasks, logProgressStatus: true })
 
     return handleProcessResults(garden, log, "deploy", results)
   }

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -208,7 +208,7 @@ export class RunCommand extends Command<Args, Opts> {
         })
     )
 
-    const results = await garden.processTasks({ tasks })
+    const results = await garden.processTasks({ tasks, logProgressStatus: true })
 
     return handleProcessResults(garden, log, "run", results)
   }

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -221,7 +221,7 @@ export class TestCommand extends Command<Args, Opts> {
       })
     }
 
-    const results = await garden.processTasks({ tasks })
+    const results = await garden.processTasks({ tasks, logProgressStatus: true })
 
     return handleProcessResults(garden, log, "test", results)
   }

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -38,6 +38,7 @@ export interface TaskNodeParams<T extends Task> {
 export abstract class TaskNode<T extends Task = Task> {
   abstract readonly executionType: NodeType
   public readonly type: string
+  public readonly createdAt: Date
   public startedAt?: Date
   public readonly task: T
   public readonly statusOnly: boolean
@@ -48,6 +49,7 @@ export abstract class TaskNode<T extends Task = Task> {
   protected solver: GraphSolver
   protected dependants: { [key: string]: TaskNode }
   protected result?: GraphResult<any>
+  protected completedAt?: Date
 
   constructor({ solver, task, statusOnly }: TaskNodeParams<T>) {
     this.task = task
@@ -55,6 +57,7 @@ export abstract class TaskNode<T extends Task = Task> {
     this.solver = solver
     this.statusOnly = statusOnly
     this.dependants = {}
+    this.createdAt = new Date()
   }
 
   abstract describe(): string
@@ -156,6 +159,8 @@ export abstract class TaskNode<T extends Task = Task> {
       success: !error && !aborted,
       attached: !!result?.attached,
     }
+
+    this.completedAt = new Date()
 
     if (aborted || error) {
       // We abort every dependant, and complete the corresponding request node for the failed node with an error.


### PR DESCRIPTION
This makes it a bit more clear how graph execution is progressing, particularly for longer runs.

There's a lot of potential approaches here, any suggestions or feedback are welcome.

<img width="1700" height="162" alt="Screenshot 2025-10-14 at 11 33 18" src="https://github.com/user-attachments/assets/e1f9c02d-6a83-4494-874c-9169255b2fb8" />
