### PR TITLE
fix(k8s): don't create validating webhook for nginx

### DIFF
--- a/core/src/plugins/kubernetes/nginx/nginx-kind-manifests.ts
+++ b/core/src/plugins/kubernetes/nginx/nginx-kind-manifests.ts
@@ -7,10 +7,7 @@
  */
 
 import type { KubernetesResource } from "../types.js"
-import {
-  defaultGardenIngressControllerImage,
-  defaultGardenIngressControllerKubeWebhookCertGenImage,
-} from "../constants.js"
+import { defaultGardenIngressControllerImage } from "../constants.js"
 
 const INGRESS_NGINX_CONTROLLER_VERSION = "1.12.1"
 
@@ -57,37 +54,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
     },
     {
       apiVersion: "v1",
-      kind: "Service",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "controller",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-controller-admission",
-        namespace,
-      },
-      spec: {
-        ports: [
-          {
-            appProtocol: "https",
-            name: "https-webhook",
-            port: 443,
-            targetPort: "webhook",
-          },
-        ],
-        selector: {
-          "app.kubernetes.io/component": "controller",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-        },
-        type: "ClusterIP",
-      },
-    },
-    {
-      apiVersion: "v1",
       kind: "Namespace",
       metadata: {
         labels: {
@@ -128,21 +94,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
           "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
         },
         name: "ingress-nginx",
-        namespace,
-      },
-    },
-    {
-      apiVersion: "v1",
-      kind: "ServiceAccount",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission",
         namespace,
       },
     },
@@ -193,27 +144,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
           apiGroups: ["networking.k8s.io"],
           resources: ["ingressclasses"],
           verbs: ["get", "list", "watch"],
-        },
-      ],
-    },
-    {
-      apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "ClusterRole",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission",
-      },
-      rules: [
-        {
-          apiGroups: ["admissionregistration.k8s.io"],
-          resources: ["validatingwebhookconfigurations"],
-          verbs: ["get", "update"],
         },
       ],
     },
@@ -282,28 +212,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
     },
     {
       apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "Role",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission",
-        namespace,
-      },
-      rules: [
-        {
-          apiGroups: [""],
-          resources: ["secrets"],
-          verbs: ["get", "create"],
-        },
-      ],
-    },
-    {
-      apiVersion: "rbac.authorization.k8s.io/v1",
       kind: "RoleBinding",
       metadata: {
         labels: {
@@ -331,33 +239,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
     },
     {
       apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "RoleBinding",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission",
-        namespace,
-      },
-      roleRef: {
-        apiGroup: "rbac.authorization.k8s.io",
-        kind: "Role",
-        name: "ingress-nginx-admission",
-      },
-      subjects: [
-        {
-          kind: "ServiceAccount",
-          name: "ingress-nginx-admission",
-          namespace,
-        },
-      ],
-    },
-    {
-      apiVersion: "rbac.authorization.k8s.io/v1",
       kind: "ClusterRoleBinding",
       metadata: {
         labels: {
@@ -377,32 +258,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
         {
           kind: "ServiceAccount",
           name: "ingress-nginx",
-          namespace,
-        },
-      ],
-    },
-    {
-      apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "ClusterRoleBinding",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission",
-      },
-      roleRef: {
-        apiGroup: "rbac.authorization.k8s.io",
-        kind: "ClusterRole",
-        name: "ingress-nginx-admission",
-      },
-      subjects: [
-        {
-          kind: "ServiceAccount",
-          name: "ingress-nginx-admission",
           namespace,
         },
       ],
@@ -454,9 +309,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
                   "--controller-class=k8s.io/ingress-nginx",
                   "--ingress-class=nginx",
                   "--configmap=$(POD_NAMESPACE)/ingress-nginx-controller",
-                  "--validating-webhook=:8443",
-                  "--validating-webhook-certificate=/usr/local/certificates/cert",
-                  "--validating-webhook-key=/usr/local/certificates/key",
                   "--watch-ingress-without-class=true",
                   "--publish-status-address=localhost",
                 ],
@@ -517,11 +369,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
                     name: "https",
                     protocol: "TCP",
                   },
-                  {
-                    containerPort: 8443,
-                    name: "webhook",
-                    protocol: "TCP",
-                  },
                 ],
                 readinessProbe: {
                   failureThreshold: 3,
@@ -549,13 +396,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
                   },
                   runAsUser: 101,
                 },
-                volumeMounts: [
-                  {
-                    mountPath: "/usr/local/certificates/",
-                    name: "webhook-cert",
-                    readOnly: true,
-                  },
-                ],
               },
             ],
             dnsPolicy: "ClusterFirst",
@@ -572,150 +412,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
                 operator: "Equal",
               },
             ],
-            volumes: [
-              {
-                name: "webhook-cert",
-                secret: {
-                  secretName: "ingress-nginx-admission",
-                },
-              },
-            ],
-          },
-        },
-      },
-    },
-    {
-      apiVersion: "batch/v1",
-      kind: "Job",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission-create",
-        namespace,
-      },
-      spec: {
-        template: {
-          metadata: {
-            labels: {
-              "app.kubernetes.io/component": "admission-webhook",
-              "app.kubernetes.io/instance": "ingress-nginx",
-              "app.kubernetes.io/name": "ingress-nginx",
-              "app.kubernetes.io/part-of": "ingress-nginx",
-              "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-            },
-            name: "ingress-nginx-admission-create",
-          },
-          spec: {
-            containers: [
-              {
-                args: [
-                  "create",
-                  "--host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc",
-                  "--namespace=$(POD_NAMESPACE)",
-                  "--secret-name=ingress-nginx-admission",
-                ],
-                env: [
-                  {
-                    name: "POD_NAMESPACE",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.namespace",
-                      },
-                    },
-                  },
-                ],
-                image: defaultGardenIngressControllerKubeWebhookCertGenImage,
-                imagePullPolicy: "IfNotPresent",
-                name: "create",
-                securityContext: {
-                  allowPrivilegeEscalation: false,
-                },
-              },
-            ],
-            nodeSelector: {
-              "kubernetes.io/os": "linux",
-            },
-            restartPolicy: "OnFailure",
-            securityContext: {
-              fsGroup: 2000,
-              runAsNonRoot: true,
-              runAsUser: 2000,
-            },
-            serviceAccountName: "ingress-nginx-admission",
-          },
-        },
-      },
-    },
-    {
-      apiVersion: "batch/v1",
-      kind: "Job",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission-patch",
-        namespace,
-      },
-      spec: {
-        template: {
-          metadata: {
-            labels: {
-              "app.kubernetes.io/component": "admission-webhook",
-              "app.kubernetes.io/instance": "ingress-nginx",
-              "app.kubernetes.io/name": "ingress-nginx",
-              "app.kubernetes.io/part-of": "ingress-nginx",
-              "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-            },
-            name: "ingress-nginx-admission-patch",
-          },
-          spec: {
-            containers: [
-              {
-                args: [
-                  "patch",
-                  "--webhook-name=ingress-nginx-admission",
-                  "--namespace=$(POD_NAMESPACE)",
-                  "--patch-mutating=false",
-                  "--secret-name=ingress-nginx-admission",
-                  "--patch-failure-policy=Fail",
-                ],
-                env: [
-                  {
-                    name: "POD_NAMESPACE",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.namespace",
-                      },
-                    },
-                  },
-                ],
-                image: defaultGardenIngressControllerKubeWebhookCertGenImage,
-                imagePullPolicy: "IfNotPresent",
-                name: "patch",
-                securityContext: {
-                  allowPrivilegeEscalation: false,
-                },
-              },
-            ],
-            nodeSelector: {
-              "kubernetes.io/os": "linux",
-            },
-            restartPolicy: "OnFailure",
-            securityContext: {
-              fsGroup: 2000,
-              runAsNonRoot: true,
-              runAsUser: 2000,
-            },
-            serviceAccountName: "ingress-nginx-admission",
           },
         },
       },
@@ -739,44 +435,6 @@ export function kindNginxGetManifests(namespace: string): KubernetesResource[] {
       spec: {
         controller: "k8s.io/ingress-nginx",
       },
-    },
-    {
-      apiVersion: "admissionregistration.k8s.io/v1",
-      kind: "ValidatingWebhookConfiguration",
-      metadata: {
-        labels: {
-          "app.kubernetes.io/component": "admission-webhook",
-          "app.kubernetes.io/instance": "ingress-nginx",
-          "app.kubernetes.io/name": "ingress-nginx",
-          "app.kubernetes.io/part-of": "ingress-nginx",
-          "app.kubernetes.io/version": INGRESS_NGINX_CONTROLLER_VERSION,
-        },
-        name: "ingress-nginx-admission",
-      },
-      webhooks: [
-        {
-          admissionReviewVersions: ["v1"],
-          clientConfig: {
-            service: {
-              name: "ingress-nginx-controller-admission",
-              namespace,
-              path: "/networking/v1/ingresses",
-            },
-          },
-          failurePolicy: "Fail",
-          matchPolicy: "Equivalent",
-          name: "validate.nginx.ingress.kubernetes.io",
-          rules: [
-            {
-              apiGroups: ["networking.k8s.io"],
-              apiVersions: ["v1"],
-              operations: ["CREATE", "UPDATE"],
-              resources: ["ingresses"],
-            },
-          ],
-          sideEffects: "None",
-        },
-      ],
     },
   ]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, and @stefreak.
-->

**What this PR does / why we need it**:

The nginx ingress controller was creating a ValidatingWebhookConfiguration even though `admissionWebhooks.enabled=false` was set in the Helm values. This caused intermittent deploy failures with "certificate signed by unknown authority" errors when creating Ingress resources.

Root cause: The `--set-json` arguments were passed as a single comma-separated string (`--set-json "key1=val1,key2=val2"`) which Helm didn't parse correctly. Here, we instead write the values to a tempfile and pass it via `--values` (which is how we usually do this, and is imho easier to reason about than these somewhat fiddly CLI options).

Also removed webhook resources from KIND manifests for consistency with Helm.
