### PR TITLE
feat(variables): support loading vars/secrets from files and exec

### DIFF
--- a/core/src/cloud/api/api.ts
+++ b/core/src/cloud/api/api.ts
@@ -457,7 +457,6 @@ export class GardenCloudApi {
     log: Log
     legacyProjectId: string | undefined
   }) {
-    log.info(`Fetching remote variables`)
     const variableListIds = await this.getVariableListIds(importVariables, legacyProjectId, log)
     const reqs = variableListIds.map(async (variableListId, index) => {
       log.debug(`Fetching remote variables for variableListId=${variableListId}`)

--- a/core/src/config/import-variables.ts
+++ b/core/src/config/import-variables.ts
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import dotenv from "dotenv"
+import { resolve } from "path"
+import { readFile } from "fs/promises"
+import { existsSync } from "fs"
+import { isPlainObject } from "lodash-es"
+import { execa } from "execa"
+import tmp from "tmp-promise"
+
+import type { Log } from "../logger/log-entry.js"
+import type { StringMap } from "./common.js"
+import type { GardenCloudApi } from "../cloud/api/api.js"
+import type { ImportVariablesConfig, ImportVarsSourceFormat } from "./project.js"
+import { ConfigurationError, RuntimeError } from "../exceptions.js"
+import { loadAndValidateYaml } from "./base.js"
+
+/**
+ * Loads variables from all configured import sources.
+ * Variables are merged in order, with later sources taking precedence.
+ */
+export async function loadImportedVariables({
+  importVariables,
+  projectRoot,
+  log,
+  cloudApi,
+  environmentName,
+  legacyProjectId,
+}: {
+  importVariables: ImportVariablesConfig
+  projectRoot: string
+  log: Log
+  cloudApi?: GardenCloudApi
+  environmentName: string
+  legacyProjectId?: string
+}): Promise<StringMap> {
+  if (!importVariables || importVariables.length === 0) {
+    return {}
+  }
+
+  let result: StringMap = {}
+
+  for (const source of importVariables) {
+    let vars: StringMap = {}
+
+    switch (source.from) {
+      case "garden-cloud":
+        if (!cloudApi) {
+          log.warn(`Cannot import variables from Garden Cloud: Not logged in. Skipping source.`)
+          continue
+        }
+        log.info(`Fetching variables from Garden Cloud (list: ${source.list})`)
+        vars = await loadFromGardenCloud({
+          cloudApi,
+          variableListId: source.list,
+          environmentName,
+          legacyProjectId,
+          log,
+        })
+        break
+
+      case "file":
+        log.info(`Loading variables from file: ${source.path}`)
+        vars = await loadFromFile({
+          projectRoot,
+          path: source.path,
+          format: source.format,
+          log,
+        })
+        break
+
+      case "exec":
+        log.info(`Running command to load variables: ${source.command.join(" ")}`)
+        vars = await loadFromExec({
+          projectRoot,
+          command: source.command,
+          format: source.format,
+          environmentName,
+          log,
+        })
+        break
+    }
+
+    // Merge variables, with later sources taking precedence
+    result = { ...result, ...vars }
+  }
+
+  return result
+}
+
+/**
+ * Loads variables from a Garden Cloud variable list.
+ */
+async function loadFromGardenCloud({
+  cloudApi,
+  variableListId,
+  environmentName,
+  legacyProjectId,
+  log,
+}: {
+  cloudApi: GardenCloudApi
+  variableListId: string
+  environmentName: string
+  legacyProjectId?: string
+  log: Log
+}): Promise<StringMap> {
+  // Use the existing getVariables method but for a single list
+  const result = await cloudApi.getVariables({
+    importVariables: [{ from: "garden-cloud", list: variableListId }],
+    environmentName,
+    log,
+    legacyProjectId,
+  })
+  return result
+}
+
+/**
+ * Loads variables from a local file.
+ */
+async function loadFromFile({
+  projectRoot,
+  path,
+  format,
+  log,
+}: {
+  projectRoot: string
+  path: string
+  format: ImportVarsSourceFormat
+  log: Log
+}): Promise<StringMap> {
+  const resolvedPath = resolve(projectRoot, path)
+
+  let fileContents: Buffer
+  try {
+    fileContents = await readFile(resolvedPath)
+    log.silly(() => `Loaded ${fileContents.length} bytes from ${resolvedPath}`)
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      log.warn(
+        `Could not find import variables file at path '${path}'. Absolute path: ${resolvedPath}. No variables imported from this source.`
+      )
+      return {}
+    }
+    throw new ConfigurationError({
+      message: `Unable to load import variables file at '${path}': ${error}`,
+    })
+  }
+
+  return parseVariablesContent(fileContents.toString("utf-8"), format, path)
+}
+
+/**
+ * Loads variables by running a command that writes output to a temp file.
+ */
+async function loadFromExec({
+  projectRoot,
+  command,
+  format,
+  environmentName,
+  log,
+}: {
+  projectRoot: string
+  command: string[]
+  format: ImportVarsSourceFormat
+  environmentName: string
+  log: Log
+}): Promise<StringMap> {
+  const tmpFile = await tmp.file({ prefix: "garden-import-vars-", postfix: `.${format}` })
+
+  try {
+    const [cmd, ...args] = command
+
+    const result = await execa(cmd, args, {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        GARDEN_OUTPUT_PATH: tmpFile.path,
+        GARDEN_ENVIRONMENT: environmentName,
+      },
+      reject: false,
+    })
+
+    if (result.exitCode !== 0) {
+      throw new RuntimeError({
+        message: `Command "${command.join(" ")}" failed with exit code ${result.exitCode}.\nStderr: ${result.stderr || "(empty)"}`,
+      })
+    }
+
+    // Check if the file was written to
+    if (!existsSync(tmpFile.path)) {
+      log.warn(
+        `Command "${command.join(" ")}" did not write to GARDEN_OUTPUT_PATH. No variables imported from this source.`
+      )
+      return {}
+    }
+
+    // Read the file contents
+    const fileContents = await readFile(tmpFile.path, "utf-8")
+
+    // Check if file is empty
+    if (fileContents.trim() === "") {
+      log.warn(
+        `Command "${command.join(" ")}" wrote an empty file to GARDEN_OUTPUT_PATH. No variables imported from this source.`
+      )
+      return {}
+    }
+
+    return parseVariablesContent(fileContents, format, `output from command "${command.join(" ")}"`)
+  } finally {
+    // Clean up temp file
+    await tmpFile.cleanup()
+  }
+}
+
+/**
+ * Parses variable content based on the specified format.
+ */
+async function parseVariablesContent(
+  content: string,
+  format: ImportVarsSourceFormat,
+  sourceDescription: string
+): Promise<StringMap> {
+  switch (format) {
+    case "json": {
+      try {
+        const parsed = JSON.parse(content)
+        if (!isPlainObject(parsed)) {
+          throw new ConfigurationError({
+            message: `Import variables from ${sourceDescription} must be a valid plain JSON object. Got: ${typeof parsed}`,
+          })
+        }
+        // Convert all values to strings
+        return objectToStringMap(parsed)
+      } catch (error: any) {
+        if (error instanceof ConfigurationError) {
+          throw error
+        }
+        throw new ConfigurationError({
+          message: `Failed to parse JSON from ${sourceDescription}: ${error.message}`,
+        })
+      }
+    }
+
+    case "yaml": {
+      const loaded = await loadAndValidateYaml({
+        content,
+        filename: undefined,
+        version: "1.2",
+        sourceDescription: `import variables from ${sourceDescription}`,
+      })
+
+      if (loaded.length === 0) {
+        return {}
+      }
+
+      if (loaded.length > 1) {
+        throw new ConfigurationError({
+          message: `Import variables from ${sourceDescription} must be a single YAML document. Got multiple (${loaded.length}) YAML documents`,
+        })
+      }
+
+      const data = loaded[0].toJS() || {}
+      if (!isPlainObject(data)) {
+        throw new ConfigurationError({
+          message: `Import variables from ${sourceDescription} must be a single plain YAML mapping. Got: ${typeof data}`,
+        })
+      }
+
+      return objectToStringMap(data)
+    }
+
+    case "dotenv": {
+      const parsed = dotenv.parse(content)
+      return parsed as StringMap
+    }
+
+    default:
+      throw new ConfigurationError({
+        message: `Unknown import variables format: ${format}`,
+      })
+  }
+}
+
+/**
+ * Converts a plain object to a StringMap, converting all values to strings.
+ */
+function objectToStringMap(obj: Record<string, any>): StringMap {
+  const result: StringMap = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined) {
+      result[key] = ""
+    } else if (typeof value === "object") {
+      result[key] = JSON.stringify(value)
+    } else {
+      result[key] = String(value)
+    }
+  }
+  return result
+}

--- a/core/test/unit/src/config/import-variables.ts
+++ b/core/test/unit/src/config/import-variables.ts
@@ -1,0 +1,488 @@
+/*
+ * Copyright (C) 2018-2025 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import tmp from "tmp-promise"
+import fsExtra from "fs-extra"
+import { join } from "path"
+import { getRootLogger } from "../../../../src/logger/logger.js"
+import { loadImportedVariables } from "../../../../src/config/import-variables.js"
+import { importVariablesBaseSchema } from "../../../../src/config/project.js"
+import { expectError } from "../../../helpers.js"
+
+const { writeFile, ensureDir, chmod } = fsExtra
+
+const log = getRootLogger().createLog()
+
+describe("importVariablesBaseSchema", () => {
+  describe("garden-cloud source", () => {
+    it("should validate a valid garden-cloud source", () => {
+      const config = [{ from: "garden-cloud", list: "varlist_123" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should validate a garden-cloud source with description", () => {
+      const config = [{ from: "garden-cloud", list: "varlist_123", description: "My variables" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should reject garden-cloud source without list", () => {
+      const config = [{ from: "garden-cloud" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+  })
+
+  describe("file source", () => {
+    it("should validate a valid file source with yaml format", () => {
+      const config = [{ from: "file", path: "vars.yaml", format: "yaml" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should validate a valid file source with json format", () => {
+      const config = [{ from: "file", path: "vars.json", format: "json" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should validate a valid file source with dotenv format", () => {
+      const config = [{ from: "file", path: "vars.env", format: "dotenv" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should validate a file source with description", () => {
+      const config = [{ from: "file", path: "vars.yaml", format: "yaml", description: "My vars" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should reject file source without path", () => {
+      const config = [{ from: "file", format: "yaml" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+
+    it("should reject file source without format", () => {
+      const config = [{ from: "file", path: "vars.yaml" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+
+    it("should reject file source with invalid format", () => {
+      const config = [{ from: "file", path: "vars.xml", format: "xml" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+  })
+
+  describe("exec source", () => {
+    it("should validate a valid exec source", () => {
+      const config = [{ from: "exec", command: ["./fetch-vars.sh"], format: "json" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should validate an exec source with multiple command args", () => {
+      const config = [{ from: "exec", command: ["node", "scripts/get-vars.js", "--env", "prod"], format: "yaml" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should validate an exec source with description", () => {
+      const config = [{ from: "exec", command: ["./fetch-vars.sh"], format: "json", description: "Fetch from vault" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+
+    it("should reject exec source without command", () => {
+      const config = [{ from: "exec", format: "json" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+
+    it("should reject exec source with empty command array", () => {
+      const config = [{ from: "exec", command: [], format: "json" }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+
+    it("should reject exec source without format", () => {
+      const config = [{ from: "exec", command: ["./fetch-vars.sh"] }]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.exist
+    })
+  })
+
+  describe("multiple sources", () => {
+    it("should validate multiple sources of different types", () => {
+      const config = [
+        { from: "file", path: "base-vars.yaml", format: "yaml" },
+        { from: "garden-cloud", list: "varlist_123" },
+        { from: "exec", command: ["./get-secrets.sh"], format: "json" },
+      ]
+      const result = importVariablesBaseSchema().validate(config)
+      expect(result.error).to.be.undefined
+      expect(result.value).to.eql(config)
+    })
+  })
+})
+
+describe("loadImportedVariables", () => {
+  let tmpDir: tmp.DirectoryResult
+
+  beforeEach(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+  })
+
+  afterEach(async () => {
+    await tmpDir.cleanup()
+  })
+
+  describe("empty config", () => {
+    it("should return empty object when importVariables is undefined", async () => {
+      const result = await loadImportedVariables({
+        importVariables: undefined,
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+      expect(result).to.eql({})
+    })
+
+    it("should return empty object when importVariables is empty array", async () => {
+      const result = await loadImportedVariables({
+        importVariables: [],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+      expect(result).to.eql({})
+    })
+  })
+
+  describe("file source", () => {
+    it("should load variables from a YAML file", async () => {
+      const varsPath = join(tmpDir.path, "vars.yaml")
+      await writeFile(varsPath, "foo: bar\nbaz: qux\n")
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "file", path: "vars.yaml", format: "yaml" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ foo: "bar", baz: "qux" })
+    })
+
+    it("should load variables from a JSON file", async () => {
+      const varsPath = join(tmpDir.path, "vars.json")
+      await writeFile(varsPath, JSON.stringify({ api_key: "secret123", debug: true }))
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "file", path: "vars.json", format: "json" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ api_key: "secret123", debug: "true" })
+    })
+
+    it("should load variables from a dotenv file", async () => {
+      const varsPath = join(tmpDir.path, "vars.env")
+      await writeFile(varsPath, "DATABASE_URL=postgres://localhost/db\nAPI_KEY=abc123\n")
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "file", path: "vars.env", format: "dotenv" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ DATABASE_URL: "postgres://localhost/db", API_KEY: "abc123" })
+    })
+
+    it("should warn and return empty vars when file does not exist", async () => {
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "file", path: "nonexistent.yaml", format: "yaml" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({})
+    })
+
+    it("should handle nested paths", async () => {
+      const subDir = join(tmpDir.path, "config", "vars")
+      await ensureDir(subDir)
+      const varsPath = join(subDir, "secrets.yaml")
+      await writeFile(varsPath, "secret: value\n")
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "file", path: "config/vars/secrets.yaml", format: "yaml" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ secret: "value" })
+    })
+  })
+
+  describe("exec source", () => {
+    it("should load variables from a command that writes to GARDEN_OUTPUT_PATH", async () => {
+      // Create a script that writes to GARDEN_OUTPUT_PATH
+      const scriptPath = join(tmpDir.path, "get-vars.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+echo '{"from_script": "hello", "number": 42}' > "$GARDEN_OUTPUT_PATH"
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "exec", command: [scriptPath], format: "json" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ from_script: "hello", number: "42" })
+    })
+
+    it("should warn and return empty vars when command does not write to output file", async () => {
+      // Create a script that does NOT write to GARDEN_OUTPUT_PATH
+      const scriptPath = join(tmpDir.path, "no-output.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+echo "This script doesn't write to GARDEN_OUTPUT_PATH"
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "exec", command: [scriptPath], format: "json" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({})
+    })
+
+    it("should warn and return empty vars when command writes empty file", async () => {
+      const scriptPath = join(tmpDir.path, "empty-output.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+touch "$GARDEN_OUTPUT_PATH"
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "exec", command: [scriptPath], format: "json" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({})
+    })
+
+    it("should throw error when command fails", async () => {
+      const scriptPath = join(tmpDir.path, "fail.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+exit 1
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      await expectError(
+        () =>
+          loadImportedVariables({
+            importVariables: [{ from: "exec", command: [scriptPath], format: "json" }],
+            projectRoot: tmpDir.path,
+            log,
+            cloudApi: undefined,
+            environmentName: "test",
+            legacyProjectId: undefined,
+          }),
+        { contains: "failed with exit code 1" }
+      )
+    })
+
+    it("should support yaml format from exec", async () => {
+      const scriptPath = join(tmpDir.path, "yaml-output.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+cat > "$GARDEN_OUTPUT_PATH" << EOF
+key1: value1
+key2: value2
+EOF
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "exec", command: [scriptPath], format: "yaml" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ key1: "value1", key2: "value2" })
+    })
+
+    it("should support dotenv format from exec", async () => {
+      const scriptPath = join(tmpDir.path, "dotenv-output.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+cat > "$GARDEN_OUTPUT_PATH" << EOF
+VAR1=value1
+VAR2=value2
+EOF
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "exec", command: [scriptPath], format: "dotenv" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({ VAR1: "value1", VAR2: "value2" })
+    })
+  })
+
+  describe("variable merging", () => {
+    it("should merge variables from multiple sources in order", async () => {
+      // First file
+      const vars1Path = join(tmpDir.path, "vars1.yaml")
+      await writeFile(vars1Path, "a: from-file1\nb: from-file1\n")
+
+      // Second file that overrides 'b'
+      const vars2Path = join(tmpDir.path, "vars2.yaml")
+      await writeFile(vars2Path, "b: from-file2\nc: from-file2\n")
+
+      const result = await loadImportedVariables({
+        importVariables: [
+          { from: "file", path: "vars1.yaml", format: "yaml" },
+          { from: "file", path: "vars2.yaml", format: "yaml" },
+        ],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({
+        a: "from-file1",
+        b: "from-file2", // Overridden by second source
+        c: "from-file2",
+      })
+    })
+
+    it("should merge variables from file and exec sources", async () => {
+      // File source
+      const varsPath = join(tmpDir.path, "vars.yaml")
+      await writeFile(varsPath, "from_file: yes\nshared: from-file\n")
+
+      // Exec source
+      const scriptPath = join(tmpDir.path, "get-vars.sh")
+      await writeFile(
+        scriptPath,
+        `#!/bin/bash
+echo '{"from_exec": "yes", "shared": "from-exec"}' > "$GARDEN_OUTPUT_PATH"
+`
+      )
+      await chmod(scriptPath, 0o755)
+
+      const result = await loadImportedVariables({
+        importVariables: [
+          { from: "file", path: "vars.yaml", format: "yaml" },
+          { from: "exec", command: [scriptPath], format: "json" },
+        ],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined,
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({
+        from_file: "yes",
+        from_exec: "yes",
+        shared: "from-exec", // Overridden by exec source (later in list)
+      })
+    })
+  })
+
+  describe("garden-cloud source", () => {
+    it("should warn and skip when cloudApi is not available", async () => {
+      const result = await loadImportedVariables({
+        importVariables: [{ from: "garden-cloud", list: "varlist_123" }],
+        projectRoot: tmpDir.path,
+        log,
+        cloudApi: undefined, // No cloud API
+        environmentName: "test",
+        legacyProjectId: undefined,
+      })
+
+      expect(result).to.eql({})
+    })
+  })
+})

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1961,8 +1961,10 @@ variables:
 
 # The 'importVariables' config
 importVariables:
-  - from:
+  - # Import variables from a Garden Cloud variable list.
+    from:
 
+    # The ID of the variable list to import from Garden Cloud.
     list:
 
     # Variable lists are referenced by their IDs so here you can add an optional description. When copying the

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -300,18 +300,25 @@ varfile: garden.env
 # permitted, including arrays and objects of any nesting.
 variables: {}
 
-# EXPERIMENTAL: This is an experimental feature that requires enabling variables for your organization in Garden Cloud
-# (currenty only available in early access).
+# Specify sources from which to import variables. Variables are merged in the order specified,
+# with later sources taking precedence over earlier ones.
 #
-# Specify an array of variable lists from which to load variables/secrets. The lists and their variables/secrets are
-# created in [Garden Cloud](https://app.garden.io/variables).
+# Three source types are supported:
 #
-# Variable are merged in the order of the lists (so the value from a variable in a list that appears later in the
-# array overwrites the value of a
-# variable from an earlier list if they have the same name).
-importVariables:
-  - from:
+# **Garden Cloud** (`from: "garden-cloud"`): Import variables from a Garden Cloud variable list. Requires being logged
+# in to Garden Cloud.
+#
+# **File** (`from: "file"`): Import variables from a local file. Supports yaml, json, and dotenv formats.
+#
+# **Exec** (`from: "exec"`): Import variables by running a command. The command receives `GARDEN_OUTPUT_PATH` (path to
+# a temp file where it should write the variables) and `GARDEN_ENVIRONMENT` (the current environment name) as
+# environment variables. If the command does not write to the file, a warning is logged and no variables are imported
+# from this source.
+importVariables: []
+  - # Import variables from a Garden Cloud variable list.
+    from:
 
+    # The ID of the variable list to import from Garden Cloud.
     list:
 
     # Variable lists are referenced by their IDs so here you can add an optional description. When copying the
@@ -973,28 +980,35 @@ Key/value map of variables to configure for all environments. Keys may contain l
 
 ### `importVariables[]`
 
-EXPERIMENTAL: This is an experimental feature that requires enabling variables for your organization in Garden Cloud (currenty only available in early access).
+Specify sources from which to import variables. Variables are merged in the order specified,
+with later sources taking precedence over earlier ones.
 
-Specify an array of variable lists from which to load variables/secrets. The lists and their variables/secrets are created in [Garden Cloud](https://app.garden.io/variables).
+Three source types are supported:
 
-Variable are merged in the order of the lists (so the value from a variable in a list that appears later in the array overwrites the value of a
-variable from an earlier list if they have the same name).
+**Garden Cloud** (`from: "garden-cloud"`): Import variables from a Garden Cloud variable list. Requires being logged in to Garden Cloud.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[object]` | `[]`    | No       |
+**File** (`from: "file"`): Import variables from a local file. Supports yaml, json, and dotenv formats.
+
+**Exec** (`from: "exec"`): Import variables by running a command. The command receives `GARDEN_OUTPUT_PATH` (path to a temp file where it should write the variables) and `GARDEN_ENVIRONMENT` (the current environment name) as environment variables. If the command does not write to the file, a warning is logged and no variables are imported from this source.
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[alternatives]` | `[]`    | No       |
 
 Example:
 
 ```yaml
 importVariables:
-  - from: garden-cloud
-    list: varlist_abc
+  - from: file
+    path: secrets.env
+    format: dotenv
 ```
 
 ### `importVariables[].from`
 
 [importVariables](#importvariables) > from
+
+Import variables from a Garden Cloud variable list.
 
 | Type     | Allowed Values | Required |
 | -------- | -------------- | -------- |
@@ -1003,6 +1017,8 @@ importVariables:
 ### `importVariables[].list`
 
 [importVariables](#importvariables) > list
+
+The ID of the variable list to import from Garden Cloud.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
This adds `from: "file"` and `from: "command"` to entries in the `importVariables` stanza in project configs.

This allows using custom secrets management, for example.