### PR TITLE
fix(cloud): potential OOM when Cloud connection fails

### DIFF
--- a/core/src/logger/log-entry.ts
+++ b/core/src/logger/log-entry.ts
@@ -178,7 +178,7 @@ export interface LogEntry<C extends BaseContext = LogContext>
   skipEmit?: boolean
 }
 
-interface LogParams
+export interface LogParams
   extends Pick<LogEntry, "metadata" | "msg" | "rawMsg" | "symbol" | "data" | "dataFormat" | "error" | "skipEmit">,
     Pick<LogContext, "origin">,
     Pick<LogConfig<LogContext>, "showDuration"> {}


### PR DESCRIPTION
Turns out this wasn't fully addressed previously, and there were some scenarios left in where gRPC stream errors could feed back into the buffer and cause a recursion in log entries stacking up.

Also extended the timeout to deliver events at the end of execution.
