### PR TITLE
fix(core): wait before emitting first heartbeat event

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -386,10 +386,14 @@ export abstract class Command<
             _projectRootDirAbs: garden.projectRoot,
           })
 
-          garden.events.emit("commandHeartbeat", { sentAt: new Date().toISOString() })
-          this.heartbeatIntervalId = setInterval(() => {
+          // Wait 5 seconds before sending the first heartbeat to ensure (almost certainly) that commandInfo
+          // arrives first.
+          this.heartbeatIntervalId = setTimeout(() => {
             garden.events.emit("commandHeartbeat", { sentAt: new Date().toISOString() })
-          }, 5_000) // Emit a heartbeat event every 5 seconds
+            this.heartbeatIntervalId = setInterval(() => {
+              garden.events.emit("commandHeartbeat", { sentAt: new Date().toISOString() })
+            }, 5_000) // Emit a heartbeat event every 5 seconds
+          }, 5_000)
 
           // Check if the command is protected and ask for confirmation to proceed if production flag is "true".
           if (await this.isAllowedToRun(garden, log, allOpts)) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

We now wait 5 seconds before emitting the first heartbeat event to (almost) ensure that the `commandInfo` event is sent to the API before the first heartbeat event.