### PR TITLE
feat(cli): write JSON command results on every execution

### DIFF
--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -410,6 +410,10 @@ export const globalDisplayOptions = {
     defaultValue: false,
     cliOnly: true,
   }),
+  "json-result-path": new StringParameter({
+    help: "Output command result to the specified path. Defaults to <garden-dir>/command-results/<command-name>-<timestamp>.json.",
+    cliOnly: true,
+  }),
   "logger-type": new ChoicesParameter({
     choices: [...LOGGER_TYPES],
     help: deline`

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -635,6 +635,8 @@ describe("cli", () => {
         "--logger-type=json",
         "--show-timestamps=false",
         "--force-refresh",
+        "--json-result-path",
+        "test-result.json",
         "--var",
         "my=value,other=something",
       ]
@@ -661,6 +663,7 @@ describe("cli", () => {
           "var": ["my=value", "other=something"],
           "version": false,
           "help": false,
+          "json-result-path": "test-result.json",
         },
       })
     })
@@ -792,6 +795,7 @@ describe("cli", () => {
           "output": undefined,
           "root": undefined,
           "var": undefined,
+          "json-result-path": undefined,
         },
       })
     })
@@ -867,6 +871,7 @@ describe("cli", () => {
           "output": undefined,
           "root": undefined,
           "var": undefined,
+          "json-result-path": undefined,
         },
       })
     })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -27,6 +27,7 @@ The following option flags can be used with any of the CLI commands:
   | `--yes` |  | boolean | Automatically approve any yes/no prompts during execution, and allow running protected commands against production environments.
   | `--silent` |  | boolean | Suppress log output. Same as setting --logger-type&#x3D;quiet.
   | `--offline` |  | boolean | Use the --offline option when you can&#x27;t log in right now. Some features won&#x27;t be available in offline mode.
+  | `--json-result-path` |  | string | Output command result to the specified path. Defaults to &lt;garden-dir&gt;/command-results/&lt;command-name&gt;-&lt;timestamp&gt;.json.
   | `--logger-type` |  | `quiet` `default` `basic` `json` `ink`  | Set logger type. default The default Garden logger, basic: [DEPRECATED] An alias for &quot;default&quot;. json: Renders log lines as JSON. quiet: Suppresses all log output, same as --silent.
   | `--log-level` |  | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level. Values can be either string or numeric and are prioritized from 0 to 5 (highest to lowest) as follows: error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5. From the verbose log level onward action execution logs are also printed (e.g. test or run live log outputs).
   | `--output` |  | `json` `yaml`  | Output command result in the specified format. When used, this option disables line-by-line logging, even if the GARDEN_LOGGER_TYPE environment variable is used.


### PR DESCRIPTION
This can help in e.g. CI pipelines where we want to see execution logs but also parse the resulting JSON after execution.

Also included a `--json-result-path` flag to control the result file path.
