### PR TITLE
fix(cloud): default list for var utility commands

### DIFF
--- a/core/src/commands/get/get-remote-variables.ts
+++ b/core/src/commands/get/get-remote-variables.ts
@@ -15,7 +15,6 @@ import { joi, joiArray } from "../../config/common.js"
 import { ConfigurationError } from "../../exceptions.js"
 import { getCloudListCommandBaseDescription, noApiMsg, throwIfLegacyCloud } from "../helpers.js"
 import { makeDocsLinkPlain } from "../../docs/common.js"
-import { getVarlistIdsFromRemoteVarsConfig } from "../../config/project.js"
 import type { RouterOutput } from "../../cloud/api/trpc.js"
 import type { EmptyObject } from "type-fest"
 
@@ -92,7 +91,7 @@ export class GetRemoteVariablesCommand extends Command<EmptyObject, Opts> {
       throw new ConfigurationError({ message: noApiMsg("get", "cloud variables") })
     }
 
-    const variableListIds = getVarlistIdsFromRemoteVarsConfig(garden.importVariables)
+    const variableListIds = await garden.cloudApi.getVariableListIds(garden.importVariables, garden.projectId, log)
 
     if (variableListIds.length === 0) {
       log.info(dedent`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

This fixes an omission in the original PR that added logic for handling default variable lists for imported enterprise customers - we forgot to apply this logic to the `get variables` and `get-remote-variables` commands.