### PR TITLE
improvement(cloud): add toggles to disable log streaming to Cloud

### DIFF
--- a/core/src/cloud/api/grpc-event-converter.ts
+++ b/core/src/cloud/api/grpc-event-converter.ts
@@ -81,7 +81,7 @@ const aecEnvironmentUpdateActionTriggeredMap = {
 export class GrpcEventConverter {
   private readonly garden: GardenWithNewBackend
   private readonly log: Log
-  private readonly shouldStreamLogEntries: boolean
+  private readonly streamLogEntries: boolean
 
   /**
    * It is important to keep it static,
@@ -90,10 +90,10 @@ export class GrpcEventConverter {
    */
   private static readonly uuidToUlidMap = new Map<UUID, ULID>()
 
-  constructor(garden: GardenWithNewBackend, log: Log, shouldStreamLogEntries: boolean) {
+  constructor(garden: GardenWithNewBackend, log: Log, streamLogEntries: boolean) {
     this.garden = garden
     this.log = log
-    this.shouldStreamLogEntries = shouldStreamLogEntries
+    this.streamLogEntries = streamLogEntries
   }
 
   convert<T extends CoreEventName>(name: T, payload: CoreEventPayload<T>): GrpcEventEnvelope[] {
@@ -163,7 +163,7 @@ export class GrpcEventConverter {
     context: GardenEventContext
     payload: LogEntryEventPayload
   }): GrpcEventEnvelope[] {
-    if (!this.shouldStreamLogEntries) {
+    if (!this.streamLogEntries) {
       return []
     }
     const msg = resolveMsg(payload.message.msg)

--- a/core/src/cloud/api/grpc-event-stream.ts
+++ b/core/src/cloud/api/grpc-event-stream.ts
@@ -37,7 +37,7 @@ export class GrpcEventStream {
   private readonly eventListener: GardenEventAnyListener<EventName>
   private readonly logListener: GardenEventAnyListener<"logEntry">
 
-  private readonly shouldStreamLogEntries: boolean
+  private readonly streamLogEntries: boolean
 
   private readonly eventIngestionService: Client<typeof GardenEventIngestionService>
 
@@ -56,20 +56,20 @@ export class GrpcEventStream {
     garden,
     log,
     eventIngestionService,
-    shouldStreamLogEntries,
+    streamLogEntries,
   }: {
     garden: GardenWithNewBackend
     log: Log
     eventIngestionService: Client<typeof GardenEventIngestionService>
-    shouldStreamLogEntries: boolean
+    streamLogEntries: boolean
   }) {
     this.garden = garden
     this.log = log
     this.eventIngestionService = eventIngestionService
     this.isClosed = false
-    this.shouldStreamLogEntries = shouldStreamLogEntries
+    this.streamLogEntries = streamLogEntries
 
-    this.converter = new GrpcEventConverter(this.garden, this.log, this.shouldStreamLogEntries)
+    this.converter = new GrpcEventConverter(this.garden, this.log, this.streamLogEntries)
 
     // TODO: make sure it waits for the callback function completion
     registerCleanupFunction("grow-stream-session-cancelled-event", () => {

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -347,13 +347,13 @@ export abstract class Command<
         let result: CommandResult<R>
 
         // We're streaming more logs to Garden Cloud v2 so we have a separate flag for that
-        const shouldStreamLogs = this.streamLogEntries || (!!garden.cloudApi && this.streamLogEntriesV2)
+        const streamLogEntries = this.streamLogEntries || (!!garden.cloudApi && this.streamLogEntriesV2)
 
         const cloudEventStream = createCloudEventStream({
           sessionId: garden.sessionId,
           log,
           garden,
-          opts: { shouldStreamEvents: this.streamEvents, shouldStreamLogs },
+          opts: { streamEvents: this.streamEvents, streamLogEntries },
         })
         if (cloudEventStream) {
           log.silly(() => `Connecting Garden instance events to Cloud API`)

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -240,6 +240,7 @@ export interface ProjectConfig extends BaseGardenResource {
   varfile?: string
   variables: DeepPrimitiveMap
   importVariables: ImportVariablesConfig
+  disableCloudLogs?: boolean
 }
 
 export const projectApiVersionSchema = memoize(() =>
@@ -393,6 +394,7 @@ export const projectSchema = createSchema({
         `
       )
       .example("dev"),
+    disableCloudLogs: joi.boolean().description("Set to true to disable streaming of logs to Garden Cloud."),
     dotIgnoreFile: joi
       .posixPath()
       .filenameOnly()

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -75,6 +75,7 @@ export const gardenEnv = {
   GARDEN_CACHE_TTL: env.get("GARDEN_CACHE_TTL").required(false).asInt(),
   GARDEN_DB_DIR: env.get("GARDEN_DB_DIR").required(false).default(GARDEN_GLOBAL_PATH).asString(),
   GARDEN_DISABLE_ANALYTICS: env.get("GARDEN_DISABLE_ANALYTICS").required(false).asBool(),
+  GARDEN_DISABLE_CLOUD_LOGS: env.get("GARDEN_DISABLE_CLOUD_LOGS").required(false).asBool(),
   GARDEN_DISABLE_PORT_FORWARDS: env.get("GARDEN_DISABLE_PORT_FORWARDS").required(false).asBool(),
   GARDEN_DISABLE_VERSION_CHECK: env.get("GARDEN_DISABLE_VERSION_CHECK").required(false).asBool(),
   GARDEN_ENABLE_PROFILING: env.get("GARDEN_ENABLE_PROFILING").required(false).default("false").asBool(),

--- a/core/src/plugins/kubernetes/commands/aec-agent.ts
+++ b/core/src/plugins/kubernetes/commands/aec-agent.ts
@@ -170,7 +170,7 @@ async function handler({ ctx, log, args, garden }: PluginCommandParams<Kubernete
       sessionId: garden.sessionId,
       log,
       garden,
-      opts: { shouldStreamEvents: true, shouldStreamLogs: false },
+      opts: { streamEvents: true, streamLogEntries: false },
     })
   }
 

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -780,7 +780,7 @@ export class GardenServer extends EventEmitter {
         sessionId: sessionIdForConfigLoad,
         log,
         garden,
-        opts: { shouldStreamEvents: true, shouldStreamLogs: false },
+        opts: { streamEvents: true, streamLogEntries: false },
       })
 
       let graph: ConfigGraph | undefined

--- a/core/test/unit/src/cloud/grpc-event-stream.ts
+++ b/core/test/unit/src/cloud/grpc-event-stream.ts
@@ -102,7 +102,7 @@ describe("GrpcEventStream", () => {
       log,
       garden,
       eventIngestionService: mockClient,
-      shouldStreamLogEntries: true,
+      streamLogEntries: true,
     })
   })
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -167,6 +167,9 @@ providers:
 # the format `<namespace>.<environment>`. Defaults to the first configured environment, with no namespace set.
 defaultEnvironment: ''
 
+# Set to true to disable streaming of logs to Garden Cloud.
+disableCloudLogs:
+
 # Specify a filename that should be used as ".ignore" file across the project, using the same syntax and semantics as
 # `.gitignore` files. By default, patterns matched in `.gardenignore` files, found anywhere in the project, are
 # ignored when scanning for actions and action sources.
@@ -687,6 +690,14 @@ Example:
 ```yaml
 defaultEnvironment: "dev"
 ```
+
+### `disableCloudLogs`
+
+Set to true to disable streaming of logs to Garden Cloud.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
 
 ### `dotIgnoreFile`
 


### PR DESCRIPTION
You can now set `GARDEN_DISABLE_CLOUD_LOGS=1` in your env or `disableCloudLogs: true` in your project configuration to disable streaming of logs to Garden Cloud (only relevant if you are actually using and connected to Garden Cloud).
