### PR TITLE
chore: remove Discord links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 > [!NOTE]
-> If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Join our [Discord](https://go.garden.io/discord).
+> If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Check out [Garden Discussions](https://github.com/garden-io/garden/discussions).
 
 :tada: Thanks for taking an interest in contributing to Garden and Garden's docs. We appreciate your effort and passion! :clap:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Garden
 
-_If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Join our [Discord](https://go.garden.io/discord)._
+_If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Check out [Garden Discussions](https://github.com/garden-io/garden/discussions)._
 
 <p align="center">
   <picture>
@@ -19,8 +19,6 @@ _If you love Garden, please ★ star this repository to show your support :green
   <a href="https://github.com/garden-io/garden/tree/0.14.13/examples">Examples</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://garden.io/blog/?utm_source=github">Blog</a>
-  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://go.garden.io/discord">Discord</a>
 </div>
 
 ## Welcome to Garden!
@@ -127,7 +125,7 @@ Garden is _pluggable_: how actions are executed depends on the plugins used. Our
 
 ## Community
 
-Join our [Discord community](https://go.garden.io/discord) to ask questions, give feedback or just say hi 🙂
+Check out [Garden Discussions](https://github.com/garden-io/garden/discussions) to ask questions, give feedback or just say hi 🙂
 
 ## Contributing
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -62,7 +62,6 @@ Once the release CI job is done, a draft release will appear in GitHub. That dra
 10. Install the Homebrew package and make sure it works okay:
     - `brew tap garden-io/garden && brew install garden-cli || true && brew update && brew upgrade garden-cli`
     - Run `$(brew --prefix garden-cli)/bin/garden dev` and run the `version` command in the console (to make sure you're using the packaged release). Do a quick manual test in an example project and see if all looks OK.
-11. Prepare the release announcement and publish it in our channels (Discord and Twitter). If not possible, delegate the task to an available contributor.
 
 ## Misc
 

--- a/core/src/commands/community.ts
+++ b/core/src/commands/community.ts
@@ -13,10 +13,10 @@ import { exec } from "../util/util.js"
 
 export class CommunityCommand extends Command {
   name = "community"
-  help = "Join our community Discord to chat with us!"
+  help = "Checkout Garden Discussions on GitHub to chat with us!"
 
   override description = dedent`
-    Opens the Garden Community Discord invite link
+    Opens the Garden Discussions page.
   `
 
   override noProject = true
@@ -24,14 +24,14 @@ export class CommunityCommand extends Command {
   override printHeader() {}
 
   async action(): Promise<CommandResult> {
-    const discordInvite = "https://discord.gg/FrmhuUjFs6"
+    const discussionsLink = "https://github.com/garden-io/garden/discussions"
     // eslint-disable-next-line no-console
-    console.log(discordInvite)
+    console.log(discussionsLink)
 
     try {
-      await exec("open", [discordInvite])
+      await exec("open", [discussionsLink])
     } catch (_) {}
 
-    return { result: { discordInvite } }
+    return { result: { discussionsLink } }
   }
 }

--- a/core/src/commands/get/get-debug-info.ts
+++ b/core/src/commands/get/get-debug-info.ts
@@ -317,8 +317,6 @@ export class GetDebugInfoCommand extends Command<Args, Opts> {
       dedent`
         NOTE: Please be aware that the output file might contain sensitive information.
         If you plan to make the file available to the general public (e.g. GitHub), please review the content first.
-        If you need to share a file containing sensitive information with the Garden team, please contact us on
-        our Discord community: https://discord.gg/FrmhuUjFs6.
       `
     )
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -4,7 +4,7 @@ order: 99
 ---
 
 {% hint style="info" %}
-If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Join our [Discord](https://go.garden.io/discord).
+_If you love Garden, please ★ star this repository to show your support :green_heart:. Looking for support? Check out [Garden Discussions](https://github.com/garden-io/garden/discussions)._
 {% endhint %}
 
 ## Contributing guidelines

--- a/docs/garden-for/kubernetes/README.md
+++ b/docs/garden-for/kubernetes/README.md
@@ -26,4 +26,4 @@ For tests and tasks, Garden spins up Pods from the respective image that execute
 
 For live code synchronization, Garden uses a tool called Mutagen to sync changes to the running container.
 
-There's a lot more to the Kubernetes plugins and if you're interested in the "nitty-gritty", we're more than happy to answer questions us on our [Discord channel](https://discord.gg/FrmhuUjFs6).
+There's a lot more to the Kubernetes plugins and if you're interested in the "nitty-gritty", we're more than happy to answer questions us on [Garden Discussions](https://github.com/garden-io/garden/discussions).

--- a/docs/getting-started/basics.md
+++ b/docs/getting-started/basics.md
@@ -143,4 +143,4 @@ The gif below shows the test caching in action:
 
 Don't worry too much about the different action kinds and types, we have plenty of examples to help you pick the right one. Just know that you can model a system of any complexity with this pattern, even if it's components are spread across multiple repos.
 
-And if you have any questions, feel free to open an issue on Github or ping us on [Discord](https://go.garden.io/discord).
+And if you have any questions, feel free to open an issue on Github or ask a question on [Garden Discussions](https://github.com/garden-io/garden/discussions).

--- a/docs/getting-started/next-steps.md
+++ b/docs/getting-started/next-steps.md
@@ -213,4 +213,4 @@ And that's the gist of it!
 
 We encourage you to try adding Garden to your own project. You won't need to change any of your existing code or configuration, only sprinkle in some Garden config files to codify your workflows and you'll be going **from zero to a running system in a single command**.
 
-And if you have any questions, don't hesitate to reach out to our [our Discord community](https://discord.gg/FrmhuUjFs6).
+And if you have any questions, don't hesitate to reach out on [Garden Discussions](https://github.com/garden-io/garden/discussions).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -144,7 +144,7 @@ Start by checking out the [Garden basics guide](./basics.md) which covers the ma
 
 After that you can either go through [first project tutorial](../tutorials/your-first-project/) which explains step-by-step how to add Garden to an existing project. Or you can check out the [Next Steps guide](./next-steps.md) which gives you a more high level but still step-wise overview of how to adopt Garden and add it to your stack.
 
-If you have any questions or feedback—or just want to say hi 🙂—we encourage you to join our [Discord community](https://go.garden.io/discord)!
+If you have any questions or feedback—or just want to say hi 🙂—we encourage you to use [Garden Discussion](https://github.com/garden-io/garden/discussions)!
 
 ## Troubleshooting
 

--- a/docs/guides/deploying-to-production.md
+++ b/docs/guides/deploying-to-production.md
@@ -17,4 +17,4 @@ The flag is also given to each provider, which may modify behavior accordingly. 
 4. Increase the `RevisionHistoryLimit` on workloads to 10.
 5. By default, running `garden deploy --force` will propagate the `--force` flag to `helm upgrade`, and set the `--replace` flag on `helm install` when deploying `helm` actions. This may be okay while developing but risky in production, so the `production` flag prevents both of those.
 
-We would highly appreciate feedback on other configuration settings that should be altered when `production: true`. Please send us feedback via [GitHub issues](https://github.com/garden-io/garden/issues) or reach out on [our Discord Community](https://discord.gg/FrmhuUjFs6)!
+We would highly appreciate feedback on other configuration settings that should be altered when `production: true`. Please send us feedback via [GitHub issues](https://github.com/garden-io/garden/issues) or reach out on [Garden Discussions](https://github.com/garden-io/garden/discussions)!

--- a/docs/guides/migrating-from-docker-compose.md
+++ b/docs/guides/migrating-from-docker-compose.md
@@ -205,5 +205,5 @@ applications.
 This is a basic example but it should give you what you need to migrate larger projects too. If you have feedback on
 how we could make migrating from Docker Compose easier, please send it our way
 via [GitHub issues](https://github.com/garden-io/garden/issues) or reach out
-on [our Discord community](https://discord.gg/FrmhuUjFs6).
+on [Garden Discussions](https://github.com/garden-io/garden/discussions).
 

--- a/docs/misc/adopting-garden.md
+++ b/docs/misc/adopting-garden.md
@@ -71,4 +71,4 @@ You can learn more in [this blog post](https://garden.io/blog/garden-linkerd) on
 
 Now that you have a feel for how teams typically adopt Garden, we recommend diving right in with our [Quickstart guide](../getting-started/quickstart.md) or learning how to [add Garden to your own project](../getting-started/next-steps.md).
 
-And if you have any questions, don't hesitate to reach out to our [our Discord community](https://discord.gg/FrmhuUjFs6).
+And if you have any questions, don't hesitate to reach out on [Garden Discussions](https://github.com/garden-io/garden/discussions).

--- a/docs/misc/cloud-announcement.md
+++ b/docs/misc/cloud-announcement.md
@@ -32,5 +32,3 @@ To use the new cloud version after the release, you’ll need update to Garden t
 If you’re logged into [app.garden.io](http://app.garden.io) using older versions of the Garden CLI, you’ll see a warning message saying that your command results won’t be available in Garden Cloud. Other than that, Garden will continue to work as expected—the only difference is that logs and command results won’t be visible in the UI.
 
 Again, we’re actively working to **restore this functionality** while making the new Garden Cloud a **vastly better experience overall**.
-
-Stay tuned, and if you have any questions, don’t hesitate to reach out [on Discord](https://discord.com/invite/FrmhuUjFs6) or directly to [ricky@garden.io](mailto:ricky@garden.io) ❤️

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -295,7 +295,7 @@ Yes! `two-way` sync mode can be configured with Garden sync mode. See [this guid
 
 Garden is currently in use by many teams. We don’t have a set date or plan to label it as 1.0, but we don't expect to do it anytime soon.
 
-We have a team of people working on it full-time, and we make it a priority to address all non-trivial bugs. We’re also happy to help out and answer questions via [our Discord community](https://discord.gg/FrmhuUjFs6).
+We have a team of people working on it full-time, and we make it a priority to address all non-trivial bugs. We’re also happy to help out and answer questions on [Garden Discussions](https://github.com/garden-io/garden/discussions).
 
 ### Does Garden work offline?
 

--- a/docs/overview/use-cases/jumpstart-idp.md
+++ b/docs/overview/use-cases/jumpstart-idp.md
@@ -25,10 +25,6 @@ Navigate to [Examples](#examples) for a selection of pre-configured stacks you c
 - Use [Config Templates](../../features/config-templates.md) to vend development environments to all your developers
 - If you're coming from Docker Compose, visit our [Migrating From Docker Compose](../../guides/migrating-from-docker-compose.md) guide
 
-{% hint style="info" %}
-Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
-{% endhint %}
-
 ## Further Reading
 
 - [What is Garden](../../overview/what-is-garden.md)

--- a/docs/overview/use-cases/local-development-remote-clusters.md
+++ b/docs/overview/use-cases/local-development-remote-clusters.md
@@ -47,10 +47,6 @@ So with that in mind, here are the recommended next steps:
 - [Add actions](../../garden-for/kubernetes/README.md) to build and deploy your project
 - [Configure code syncing](../../features/code-synchronization.md) so you can live reload changes to the remote cluster
 
-{% hint style="info" %}
-Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
-{% endhint %}
-
 ## Further Reading
 
 - [What is Garden](../../overview/what-is-garden.md)

--- a/docs/overview/use-cases/on-demand-preview-envs.md
+++ b/docs/overview/use-cases/on-demand-preview-envs.md
@@ -47,10 +47,6 @@ So with that in mind, these are the recommended next steps:
 - [Add actions](../../garden-for/kubernetes/README.md) to build and deploy your project
 - Follow our guide on [environments and namespaces](../../guides/namespaces.md) to ensure each preview environment is isolated
 
-{% hint style="info" %}
-Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
-{% endhint %}
-
 ## Further Reading
 
 - [What is Garden](../../overview/what-is-garden.md)

--- a/docs/overview/use-cases/portable-ci-pipelines.md
+++ b/docs/overview/use-cases/portable-ci-pipelines.md
@@ -29,10 +29,6 @@ If you're already familiar with Garden and just want to get going, click any of 
 - [Using Garden in CircleCI](../../guides/using-garden-in-circleci.md)
 - Garden's official [GitHub Action](https://github.com/marketplace/actions/garden-action).
 
-{% hint style="info" %}
-Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
-{% endhint %}
-
 ## Further Reading
 
 - [What is Garden](../../overview/what-is-garden.md)

--- a/docs/overview/use-cases/shift-testing-left.md
+++ b/docs/overview/use-cases/shift-testing-left.md
@@ -49,10 +49,6 @@ So with that in mind, these are the recommended next steps:
 - [Set up your remote cluster](../../garden-for/kubernetes/remote-kubernetes.md)
 - [Add actions](../../garden-for/kubernetes/README.md) to build and deploy your project
 
-{% hint style="info" %}
-Join our [Discord community](https://go.garden.io/discord) 🌸 for access to Garden's dedicated Community Engineers and our AI chatbot 🤖  trained on our docs.
-{% endhint %}
-
 ## Further Reading
 
 - [What is Garden](../../overview/what-is-garden.md)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -655,9 +655,9 @@ Examples:
 
 ### garden community
 
-**Join our community Discord to chat with us!**
+**Checkout Garden Discussions on GitHub to chat with us!**
 
-Opens the Garden Community Discord invite link
+Opens the Garden Discussions page.
 
 #### Usage
 

--- a/docs/tutorials/remote-k8s/create-cluster/README.md
+++ b/docs/tutorials/remote-k8s/create-cluster/README.md
@@ -17,7 +17,7 @@ Below you'll find basic guides for some common cloud providers:
 * [GCP](./gcp.md)
 * [Azure](./azure.md)
 
-Let us know on [our Discord community](https://discord.gg/FrmhuUjFs6) if you'd like guides for more providers.
+Let us know on [Garden Discussions](https://github.com/garden-io/garden/discussions) if you'd like guides for more providers.
 
 Note that there are multiple ways to create Kubernetes clusters (e.g. point-and-click, Terraform, Pulumi, etc) and feel free to pick whatever approach you're most comfortable with.
 

--- a/docs/tutorials/your-first-project/6-configure-your-project.md
+++ b/docs/tutorials/your-first-project/6-configure-your-project.md
@@ -23,4 +23,4 @@ For a large, complex project, it might be good to start with a subset of it, so 
 
 Whatever your setup is, we're sure you'll be rewarded with an elegant, productive setup for testing and developing your system!
 
-And if there's something you can't find in our docs, we happily encourage you to [join our Discord community](https://discord.gg/FrmhuUjFs6) and/or file an issue on [our GitHub repo](https://github.com/garden-io/garden). We're more than happy to help!
+And if there's something you can't find in our docs, we happily encourage you to [check out Garden Discussions](https://github.com/garden-io/garden/discussions) and/or file an issue on [our GitHub repo](https://github.com/garden-io/garden). We're more than happy to help!

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -11,7 +11,7 @@ description: >-
 
 Garden lets you spin up **production-like environments** for development, testing, and CI **on demand**. It enables teams to use the **same configuration** and workflows for **every stage of software delivery**—and dramatically **speeds up builds and test runs** via smart caching.
 
-If there's something you can't find in our docs, we happily encourage you to [join our Discord community](https://discord.gg/FrmhuUjFs6) and/or file an issue on [our GitHub repo](https://github.com/garden-io/garden). We're more than happy to help!
+If there's something you can't find in our docs, we happily encourage you to checkout [Garden Discussions](https://github.com/garden-io/garden/discussions) and/or file an issue on [our GitHub repo](https://github.com/garden-io/garden). We're more than happy to help!
 
 ### Overview
 


### PR DESCRIPTION
We're migrating from Discord to GitHub Discussions. This commit replaces links to Discord with links to our GitHub Discussions page.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
