### PR TITLE
chore(CI): update Rust & wine setup

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -290,8 +290,8 @@ commands:
 
             # Install the latest stable Rust version
             # We maintain it manually to avoid unexpected breaking changes like we faced in Rust 1.78 for Windows builds.
-            # See https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html for details.
-            RUST_VERSION="1.83.0"
+            # Cross v0.2.5 dependencies require Rust 1.88.0 or later
+            RUST_VERSION="1.88.0"
             rustup install $RUST_VERSION
             rustup default $RUST_VERSION
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `build-dist-macos` and `build-dist-linux-windows` CirleCI jobs were failing with:

```
feature `edition2024` is required
The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0
(5ffbef321 2024-10-29))
```

This PR bumps Rust to version 1.88.0 to fix that.

After updating Rust in CI, we got errors from wine indicating problems with 32-bit binaries and the lack of a window server. This is also fixed here.