### PR TITLE
feat(core): emit deploy run results to Garden Cloud

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -26,7 +26,7 @@
   "types": "build/src/index.d.ts",
   "dependencies": {
     "@bufbuild/protobuf": "2.8.0",
-    "@buf/garden_grow-platform.bufbuild_es": "2.8.0-20250916142245-2420a337ce6a.1",
+    "@buf/garden_grow-platform.bufbuild_es": "2.8.0-20251027135652-778164cdd988.1",
     "@codenamize/codenamize": "^1.1.1",
     "@connectrpc/connect": "2.1.0",
     "@connectrpc/connect-node": "2.0.4",

--- a/core/src/events/action-status-events.ts
+++ b/core/src/events/action-status-events.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import type { ActionKind } from "../actions/types.js"
 import { actionStates } from "../actions/types.js"
 import type { BuildState } from "../plugin/handlers/Build/get-status.js"
 import type { ActionRuntime, RunState } from "../plugin/plugin.js"
@@ -94,7 +95,7 @@ interface ActionStatusPayloadBase {
    * should've been actionKind.
    */
   actionType: string
-  actionKind: string
+  actionKind: Lowercase<ActionKind>
   actionVersion: string
   actionUid: string
   /**

--- a/core/src/events/util.ts
+++ b/core/src/events/util.ts
@@ -78,7 +78,7 @@ export function makeActionStatusPayloadBase({
     actionName: action.name,
     actionVersion: action.versionString(log),
     // NOTE: The type/kind needs to be lower case in the event payload
-    actionKind: action.kind.toLowerCase(),
+    actionKind: action.kind.toLowerCase() as Lowercase<ActionKind>,
     actionType: action.type,
     actionUid: action.uid,
     moduleName: action.moduleName(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1062,7 +1062,7 @@
       "version": "0.14.9",
       "license": "MPL-2.0",
       "dependencies": {
-        "@buf/garden_grow-platform.bufbuild_es": "2.8.0-20250916142245-2420a337ce6a.1",
+        "@buf/garden_grow-platform.bufbuild_es": "2.8.0-20251027135652-778164cdd988.1",
         "@bufbuild/protobuf": "2.8.0",
         "@codenamize/codenamize": "^1.1.1",
         "@connectrpc/connect": "2.1.0",
@@ -1298,8 +1298,8 @@
       }
     },
     "core/node_modules/@buf/garden_grow-platform.bufbuild_es": {
-      "version": "2.8.0-20250916142245-2420a337ce6a.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/garden_grow-platform.bufbuild_es/-/garden_grow-platform.bufbuild_es-2.8.0-20250916142245-2420a337ce6a.1.tgz",
+      "version": "2.8.0-20251027135652-778164cdd988.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/garden_grow-platform.bufbuild_es/-/garden_grow-platform.bufbuild_es-2.8.0-20251027135652-778164cdd988.1.tgz",
       "dependencies": {
         "@buf/bufbuild_protovalidate.bufbuild_es": "2.8.0-20250613105001-9f2d3c737feb.1"
       },


### PR DESCRIPTION
With this change we include the results with the
ACTION_RUN_COMPLETED event if the action kind is Deploy.

This enables us display links to ingresses in the Garden Cloud UI.

The plan was also to include kind specific state such as whether a Test action was cached in team or local cache but that's a bigger lift and will need be handled in a separate PR.

The protobuf schema already accounts for those fields as well though.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
