### PR TITLE
chore(ci): update Mac runner type

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -418,7 +418,7 @@ jobs:
   build-dist-macos:
     macos:
       xcode: 15.0.0
-    resource_class: macos.m1.medium.gen1
+    resource_class: macos.m4pro.medium.gen1
     parameters:
       version:
         description: The version tag/name to set


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

CircleCI has deprecated the Mac runner type we've been using, resulting in our dist pipelines failing. This should fix that.