### PR TITLE
Skip error log dump when logged in

### DIFF
--- a/core/src/cloud/api-legacy/api.ts
+++ b/core/src/cloud/api-legacy/api.ts
@@ -93,7 +93,7 @@ interface CloudSessionResponse {
   shortId: string
 }
 
-export interface CloudSession extends CloudSessionResponse {
+export interface CloudSessionLegacy extends CloudSessionResponse {
   api: GardenCloudApiLegacy
   id: string
   projectId: string
@@ -171,7 +171,7 @@ export class GardenCloudApiLegacy {
   private readonly httpClient: GardenCloudHttpClient
 
   private projects: Map<string, CloudProject> // keyed by project ID
-  private registeredSessions: Map<string, CloudSession> // keyed by session ID
+  private registeredSessions: Map<string, CloudSessionLegacy> // keyed by session ID
 
   private readonly log: Log
   public readonly domain: string
@@ -477,7 +477,7 @@ export class GardenCloudApiLegacy {
     environment: string
     namespace: string
     isDevCommand: boolean
-  }): Promise<CloudSession | undefined> {
+  }): Promise<CloudSessionLegacy | undefined> {
     let session = this.registeredSessions.get(sessionId)
 
     if (session) {

--- a/core/src/cloud/api-legacy/restful-event-stream.ts
+++ b/core/src/cloud/api-legacy/restful-event-stream.ts
@@ -15,7 +15,7 @@ import { got } from "../../util/http.js"
 
 import type { LogLevel } from "../../logger/logger.js"
 import type { Garden } from "../../garden.js"
-import type { CloudSession } from "./api.js"
+import type { CloudSessionLegacy } from "./api.js"
 import { getSection } from "../../logger/renderers.js"
 import { registerCleanupFunction } from "../../util/util.js"
 import { makeAuthHeader } from "./auth.js"
@@ -101,7 +101,7 @@ export interface ApiLogBatch extends ApiBatchBase {
 export interface RestfulEventStreamParams {
   log: Log
   maxLogLevel: LogLevel
-  cloudSession: CloudSession
+  cloudSession: CloudSessionLegacy
   garden: Garden
   streamEvents?: boolean
   streamLogEntries?: boolean
@@ -119,7 +119,7 @@ export interface RestfulEventStreamParams {
  * any) e.g. when config changes during a watch-mode command.
  */
 export class RestfulEventStream {
-  private readonly cloudSession: CloudSession
+  private readonly cloudSession: CloudSessionLegacy
   private readonly garden: Garden
 
   private readonly log: Log

--- a/core/src/cloud/api/grpc-event-converter.ts
+++ b/core/src/cloud/api/grpc-event-converter.ts
@@ -92,7 +92,7 @@ export class GrpcEventConverter {
    * because each command execution in the dev console causes a new instance creation.
    * We need to be sure that uuid to ulid mapping is stable is the case if we have a cache miss here.
    */
-  private static readonly uuidToUlidMap = new Map<UUID, ULID>()
+  static readonly uuidToUlidMap = new Map<UUID, ULID>()
 
   constructor(garden: GardenWithNewBackend, log: Log, streamLogEntries: boolean) {
     this.garden = garden

--- a/core/src/plugin/base.ts
+++ b/core/src/plugin/base.ts
@@ -162,6 +162,7 @@ export const runResultSchemaZod = z.object({
   startedAt: z.coerce.date(),
   completedAt: z.coerce.date(),
   log: z.string().transform((arg) => tailString(arg, MAX_RUN_RESULT_LOG_LENGTH, true)),
+  errorMsg: z.string().optional(),
   diagnosticErrorMsg: z.string().optional(),
 })
 
@@ -178,6 +179,7 @@ export const runResultSchema = createSchema({
     startedAt: joi.date().required().description("When the module run was started."),
     completedAt: joi.date().required().description("When the module run was completed."),
     log: joi.string().allow("").default("").description("The output log from the run."),
+    errorMsg: joi.string().allow("").optional().description("An error message from the plugin."),
     diagnosticErrorMsg: joi
       .string()
       .optional()

--- a/core/src/plugins/exec/build.ts
+++ b/core/src/plugins/exec/build.ts
@@ -6,14 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { renderMessageWithDivider } from "../../logger/util.js"
 import type {
   GardenSdkActionDefinitionActionType,
   GardenSdkActionDefinitionConfigType,
   BuildStatus,
 } from "../../plugin/sdk.js"
 import { sdk } from "../../plugin/sdk.js"
-import { styles } from "../../logger/styles.js"
 import { execRunCommand, isExpectedStatusCommandError } from "./common.js"
 import {
   execCommonSchema,
@@ -84,20 +82,6 @@ export const execBuildHandler = execBuild.addHandler("build", async ({ action, l
     output.detail.buildLog = result.outputLog
     success = result.success
     output.outputs = result.outputs
-  }
-
-  if (output.detail?.buildLog) {
-    output.outputs.log = output.detail?.buildLog
-
-    const prefix = `Finished building ${styles.highlight(action.name)}. Here is the full output:`
-    log.info(
-      renderMessageWithDivider({
-        prefix,
-        msg: output.detail?.buildLog,
-        isError: !success,
-        color: styles.primary,
-      })
-    )
   }
 
   return { ...output, state: success ? "ready" : "failed" }

--- a/core/src/plugins/exec/common.ts
+++ b/core/src/plugins/exec/common.ts
@@ -110,13 +110,14 @@ export async function execRunCommand({
 
     // Comes from error object
     const shortMessage = (result as any).shortMessage || ""
-    const outputLog = ((result.stdout || "") + "\n" + (result.stderr || "") + "\n" + shortMessage).trim()
+    const outputLog = ((result.stdout || "") + "\n" + (result.stderr || "")).trim()
 
     return {
       ...result,
       outputs: { ...outputs, log: outputLog, stdout: result.stdout, stderr: result.stderr },
       outputLog,
       completedAt: new Date(),
+      errorMsg: shortMessage,
       success: result.exitCode === 0,
     }
   } finally {

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -17,7 +17,6 @@ import { TimeoutError } from "../../exceptions.js"
 import type { Log } from "../../logger/log-entry.js"
 import type { ExecaReturnBase } from "execa"
 import { execa } from "execa"
-import { renderMessageWithDivider } from "../../logger/util.js"
 import { LogLevel } from "../../logger/logger.js"
 import { createWriteStream } from "fs"
 import fsExtra from "fs-extra"
@@ -196,18 +195,6 @@ execDeploy.addHandler("deploy", async (params) => {
       env,
       opts: { reject: true },
     })
-
-    if (result.outputLog) {
-      const prefix = `Finished deploying ${styles.highlight(action.name)}. Here is the output:`
-      log.info(
-        renderMessageWithDivider({
-          prefix,
-          msg: result.outputLog,
-          isError: !result.success,
-          color: styles.primary,
-        })
-      )
-    }
 
     const deployState: DeployState = result.success ? "ready" : "unhealthy"
     const actionState: ActionState = result.success ? "ready" : "failed"

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -7,10 +7,8 @@
  */
 
 import { runResultToActionState } from "../../actions/base.js"
-import { renderMessageWithDivider } from "../../logger/util.js"
 import type { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType } from "../../plugin/sdk.js"
 import { sdk } from "../../plugin/sdk.js"
-import { styles } from "../../logger/styles.js"
 import { copyArtifacts, execGetResultHandler, execRunCommand } from "./common.js"
 import { execRunSpecSchema, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config.js"
 import { execProvider } from "./exec.js"
@@ -72,6 +70,7 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
     command,
     version: action.versionString(log),
     success: commandResult.success,
+    errorMsg: commandResult.errorMsg,
     log: commandResult.outputLog,
     startedAt,
     completedAt: commandResult.completedAt,
@@ -85,18 +84,6 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
 
   if (!commandResult.success) {
     return result
-  }
-
-  if (commandResult.outputLog) {
-    const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
-    log.info(
-      renderMessageWithDivider({
-        prefix,
-        msg: commandResult.outputLog,
-        isError: !commandResult.success,
-        color: styles.primary,
-      })
-    )
   }
 
   return result

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -7,10 +7,8 @@
  */
 
 import { runResultToActionState } from "../../actions/base.js"
-import { renderMessageWithDivider } from "../../logger/util.js"
 import type { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType } from "../../plugin/sdk.js"
 import { sdk } from "../../plugin/sdk.js"
-import { styles } from "../../logger/styles.js"
 import { copyArtifacts, execGetResultHandler, execRunCommand } from "./common.js"
 import { execRunSpecSchema, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config.js"
 import { execProvider } from "./exec.js"
@@ -74,6 +72,7 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
     command,
     version: action.versionString(log),
     success: commandResult.success,
+    errorMsg: commandResult.errorMsg,
     log: commandResult.outputLog,
     startedAt,
     completedAt: commandResult.completedAt,
@@ -87,18 +86,6 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
 
   if (!commandResult.success) {
     return result
-  }
-
-  if (commandResult.outputLog) {
-    const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
-    log.info(
-      renderMessageWithDivider({
-        prefix,
-        msg: commandResult.outputLog,
-        isError: !commandResult.success,
-        color: styles.primary,
-      })
-    )
   }
 
   return result

--- a/core/src/tasks/run.ts
+++ b/core/src/tasks/run.ts
@@ -114,7 +114,10 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
       if (status.detail?.diagnosticErrorMsg) {
         this.log.debug(`Additional context for the error:\n\n${status.detail.diagnosticErrorMsg}`)
       }
-      throw new RunFailedError({ message: status.detail?.log || "The run failed, but it did not output anything." })
+
+      throw new RunFailedError({
+        message: await this.makeErrorMsg({ errorMsg: status.detail?.errorMsg, logOutput: status.detail?.log }),
+      })
     }
 
     return {

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -126,15 +126,19 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
     } catch (err) {
       throw err
     }
-    if (status.detail?.success) {
-    } else {
+
+    if (status.detail?.success !== true) {
       const exitCode = status.detail?.exitCode
       const failedMsg = !!exitCode ? `Failed with code ${exitCode}!` : `Failed!`
       this.log.error(failedMsg)
+
       if (status.detail?.diagnosticErrorMsg) {
         this.log.debug(`Additional context for the error:\n\n${status.detail.diagnosticErrorMsg}`)
       }
-      throw new TestFailedError({ message: status.detail?.log || "The test failed, but it did not output anything." })
+
+      throw new TestFailedError({
+        message: await this.makeErrorMsg({ errorMsg: status.detail?.errorMsg, logOutput: status.detail?.log }),
+      })
     }
 
     return {

--- a/core/test/unit/src/cloud/restful-event-stream.ts
+++ b/core/test/unit/src/cloud/restful-event-stream.ts
@@ -12,13 +12,13 @@ import { RestfulEventStream } from "../../../../src/cloud/api-legacy/restful-eve
 import { getRootLogger, LogLevel } from "../../../../src/logger/logger.js"
 import { makeTestGardenA } from "../../../helpers.js"
 import { find, isMatch, range, repeat } from "lodash-es"
-import type { CloudSession, GardenCloudApiLegacy } from "../../../../src/cloud/api-legacy/api.js"
+import type { CloudSessionLegacy, GardenCloudApiLegacy } from "../../../../src/cloud/api-legacy/api.js"
 
 function makeDummyRecord(sizeKb: number) {
   return { someKey: repeat("a", sizeKb * 1024) }
 }
 
-const mockCloudSession: CloudSession = {
+const mockCloudSession: CloudSessionLegacy = {
   // this api is never called in the tests below, all caller functions are overridden in the individual tests
   api: {} as GardenCloudApiLegacy,
   // we do not need any correct values of these for this test suite

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -4009,6 +4009,9 @@ actions:
         # The output log from the run.
         log:
 
+        # An error message from the plugin.
+        errorMsg:
+
         # An optional, more detailed diagnostic error message from the plugin.
         diagnosticErrorMsg:
 
@@ -4042,6 +4045,9 @@ actions:
 
         # The output log from the run.
         log:
+
+        # An error message from the plugin.
+        errorMsg:
 
         # An optional, more detailed diagnostic error message from the plugin.
         diagnosticErrorMsg:
@@ -4533,6 +4539,9 @@ detail:
   # The output log from the run.
   log:
 
+  # An error message from the plugin.
+  errorMsg:
+
   # An optional, more detailed diagnostic error message from the plugin.
   diagnosticErrorMsg:
 
@@ -4587,6 +4596,9 @@ detail:
 
   # The output log from the run.
   log:
+
+  # An error message from the plugin.
+  errorMsg:
 
   # An optional, more detailed diagnostic error message from the plugin.
   diagnosticErrorMsg:


### PR DESCRIPTION
Before this change we'd dump the entire output of Run and Test actions
at the end of a failed run.

This can be a massive amount of log lines which adds a lot of noise to the
CLI output.

Also, we were already streaming the output line by line at the default log
level so these lines are essentially rendered twice.

With this change we simply print a link to the logs instead of the
output itself for failed actions if the user is logged in.

If the user is not logged in we continue dumping the logs.

We also stop dumping the output of successful exec actions because
that's also streamed line-by-line (at the default log level).

Finally, we reintroduce the link to the command results at the start and
end of command runs.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
