### PR TITLE
fix(cloud): fix to default org flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,6 +2673,7 @@
     "core/node_modules/@kubernetes/client-node/node_modules/jsonpath-plus/node_modules/jsep": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3272,6 +3273,7 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.7.2"
       }
@@ -3859,6 +3861,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8054,6 +8057,7 @@
       "version": "15.10.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -9820,6 +9824,7 @@
     "core/node_modules/ws": {
       "version": "8.18.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10790,7 +10795,8 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.8.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@commitlint/cli": {
       "version": "19.8.1",
@@ -11793,6 +11799,7 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.0",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -11918,6 +11925,7 @@
       "version": "8.14.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14411,6 +14419,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14482,6 +14491,7 @@
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle/node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16693,6 +16703,7 @@
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle/node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -17715,6 +17726,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -17820,7 +17832,8 @@
     },
     "node_modules/@types/hapi__joi": {
       "version": "17.1.15",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ink-divider": {
       "version": "2.0.4",
@@ -18070,6 +18083,7 @@
     "node_modules/@types/node": {
       "version": "24.0.13",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -18120,6 +18134,7 @@
       "version": "19.1.10",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -20058,6 +20073,7 @@
       "version": "9.33.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -20267,6 +20283,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -37154,6 +37171,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -41298,6 +41316,7 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -41631,6 +41650,7 @@
     "node_modules/react": {
       "version": "19.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -44270,6 +44290,7 @@
     "node_modules/typescript": {
       "version": "5.9.2",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -44793,6 +44814,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

The previous implementation didn't prevent migrated single-tenant users from selecting another org than the one their project ID belongs to, leading to confusing behaviour.

Here, if a project ID is present, we ensure that the organization ID belonging to it (if any) is always used, and is automatically written into the project config on disk.