### PR TITLE
fix(container): don't check for local docker if using cloud builder

### DIFF
--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -355,7 +355,7 @@ const helpers = {
   }),
 
   /**
-   * Asserts that the specified docker client version meets the minimum requirements.
+   * Asserts that the specified docker server version meets the minimum requirements.
    */
   checkDockerServerVersion(version: DockerVersion, log: ActionLog) {
     if (!version.server) {


### PR DESCRIPTION
This would cause build failures when using Cloud Builder with no local Docker daemon present.
