### PR TITLE
fix(k8s): fix fail-fast Helm deploys

### DIFF
--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -58,6 +58,15 @@ export function getResourceKey(resource: KubernetesResource) {
 }
 
 /**
+ * Note: This format isn't used by the k8s API, but is useful for indexing manifests/resources locally in a way
+ * that avoids potential name clashes across namespaces.
+ */
+export function getNamespacedResourceKey(resource: KubernetesResource) {
+  const prefix = resource.metadata.namespace ? `namespace:${resource.metadata.namespace}/` : ""
+  return `${prefix}${resource.kind}/${resource.metadata.name}`
+}
+
+/**
  * Returns a hash of the manifest. We use this instead of the raw manifest when setting the
  * "manifest-hash" annotation. This prevents "Too long annotation" errors for long manifests.
  */
@@ -417,7 +426,7 @@ export function getApiGroup(resource: KubernetesResource) {
 /**
  * Returns true if the resource is a built-in Kubernetes workload type.
  */
-export function isWorkload(resource: KubernetesResource) {
+export function isWorkload(resource: KubernetesResource): resource is KubernetesWorkload {
   return isBuiltIn(resource) && workloadTypes.includes(resource.kind)
 }
 

--- a/core/test/integ/helpers.ts
+++ b/core/test/integ/helpers.ts
@@ -171,3 +171,12 @@ export async function getEmptyGardenWithLocalK8sProvider() {
   const projectRoot = getDataDir("test-projects", "empty-project-local-kubernetes")
   return await makeTestGarden(projectRoot)
 }
+
+/**
+ * Return a unique namespace name for per-test isolation.
+ * Example: helm-test-<timestamp>-<random>
+ */
+export function generateTestNamespace(prefix = "helm-test") {
+  const suffix = Math.random().toString(36).substring(2, 8)
+  return `${prefix}-${Date.now()}-${suffix}`
+}

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -10,6 +10,7 @@ import { expect } from "chai"
 
 import type { TestGarden } from "../../../../../helpers.js"
 import { expectError, getDataDir, makeTestGarden } from "../../../../../helpers.js"
+import { generateTestNamespace } from "../../../../helpers.js"
 import { deleteHelmDeploy, helmDeploy } from "../../../../../../src/plugins/kubernetes/helm/deployment.js"
 import type { KubernetesPluginContext, KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config.js"
 import {
@@ -18,7 +19,12 @@ import {
   getReleaseStatus,
   getRenderedResources,
 } from "../../../../../../src/plugins/kubernetes/helm/status.js"
-import { getReleaseName } from "../../../../../../src/plugins/kubernetes/helm/common.js"
+import {
+  getReleaseName,
+  prepareManifests,
+  prepareTemplates,
+  filterManifests,
+} from "../../../../../../src/plugins/kubernetes/helm/common.js"
 import { KubeApi } from "../../../../../../src/plugins/kubernetes/api.js"
 import { buildHelmModules, getHelmTestGarden } from "./common.js"
 import type { ConfigGraph } from "../../../../../../src/graph/config-graph.js"
@@ -33,12 +39,15 @@ import { parseTemplateCollection } from "../../../../../../src/template/template
 import { DEFAULT_DEPLOY_TIMEOUT_SEC } from "../../../../../../src/constants.js"
 import { join } from "node:path"
 import type { EventNamespaceStatus } from "../../../../../../src/plugin-context.js"
+import { checkResourceStatuses, waitForResources } from "../../../../../../src/plugins/kubernetes/status/status.js"
+import { helm } from "../../../../../../src/plugins/kubernetes/helm/helm-cli.js"
 
 describe("helmDeploy", () => {
   let garden: TestGarden
   let provider: KubernetesProvider
   let ctx: KubernetesPluginContext
   let graph: ConfigGraph
+  const createdNamespaces: string[] = []
 
   before(async () => {
     garden = await getHelmTestGarden()
@@ -56,18 +65,85 @@ describe("helmDeploy", () => {
     try {
       const actions = await garden.getActionRouter()
       await actions.deleteDeploys({ graph, log: garden.log })
+
+      if (createdNamespaces.length > 0) {
+        const api = await KubeApi.factory(garden.log, ctx, provider)
+        for (const namespace of createdNamespaces) {
+          // Don't await - let Kubernetes clean up in the background. We generate unique namespace names in this suite, so this is safe.
+          api.core.deleteNamespace({ name: namespace }).catch(() => {
+            // Ignore errors if namespace doesn't exist or already deleted
+          })
+        }
+      }
+
       if (garden) {
         garden.close()
       }
     } catch {}
   })
 
+  /**
+   * Wait for a Helm release to reach a stable state (deployed or failed).
+   * This helps avoid race conditions with Helm's locking mechanism when doing
+   * multiple deployments of the same release in quick succession.
+   */
+  async function waitForReleaseStable(
+    releaseName: string,
+    namespace: string,
+    timeoutMs: number = 30000
+  ): Promise<void> {
+    const startTime = Date.now()
+    const stableStatuses = ["deployed", "failed", "uninstalled", "superseded"]
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const statusJson = await helm({
+          ctx,
+          log: garden.log,
+          namespace,
+          args: ["status", releaseName, "--output", "json"],
+          emitLogEvents: false,
+        })
+        const status = JSON.parse(statusJson)
+
+        if (status?.info?.status && stableStatuses.includes(status.info.status)) {
+          return
+        }
+      } catch (error) {
+        // Release might not exist yet or be in transition, continue polling
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+
+    throw new Error(`Timeout waiting for Helm release '${releaseName}' to reach stable state after ${timeoutMs}ms`)
+  }
+
   context("normal behaviour", () => {
     for (const deployName of ["api", "oci-url", "oci-url-with-version"]) {
       it(`should deploy chart ${deployName} successfully`, async () => {
         graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+        // Pick the raw action from the graph so we can set a per-test namespace **before** resolution
+        const rawAction = graph.getDeploy(deployName) as HelmDeployAction
+        const testNamespace = generateTestNamespace()
+        createdNamespaces.push(testNamespace)
+        rawAction._config.spec.namespace = testNamespace
+
+        // Use a unique hostname for api deploy to avoid conflicts with other tests
+        if (deployName === "api") {
+          const uniqueHostname = `api-${randomString(4)}.local.demo.garden`
+          rawAction._config.spec.values = {
+            ...rawAction._config.spec.values,
+            ingress: {
+              enabled: true,
+              paths: ["/"],
+              hosts: [uniqueHostname],
+            },
+          }
+        }
+
         const action = await garden.resolveAction<HelmDeployAction>({
-          action: graph.getDeploy(deployName),
+          action: rawAction,
           log: garden.log,
           graph,
         })
@@ -76,14 +152,16 @@ describe("helmDeploy", () => {
         // Here, we're not going through a router, so we listen for the `namespaceStatus` event directly.
         let namespaceStatus: EventNamespaceStatus | null = null
         ctx.events.once("namespaceStatus", (status) => (namespaceStatus = status))
+
         await helmDeploy({
           ctx,
           log: actionLog,
           action,
           force: false,
         })
+
         expect(namespaceStatus).to.exist
-        expect(namespaceStatus!.namespaceName).to.eql("helm-test-default")
+        expect(namespaceStatus!.namespaceName).to.eql(testNamespace)
 
         const releaseName = getReleaseName(action)
         const releaseStatus = await getReleaseStatus({
@@ -108,8 +186,24 @@ describe("helmDeploy", () => {
 
     it("should deploy a chart from a converted Helm module referencing a container module version in its image tag", async () => {
       graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      // Set namespace before resolution
+      const rawAction = graph.getDeploy("api-module") as HelmDeployAction
+      const testNamespace = generateTestNamespace()
+      createdNamespaces.push(testNamespace)
+      rawAction._config.spec.namespace = testNamespace
+      // Use a unique hostname to avoid conflicts with other tests
+      const uniqueHostname = `api-module-${randomString(4)}.local.demo.garden`
+      rawAction._config.spec.values = {
+        ...rawAction._config.spec.values,
+        ingress: {
+          enabled: true,
+          paths: ["/api-module/"],
+          hosts: [uniqueHostname],
+        },
+      }
+
       const action = await garden.resolveAction<HelmDeployAction>({
-        action: graph.getDeploy("api-module"),
+        action: rawAction,
         log: garden.log,
         graph,
       })
@@ -118,6 +212,7 @@ describe("helmDeploy", () => {
       // Here, we're not going through a router, so we listen for the `namespaceStatus` event directly.
       let namespaceStatus: EventNamespaceStatus | null = null
       ctx.events.once("namespaceStatus", (status) => (namespaceStatus = status))
+
       await helmDeploy({
         ctx,
         log: actionLog,
@@ -125,7 +220,7 @@ describe("helmDeploy", () => {
         force: false,
       })
       expect(namespaceStatus).to.exist
-      expect(namespaceStatus!.namespaceName).to.eql("helm-test-default")
+      expect(namespaceStatus!.namespaceName).to.eql(testNamespace)
 
       const releaseName = getReleaseName(action)
       const releaseStatus = await getReleaseStatus({
@@ -150,8 +245,23 @@ describe("helmDeploy", () => {
         emit: false,
         actionModes: { sync: ["deploy.api"] }, // <-----
       })
+      // Deploy into a per-test namespace to avoid interfering with other tests
+      const rawAction = graph.getDeploy("api") as HelmDeployAction
+      const testNamespace = generateTestNamespace()
+      createdNamespaces.push(testNamespace)
+      rawAction._config.spec.namespace = testNamespace
+      // Use a unique hostname to avoid conflicts with other tests
+      const uniqueHostname = `api-${randomString(4)}.local.demo.garden`
+      rawAction._config.spec.values = {
+        ...rawAction._config.spec.values,
+        ingress: {
+          enabled: true,
+          paths: ["/"],
+          hosts: [uniqueHostname],
+        },
+      }
       const action = await garden.resolveAction<HelmDeployAction>({
-        action: graph.getDeploy("api"),
+        action: rawAction,
         log: garden.log,
         graph,
       })
@@ -222,8 +332,19 @@ describe("helmDeploy", () => {
 
     it("should mark a chart that is deployed but does not have a matching configmap as outdated", async () => {
       graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      const rawAction = graph.getDeploy("api") as HelmDeployAction
+      // Use a unique hostname to avoid conflicts with other tests
+      const uniqueHostname = `api-${randomString(4)}.local.demo.garden`
+      rawAction._config.spec.values = {
+        ...rawAction._config.spec.values,
+        ingress: {
+          enabled: true,
+          paths: ["/"],
+          hosts: [uniqueHostname],
+        },
+      }
       const action = await garden.resolveAction<HelmDeployAction>({
-        action: graph.getDeploy("api"),
+        action: rawAction,
         log: garden.log,
         graph,
       })
@@ -270,8 +391,19 @@ describe("helmDeploy", () => {
 
     it("should remove the garden metadata configmap associated with a helm deploy action when the chart is uninstalled", async () => {
       graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      const rawAction = graph.getDeploy("api") as HelmDeployAction
+      // Use a unique hostname to avoid conflicts with other tests
+      const uniqueHostname = `api-${randomString(4)}.local.demo.garden`
+      rawAction._config.spec.values = {
+        ...rawAction._config.spec.values,
+        ingress: {
+          enabled: true,
+          paths: ["/"],
+          hosts: [uniqueHostname],
+        },
+      }
       const action = await garden.resolveAction<HelmDeployAction>({
-        action: graph.getDeploy("api"),
+        action: rawAction,
         log: garden.log,
         graph,
       })
@@ -328,8 +460,19 @@ describe("helmDeploy", () => {
         events: undefined,
       })
 
+      const rawAction = graph.getDeploy("api") as HelmDeployAction
+      // Use a unique hostname to avoid conflicts with other tests
+      const uniqueHostname = `api-${randomString(4)}.local.demo.garden`
+      rawAction._config.spec.values = {
+        ...rawAction._config.spec.values,
+        ingress: {
+          enabled: true,
+          paths: ["/"],
+          hosts: [uniqueHostname],
+        },
+      }
       const action = await garden.resolveAction<HelmDeployAction>({
-        action: graph.getDeploy("api"),
+        action: rawAction,
         log: garden.log,
         graph,
       })
@@ -371,11 +514,16 @@ describe("helmDeploy", () => {
       const workloads = renderedResources.filter(
         (resource) => isWorkload(resource) && resource.metadata.name === "api-release"
       )
+      const namespace = await getActionNamespace({
+        ctx: ctxWithCloudApi,
+        log: gardenWithCloudApi.log,
+        action,
+        provider: ctxWithCloudApi.provider,
+      })
+
       const apiDeployment = (
         await Promise.all(
-          workloads.map((workload) =>
-            api.readBySpec({ log: gardenWithCloudApi.log, namespace: "helm-test-default", manifest: workload })
-          )
+          workloads.map((workload) => api.readBySpec({ log: gardenWithCloudApi.log, namespace, manifest: workload }))
         )
       )[0]
       const existingAnnotations = apiDeployment.metadata.annotations
@@ -386,7 +534,7 @@ describe("helmDeploy", () => {
 
       await api.apps.patchNamespacedDeployment({
         name: apiDeployment.metadata?.name,
-        namespace: "helm-test-default",
+        namespace,
         body: apiDeployment,
       })
 
@@ -402,9 +550,19 @@ describe("helmDeploy", () => {
     it("should wait for the Helm command to complete if there are no resource errors", async () => {
       graph = await garden.getConfigGraph({ log: garden.log, emit: false })
 
-      const action = graph.getDeploy("api") as HelmDeployAction
+      const rawAction = graph.getDeploy("api") as HelmDeployAction
+      // Use a unique hostname to avoid conflicts with other tests
+      const uniqueHostname = `api-${randomString(4)}.local.demo.garden`
+      rawAction._config.spec.values = {
+        ...rawAction._config.spec.values,
+        ingress: {
+          enabled: true,
+          paths: ["/"],
+          hosts: [uniqueHostname],
+        },
+      }
       const resolvedAction = await garden.resolveAction({
-        action,
+        action: rawAction,
         log: garden.log,
         graph,
       })
@@ -425,7 +583,7 @@ describe("helmDeploy", () => {
   })
 
   context("errors and failures", () => {
-    function makeAlternativeApiDeployConfig(name: string): HelmDeployConfig {
+    function makeAlternativeApiDeployConfig(name: string, hostname?: string): HelmDeployConfig {
       // based on 'deploy.api' action defined in the disk-based project
       const helmDeployConfig = {
         kind: "Deploy" as const,
@@ -460,7 +618,7 @@ describe("helmDeploy", () => {
             ingress: {
               enabled: true,
               paths: ["/"],
-              hosts: ["api.local.demo.garden"],
+              hosts: [hostname || "api.local.demo.garden"],
             },
           },
         },
@@ -548,7 +706,8 @@ describe("helmDeploy", () => {
     context("atomic=true", () => {
       it("should NOT fail fast if one of the resources is unhealthy but wait for the Helm command to complete", async () => {
         const name = `api-${randomString(4)}`
-        const deployConfig = makeAlternativeApiDeployConfig(name)
+        const uniqueHostname = `${name}.local.demo.garden`
+        const deployConfig = makeAlternativeApiDeployConfig(name, uniqueHostname)
 
         deployConfig.timeout = 5
         deployConfig.spec.atomic = true
@@ -664,6 +823,466 @@ describe("helmDeploy", () => {
             expect(message).to.include(`Error: UPGRADE FAILED`)
           }
         )
+      })
+
+      it("should not fail early when replacing an unhealthy Deployment with a healthy one", async () => {
+        // Use a unique namespace for this test to avoid Helm lock conflicts
+        const testNamespace = generateTestNamespace()
+        createdNamespaces.push(testNamespace)
+
+        graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+
+        // Step 1: Deploy an unhealthy version
+        const unhealthyAction = graph.getDeploy("api") as HelmDeployAction
+        unhealthyAction._config.timeout = 30
+        unhealthyAction._config.spec.waitForUnhealthyResources = false // Enable fail-fast
+        unhealthyAction._config.spec.atomic = false // Required for fail-fast
+        unhealthyAction._config.spec.namespace = testNamespace // Use test-specific namespace
+        unhealthyAction._config.spec.values = {
+          ...unhealthyAction._config.spec.values,
+          args: ["/bin/sh", "-c", "exit 1"], // Causes immediate failure
+          ingress: { enabled: false }, // Disable ingress to avoid conflicts with other tests
+        }
+
+        const resolvedUnhealthyAction = await garden.resolveAction<HelmDeployAction>({
+          action: unhealthyAction,
+          log: garden.log,
+          graph,
+        })
+        const unhealthyActionLog = createActionLog({
+          log: garden.log,
+          action: resolvedUnhealthyAction,
+        })
+
+        // Deploy the unhealthy version - expect it to fail
+        await expectError(
+          () =>
+            helmDeploy({
+              ctx,
+              log: unhealthyActionLog,
+              action: resolvedUnhealthyAction,
+              force: false,
+            }),
+          (err) => {
+            // Verify it failed as expected
+            expect(err).to.exist
+          }
+        )
+
+        // Wait for Helm to release its lock after the failed deployment
+        const releaseName = getReleaseName(resolvedUnhealthyAction)
+        const releaseNamespace = await getActionNamespace({
+          ctx,
+          log: garden.log,
+          action: resolvedUnhealthyAction,
+          provider,
+        })
+        await waitForReleaseStable(releaseName, releaseNamespace)
+
+        // Step 2: Prepare manifests for the healthy deployment
+        const namespace = await getActionNamespace({
+          ctx,
+          log: garden.log,
+          action: resolvedUnhealthyAction,
+          provider,
+        })
+        const api = await KubeApi.factory(garden.log, ctx, provider)
+
+        // Get preparedTemplates and manifests for verification
+        const preparedTemplates = await prepareTemplates({
+          ctx,
+          action: resolvedUnhealthyAction,
+          log: garden.log,
+        })
+        const preparedManifests = await prepareManifests({
+          ctx,
+          log: garden.log,
+          action: resolvedUnhealthyAction,
+          ...preparedTemplates,
+        })
+        const manifests = await filterManifests(preparedManifests)
+
+        // Step 3: Verify the Deployment is unhealthy
+        const initialStatuses = await checkResourceStatuses({
+          api,
+          namespace,
+          waitForJobs: false,
+          manifests,
+          log: garden.log,
+        })
+
+        const deploymentStatus = initialStatuses.find(
+          (s) =>
+            s.resource.kind === "Deployment" && s.resource.metadata.name === getReleaseName(resolvedUnhealthyAction)
+        )
+        expect(deploymentStatus).to.exist
+        expect(deploymentStatus!.state).to.equal("unhealthy")
+        expect(isWorkload(deploymentStatus!.resource)).to.be.true
+
+        const initialGeneration = deploymentStatus!.resource.metadata.generation
+
+        // Step 4: Deploy the healthy version
+        const healthyAction = graph.getDeploy("api") as HelmDeployAction
+        healthyAction._config.timeout = 30
+        healthyAction._config.spec.waitForUnhealthyResources = false // Keep fail-fast enabled
+        healthyAction._config.spec.atomic = false
+        healthyAction._config.spec.namespace = testNamespace // Use the same test-specific namespace
+        // Remove the failing args - use default behavior (just omit args from values)
+        const { args: _args, ...restValues } = healthyAction._config.spec.values || {}
+        healthyAction._config.spec.values = {
+          ...restValues,
+          ingress: { enabled: false }, // Disable ingress to avoid conflicts with other tests
+        }
+
+        const resolvedHealthyAction = await garden.resolveAction<HelmDeployAction>({
+          action: healthyAction,
+          log: garden.log,
+          graph,
+        })
+        const healthyActionLog = createActionLog({
+          log: garden.log,
+          action: resolvedHealthyAction,
+        })
+
+        // This should succeed - the key assertion of the test
+        const deployResult = await helmDeploy({
+          ctx,
+          log: healthyActionLog,
+          action: resolvedHealthyAction,
+          force: false,
+        })
+
+        // Step 5: Verify success
+        expect(deployResult.state).to.equal("ready")
+        expect(deployResult.detail).to.exist
+        expect(deployResult.detail!.detail.helmCommandSuccessful).to.be.true
+
+        // Verify the deployment is now healthy
+        const finalStatuses = await checkResourceStatuses({
+          api,
+          namespace,
+          waitForJobs: false,
+          manifests,
+          log: garden.log,
+        })
+
+        const finalDeploymentStatus = finalStatuses.find(
+          (s) => s.resource.kind === "Deployment" && s.resource.metadata.name === getReleaseName(resolvedHealthyAction)
+        )
+        expect(finalDeploymentStatus).to.exist
+        expect(finalDeploymentStatus!.state).to.equal("ready")
+
+        // Verify generation incremented (proving a new deployment happened)
+        expect(finalDeploymentStatus!.resource.metadata.generation).to.be.greaterThan(initialGeneration!)
+      })
+
+      it("should correctly detect spec changes using specChanged helper", async () => {
+        // Use a unique action name to avoid conflicts with other tests
+        const name = `api-${randomString(4)}`
+        const deployConfig = makeAlternativeApiDeployConfig(name)
+        deployConfig.spec.waitForUnhealthyResources = false
+        deployConfig.spec.atomic = false
+        // Disable ingress to avoid conflicts with other tests
+        deployConfig.spec.values.ingress = { enabled: false }
+
+        garden.addAction(deployConfig)
+
+        graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+
+        // Step 1: Deploy the initial version
+        const action = graph.getDeploy(name) as HelmDeployAction
+        const resolvedAction = await garden.resolveAction<HelmDeployAction>({
+          action,
+          log: garden.log,
+          graph,
+        })
+        const actionLog = createActionLog({
+          log: garden.log,
+          action: resolvedAction,
+        })
+
+        await helmDeploy({
+          ctx,
+          log: actionLog,
+          action: resolvedAction,
+          force: false,
+        })
+
+        // Step 2: Get the deployed resources
+        const api = await KubeApi.factory(garden.log, ctx, provider)
+        const namespace = await getActionNamespace({
+          ctx,
+          log: garden.log,
+          action: resolvedAction,
+          provider,
+        })
+        const releaseName = getReleaseName(resolvedAction)
+
+        // Get the manifest templates
+        const preparedTemplates = await prepareTemplates({
+          ctx,
+          action: resolvedAction,
+          log: garden.log,
+        })
+        const preparedManifests = await prepareManifests({
+          ctx,
+          log: garden.log,
+          action: resolvedAction,
+          ...preparedTemplates,
+        })
+        const manifests = await filterManifests(preparedManifests)
+
+        // Wait for resources to be ready to ensure Kubernetes has fully processed the deployment
+        await waitForResources({
+          namespace,
+          ctx,
+          provider,
+          logContext: "Test",
+          resources: manifests,
+          log: garden.log,
+          timeoutSec: 300,
+          waitForJobs: false,
+        })
+
+        // Get deployed resources
+        const deployedResources = await Promise.all(
+          manifests.map((manifest) => api.readBySpec({ log: garden.log, namespace, manifest }).catch(() => null))
+        )
+
+        // Step 3: Test no-op deployment - same manifests should not show spec changes
+        const { specChanged } = await import("../../../../../../src/plugins/kubernetes/status/status.js")
+
+        const unchangedChecks = manifests
+          .map((manifest, idx) => {
+            const deployed = deployedResources[idx]
+            if (!deployed) return null
+
+            const hasChanged = specChanged({ manifest, deployedResource: deployed })
+
+            return {
+              kind: manifest.kind,
+              name: manifest.metadata.name,
+              hasChanged,
+            }
+          })
+          .filter((check) => check !== null)
+
+        // All unchanged checks should return false (no spec changes)
+        const anyUnchangedFailed = unchangedChecks.some((check) => check!.hasChanged)
+        if (anyUnchangedFailed) {
+          const failedChecks = unchangedChecks.filter((check) => check!.hasChanged)
+          throw new Error(
+            `specChanged incorrectly detected changes for unchanged resources: ${failedChecks.map((c) => `${c!.kind}/${c!.name}`).join(", ")}`
+          )
+        }
+
+        // Step 4: Modify the spec (change replica count)
+        const modifiedAction = graph.getDeploy(name) as HelmDeployAction
+        modifiedAction._config.spec.waitForUnhealthyResources = false
+        modifiedAction._config.spec.atomic = false
+        // Change the replica count to trigger a spec change
+        modifiedAction._config.spec.values = {
+          ...modifiedAction._config.spec.values,
+          replicaCount: 2, // Change replica count instead of image tag to avoid ImagePullBackOff
+        }
+
+        const resolvedModifiedAction = await garden.resolveAction<HelmDeployAction>({
+          action: modifiedAction,
+          log: garden.log,
+          graph,
+        })
+        const modifiedActionLog = createActionLog({
+          log: garden.log,
+          action: resolvedModifiedAction,
+        })
+
+        // Get modified manifest templates
+        const modifiedPreparedTemplates = await prepareTemplates({
+          ctx,
+          action: resolvedModifiedAction,
+          log: garden.log,
+        })
+        const modifiedPreparedManifests = await prepareManifests({
+          ctx,
+          log: garden.log,
+          action: resolvedModifiedAction,
+          ...modifiedPreparedTemplates,
+        })
+        const modifiedManifests = await filterManifests(modifiedPreparedManifests)
+
+        // Step 5: Test modified deployment - should detect spec changes for Deployment
+        const changedChecks = modifiedManifests
+          .map((manifest, idx) => {
+            const deployed = deployedResources[idx]
+            if (!deployed) return null
+            const hasChanged = specChanged({ manifest, deployedResource: deployed })
+            return {
+              kind: manifest.kind,
+              name: manifest.metadata.name,
+              hasChanged,
+            }
+          })
+          .filter((check) => check !== null)
+
+        // Find the Deployment - it should have spec changes
+        const deploymentCheck = changedChecks.find((check) => check!.kind === "Deployment")
+        expect(deploymentCheck).to.exist
+        expect(deploymentCheck!.hasChanged).to.be.true
+
+        // Step 6: Deploy the modified version
+        await helmDeploy({
+          ctx,
+          log: modifiedActionLog,
+          action: resolvedModifiedAction,
+          force: false,
+        })
+
+        // Step 7: Verify the deployment succeeded and generation incremented
+        const finalStatuses = await checkResourceStatuses({
+          api,
+          namespace,
+          waitForJobs: false,
+          manifests: modifiedManifests,
+          log: garden.log,
+        })
+
+        const finalDeploymentStatus = finalStatuses.find(
+          (s) => s.resource.kind === "Deployment" && s.resource.metadata.name === releaseName
+        )
+        expect(finalDeploymentStatus).to.exist
+        expect(finalDeploymentStatus!.state).to.equal("ready")
+
+        // Clean up the deployment to avoid conflicts with other tests
+        await deleteHelmDeploy({ ctx, log: actionLog, action: resolvedAction })
+      })
+
+      it("should wait for workloads with changed specs before checking health", async () => {
+        graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+
+        // Step 1: Deploy the initial healthy version
+        const action = graph.getDeploy("api") as HelmDeployAction
+        action._config.timeout = 300
+        action._config.spec.waitForUnhealthyResources = true // Enable spec-change waiting
+        action._config.spec.atomic = false
+        // Ensure a known baseline replica count to avoid interference from other tests
+        action._config.spec.values = {
+          ...action._config.spec.values,
+          replicaCount: 1,
+          ingress: { enabled: false }, // Disable ingress to avoid conflicts with other tests
+        }
+
+        const resolvedAction = await garden.resolveAction<HelmDeployAction>({
+          action,
+          log: garden.log,
+          graph,
+        })
+        const actionLog = createActionLog({
+          log: garden.log,
+          action: resolvedAction,
+        })
+
+        await helmDeploy({
+          ctx,
+          log: actionLog,
+          action: resolvedAction,
+          force: false,
+        })
+
+        // Step 2: Get the initial deployed state
+        const api = await KubeApi.factory(garden.log, ctx, provider)
+        const namespace = await getActionNamespace({
+          ctx,
+          log: garden.log,
+          action: resolvedAction,
+          provider,
+        })
+        const releaseName = getReleaseName(resolvedAction)
+
+        // Get initial status
+        const initialStatuses = await checkResourceStatuses({
+          api,
+          namespace,
+          waitForJobs: false,
+          manifests: await filterManifests(
+            await prepareManifests({
+              ctx,
+              log: garden.log,
+              action: resolvedAction,
+              ...(await prepareTemplates({ ctx, action: resolvedAction, log: garden.log })),
+            })
+          ),
+          log: garden.log,
+        })
+
+        const initialDeploymentStatus = initialStatuses.find(
+          (s) => s.resource.kind === "Deployment" && s.resource.metadata.name === releaseName
+        )
+        expect(initialDeploymentStatus).to.exist
+        expect(initialDeploymentStatus!.state).to.equal("ready")
+        const initialGeneration = initialDeploymentStatus!.resource.metadata.generation
+        expect(initialGeneration).to.be.greaterThan(0)
+
+        // Step 3: Deploy a modified version with changed spec (change replicas to trigger spec change)
+        const modifiedAction = graph.getDeploy("api") as HelmDeployAction
+        modifiedAction._config.timeout = 300
+        modifiedAction._config.spec.waitForUnhealthyResources = true
+        modifiedAction._config.spec.atomic = false
+        modifiedAction._config.spec.values = {
+          ...modifiedAction._config.spec.values,
+          replicaCount: 2, // Change replica count to trigger spec change
+          ingress: { enabled: false }, // Disable ingress to avoid conflicts with other tests
+        }
+
+        const resolvedModifiedAction = await garden.resolveAction<HelmDeployAction>({
+          action: modifiedAction,
+          log: garden.log,
+          graph,
+        })
+        const modifiedActionLog = createActionLog({
+          log: garden.log,
+          action: resolvedModifiedAction,
+        })
+
+        // Deploy with spec changes - should wait for generation increment before checking health
+        const startTime = Date.now()
+        await helmDeploy({
+          ctx,
+          log: modifiedActionLog,
+          action: resolvedModifiedAction,
+          force: false,
+        })
+        const deployTime = Date.now() - startTime
+
+        // Step 4: Verify the deployment waited appropriately
+        // The deployment should take some time (waiting for generation increment)
+        // but should succeed because we're deploying a healthy version
+        expect(deployTime).to.be.greaterThan(100) // At least 100ms (showing it waited for generation increment)
+
+        // Step 5: Verify the deployment succeeded and generation incremented
+        const finalStatuses = await checkResourceStatuses({
+          api,
+          namespace,
+          waitForJobs: false,
+          manifests: await filterManifests(
+            await prepareManifests({
+              ctx,
+              log: garden.log,
+              action: resolvedModifiedAction,
+              ...(await prepareTemplates({ ctx, action: resolvedModifiedAction, log: garden.log })),
+            })
+          ),
+          log: garden.log,
+        })
+
+        const finalDeploymentStatus = finalStatuses.find(
+          (s) => s.resource.kind === "Deployment" && s.resource.metadata.name === releaseName
+        )
+        expect(finalDeploymentStatus).to.exist
+        expect(finalDeploymentStatus!.state).to.equal("ready")
+
+        // Verify generation incremented (proving the spec change was detected and deployment updated)
+        const finalGeneration = finalDeploymentStatus!.resource.metadata.generation
+        expect(finalGeneration).to.be.greaterThan(initialGeneration!)
       })
     })
   })

--- a/core/test/unit/src/plugins/kubernetes/status/spec-changed.ts
+++ b/core/test/unit/src/plugins/kubernetes/status/spec-changed.ts
@@ -1,0 +1,554 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { specChanged } from "../../../../../../src/plugins/kubernetes/status/status.js"
+import type { KubernetesResource } from "../../../../../../src/plugins/kubernetes/types.js"
+import { cloneDeep } from "lodash-es"
+
+/**
+ * Helper function to simulate what Kubernetes adds to a deployed resource.
+ * This mimics the behavior of the Kubernetes API server adding default values.
+ */
+function simulateKubernetesDeployment(resource: KubernetesResource): KubernetesResource {
+  const result = cloneDeep(resource)
+
+  // Add server-managed metadata
+  if (!result.metadata.resourceVersion) result.metadata.resourceVersion = "12345"
+  if (!result.metadata.uid) result.metadata.uid = "abc-123-def-456"
+  if (!result.metadata.generation) result.metadata.generation = 1
+  if (!result.metadata.creationTimestamp) result.metadata.creationTimestamp = "2024-01-01T00:00:00Z" as any
+
+  // Add defaults based on resource kind
+  if (result.kind === "Service") {
+    if (!result.spec.sessionAffinity) result.spec.sessionAffinity = "None"
+    if (!result.spec.type) result.spec.type = "ClusterIP"
+  }
+
+  if (result.kind === "Deployment") {
+    if (!result.spec.revisionHistoryLimit) result.spec.revisionHistoryLimit = 10
+    if (!result.spec.progressDeadlineSeconds) result.spec.progressDeadlineSeconds = 600
+    if (!result.spec.strategy) {
+      result.spec.strategy = {
+        type: "RollingUpdate",
+        rollingUpdate: {
+          maxUnavailable: "25%",
+          maxSurge: "25%",
+        },
+      }
+    }
+  }
+
+  if (result.kind === "DaemonSet") {
+    if (!result.spec.revisionHistoryLimit) result.spec.revisionHistoryLimit = 10
+    if (result.spec.minReadySeconds === undefined) result.spec.minReadySeconds = 0
+  }
+
+  if (result.kind === "StatefulSet") {
+    if (!result.spec.revisionHistoryLimit) result.spec.revisionHistoryLimit = 10
+    if (!result.spec.updateStrategy) {
+      result.spec.updateStrategy = {
+        type: "RollingUpdate",
+        rollingUpdate: { partition: 0 },
+      }
+    }
+    if (!result.spec.podManagementPolicy) result.spec.podManagementPolicy = "OrderedReady"
+  }
+
+  // Add pod spec defaults (for workloads and Pods)
+  const podSpec = result.kind === "Pod" ? result.spec : result.spec?.template?.spec
+  if (podSpec) {
+    if (!podSpec.restartPolicy) podSpec.restartPolicy = "Always"
+    if (!podSpec.dnsPolicy) podSpec.dnsPolicy = "ClusterFirst"
+    if (!podSpec.schedulerName) podSpec.schedulerName = "default-scheduler"
+    if (podSpec.terminationGracePeriodSeconds === undefined) podSpec.terminationGracePeriodSeconds = 30
+
+    // Add container defaults
+    const containers = [...(podSpec.containers || []), ...(podSpec.initContainers || [])]
+    for (const container of containers) {
+      if (!container.imagePullPolicy) {
+        const hasLatestTag =
+          container.image?.endsWith(":latest") ||
+          (container.image && !container.image.includes(":") && !container.image.includes("@"))
+        container.imagePullPolicy = hasLatestTag ? "Always" : "IfNotPresent"
+      }
+      if (!container.terminationMessagePath) container.terminationMessagePath = "/dev/termination-log"
+      if (!container.terminationMessagePolicy) container.terminationMessagePolicy = "File"
+
+      // Add port protocol defaults
+      if (container.ports) {
+        for (const port of container.ports) {
+          if (!port.protocol) port.protocol = "TCP"
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+describe("specChanged", () => {
+  describe("numeric vs string coercion", () => {
+    it("should not detect change when numeric values are strings", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 3,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      deployed.spec.replicas = "3" as any
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should detect change when numeric values differ", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 5,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      deployed.spec.replicas = 3
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.true
+    })
+  })
+
+  describe("container name-based matching", () => {
+    it("should correctly normalize containers when order matches", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [
+                { name: "app", image: "nginx:1.0" },
+                { name: "sidecar", image: "redis:6.0" },
+              ],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // Containers in same order - normalization should work correctly
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should detect change when container image differs (by name)", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [
+                { name: "app", image: "nginx:2.0" },
+                { name: "sidecar", image: "redis:6.0" },
+              ],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // Reverse order AND change sidecar image
+      deployed.spec.template.spec.containers = [
+        { ...deployed.spec.template.spec.containers[1], image: "redis:7.0" },
+        deployed.spec.template.spec.containers[0],
+      ]
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.true
+    })
+  })
+
+  describe("imagePullPolicy inference)", () => {
+    it("should infer Always for explicit :latest tag", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:latest" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      expect(deployed.spec.template.spec.containers[0].imagePullPolicy).to.equal("Always")
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should infer Always for implicit :latest (no tag)", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx" }], // No tag = implicit :latest
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      expect(deployed.spec.template.spec.containers[0].imagePullPolicy).to.equal("Always")
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should infer IfNotPresent for versioned tag", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.21.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      expect(deployed.spec.template.spec.containers[0].imagePullPolicy).to.equal("IfNotPresent")
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should infer IfNotPresent for SHA256 digest", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [
+                {
+                  name: "app",
+                  image: "nginx@sha256:abcd1234567890abcd1234567890abcd1234567890abcd1234567890abcd1234",
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      expect(deployed.spec.template.spec.containers[0].imagePullPolicy).to.equal("IfNotPresent")
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+  })
+
+  describe("Kubernetes default values", () => {
+    it("should handle Service defaults", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          ports: [{ port: 80 }],
+          selector: { app: "test" },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // K8s adds sessionAffinity and type
+      expect(deployed.spec.sessionAffinity).to.equal("None")
+      expect(deployed.spec.type).to.equal("ClusterIP")
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should handle Deployment defaults", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      expect(deployed.spec.revisionHistoryLimit).to.equal(10)
+      expect(deployed.spec.progressDeadlineSeconds).to.equal(600)
+      expect(deployed.spec.strategy).to.deep.equal({
+        type: "RollingUpdate",
+        rollingUpdate: {
+          maxUnavailable: "25%",
+          maxSurge: "25%",
+        },
+      })
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should handle Pod defaults", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          containers: [{ name: "app", image: "nginx:1.0" }],
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      expect(deployed.spec.restartPolicy).to.equal("Always")
+      expect(deployed.spec.dnsPolicy).to.equal("ClusterFirst")
+      expect(deployed.spec.terminationGracePeriodSeconds).to.equal(30)
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+  })
+
+  describe("server-managed metadata", () => {
+    it("should ignore server-managed metadata fields", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // Server adds these fields
+      expect(deployed.metadata.resourceVersion).to.exist
+      expect(deployed.metadata.uid).to.exist
+      expect(deployed.metadata.generation).to.exist
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+  })
+
+  describe("Garden annotations", () => {
+    it("should ignore garden.io/* annotations", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: "test",
+          namespace: "default",
+          annotations: {
+            "garden.io/version": "1.0.0",
+            "other-annotation": "keep-this",
+          },
+        },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      deployed.metadata.annotations!["garden.io/version"] = "2.0.0" // Different version
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should NOT detect change for metadata annotations (only spec matters)", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: "test",
+          namespace: "default",
+          annotations: {
+            "custom-annotation": "value-1",
+          },
+        },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // Change top-level metadata annotation - this is NOT a spec change
+      deployed.metadata.annotations!["custom-annotation"] = "value-2"
+
+      // Should NOT detect change because specChanged only compares .spec, not .metadata
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+
+    it("should detect change in pod template annotations (part of spec)", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: {
+              labels: { app: "test" },
+              annotations: { "custom-annotation": "value-1" },
+            },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // Change pod template annotation - this IS part of spec
+      deployed.spec.template.metadata.annotations!["custom-annotation"] = "value-2"
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.true
+    })
+  })
+
+  describe("actual spec changes", () => {
+    it("should detect replica count change", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 3,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:1.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      deployed.spec.replicas = 5
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.true
+    })
+
+    it("should detect image change", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: { name: "test", namespace: "default" },
+        spec: {
+          replicas: 1,
+          selector: { matchLabels: { app: "test" } },
+          template: {
+            metadata: { labels: { app: "test" } },
+            spec: {
+              containers: [{ name: "app", image: "nginx:2.0" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      deployed.spec.template.spec.containers[0].image = "nginx:1.0"
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.true
+    })
+  })
+
+  describe("StatefulSet defaults", () => {
+    it("should handle StatefulSet with default updateStrategy and podManagementPolicy", () => {
+      const manifest: KubernetesResource = {
+        apiVersion: "apps/v1",
+        kind: "StatefulSet",
+        metadata: { name: "postgres", namespace: "default" },
+        spec: {
+          serviceName: "postgres",
+          replicas: 1,
+          selector: { matchLabels: { app: "postgres" } },
+          template: {
+            metadata: { labels: { app: "postgres" } },
+            spec: {
+              containers: [{ name: "postgres", image: "postgres:13" }],
+            },
+          },
+        },
+      }
+
+      const deployed = simulateKubernetesDeployment(manifest)
+      // simulateKubernetesDeployment adds K8s defaults including updateStrategy and podManagementPolicy
+
+      expect(specChanged({ manifest, deployedResource: deployed })).to.be.false
+    })
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

This fixes an issue with our fail-fast Helm deploy logic, where if a previously unhealthy workload belonging to the chart was already deployed, that unhealthy state would be treated as a deploy failure before the new version of the resource had time to be committed to the API server and processed by the controller.

This was essentially a race condition because of the way we started waiting for resources immediately after we invoked the Helm CLI (whereas other code locations where we use `waitForResources` await at least the API operations going through).

The fix involved waiting for resources whose specs could be expected to be changed by the Helm operation. To make this more solid we (with help from our LLM friends) made the spec comparison code much more thorough by attempting to exhaustively address default fields etc. across most built-in resource types.