### PR TITLE
feat(terraform): allow specifying binary path

### DIFF
--- a/docs/reference/providers/pulumi.md
+++ b/docs/reference/providers/pulumi.md
@@ -40,7 +40,8 @@ providers:
       # re-run by setting `--force-refresh` on any Garden command that uses the provider.
       runScript:
 
-    # The version of pulumi to use. Set to `null` to use whichever version of `pulumi` is on your PATH.
+    # The version of pulumi to use. Set to `null` to use whichever version of `pulumi` is on your PATH, or provide
+    # an absolute path to a terraform binary.
     version: 3.122.0
 
     # Overrides the default plan directory path used when deploying with the `deployFromPreview` option for pulumi
@@ -167,11 +168,12 @@ Note that provider statuses are cached, so this script will generally only be ru
 
 [providers](#providers) > version
 
-The version of pulumi to use. Set to `null` to use whichever version of `pulumi` is on your PATH.
+The version of pulumi to use. Set to `null` to use whichever version of `pulumi` is on your PATH, or provide
+an absolute path to a terraform binary.
 
-| Type     | Allowed Values                                 | Default     | Required |
-| -------- | ---------------------------------------------- | ----------- | -------- |
-| `string` | "3.122.0", "3.102.0", "3.70.0", "3.64.0", null | `"3.122.0"` | Yes      |
+| Type                         | Default     | Required |
+| ---------------------------- | ----------- | -------- |
+| `string \| posixPath \| any` | `"3.122.0"` | No       |
 
 ### `providers[].previewDir`
 

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -57,7 +57,8 @@ providers:
     # `terraform` action configs, or you can place a `terraform.tfvars` file in each working directory.
     variables:
 
-    # The version of Terraform to use. Set to `null` to use whichever version of `terraform` that is on your PATH.
+    # The version of Terraform to use. Set to `null` to use the version of `terraform` that is on your PATH, or
+    # provide an absolute path to a terraform binary.
     version: 1.4.6
 
     # Use the specified Terraform workspace.
@@ -207,11 +208,11 @@ A map of variables to use when applying Terraform stacks. You can define these h
 
 [providers](#providers) > version
 
-The version of Terraform to use. Set to `null` to use whichever version of `terraform` that is on your PATH.
+The version of Terraform to use. Set to `null` to use the version of `terraform` that is on your PATH, or provide an absolute path to a terraform binary.
 
-| Type     | Allowed Values                                                 | Default   | Required |
-| -------- | -------------------------------------------------------------- | --------- | -------- |
-| `string` | "0.12.26", "0.13.3", "0.14.7", "1.0.5", "1.2.9", "1.4.6", null | `"1.4.6"` | Yes      |
+| Type                         | Default   | Required |
+| ---------------------------- | --------- | -------- |
+| `string \| posixPath \| any` | `"1.4.6"` | No       |
 
 ### `providers[].workspace`
 

--- a/examples/terraform-dynamic-backend/project.garden.yml
+++ b/examples/terraform-dynamic-backend/project.garden.yml
@@ -23,7 +23,7 @@ providers:
 ---
 kind: Deploy
 name: tf-hello
-
+type: terraform
 spec:
   root: .
   backendConfig: # <--- Dynamically set the backend for this action, depending on the environment

--- a/plugins/pulumi/src/provider.ts
+++ b/plugins/pulumi/src/provider.ts
@@ -27,11 +27,11 @@ export const pulumiProviderConfigSchema = providerConfigBaseSchema()
   .keys({
     // May be overridden by individual \`pulumi\` modules.
     version: joi
-      .string()
-      .allow(...supportedVersions, null)
-      .only()
+      .alternatives()
+      .try(joi.string().valid(...supportedVersions), joi.posixPath().absoluteOnly(), joi.valid(null))
       .default(defaultPulumiVersion).description(dedent`
-        The version of pulumi to use. Set to \`null\` to use whichever version of \`pulumi\` is on your PATH.
+        The version of pulumi to use. Set to \`null\` to use whichever version of \`pulumi\` is on your PATH, or provide
+        an absolute path to a terraform binary.
       `),
     previewDir: joi
       .posixPath()

--- a/plugins/terraform/src/provider.ts
+++ b/plugins/terraform/src/provider.ts
@@ -47,11 +47,10 @@ export const terraformProviderConfigSchema = providerConfigBaseSchema()
       `),
     // May be overridden by individual \`terraform\` actions.
     version: joi
-      .string()
-      .allow(...supportedVersions, null)
-      .only()
+      .alternatives()
+      .try(joi.string().valid(...supportedVersions), joi.posixPath().absoluteOnly(), joi.valid(null))
       .default(defaultTerraformVersion).description(dedent`
-        The version of Terraform to use. Set to \`null\` to use whichever version of \`terraform\` that is on your PATH.
+        The version of Terraform to use. Set to \`null\` to use the version of \`terraform\` that is on your PATH, or provide an absolute path to a terraform binary.
       `),
     workspace: joi.string().description("Use the specified Terraform workspace."),
     streamLogsToCloud: joi

--- a/sdk/src/util/ext-tools.ts
+++ b/sdk/src/util/ext-tools.ts
@@ -6,5 +6,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-export { CliWrapper } from "@garden-io/core/build/src/util/ext-tools.js"
+export { CliWrapper, GlobalCliWrapper, CliWrapperFromPath } from "@garden-io/core/build/src/util/ext-tools.js"
 export { PluginToolSpec } from "@garden-io/core/build/src/plugin/tools.js"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

We now allow passing an absolute path to the `version` field on the Terraform and Pulumi providers.

This tells Garden to use the binary found at that path (or throw an error if none is found).

 This offers more control than just using the global one on PATH
 when none of the bundled versions are suitable.

**Which issue(s) this PR fixes**:

Fixes #3502.