### PR TITLE
feat(core): make task concurrency limits configurable via env vars

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -85,6 +85,7 @@ export const gardenEnv = {
   GARDEN_DISABLE_VERSION_CHECK: env.get("GARDEN_DISABLE_VERSION_CHECK").required(false).asBool(),
   GARDEN_ENABLE_PROFILING: env.get("GARDEN_ENABLE_PROFILING").required(false).default("false").asBool(),
   GARDEN_ENVIRONMENT: env.get("GARDEN_ENVIRONMENT").required(false).asString(),
+  GARDEN_EXECUTE_CONCURRENCY_LIMIT: env.get("GARDEN_EXECUTE_CONCURRENCY_LIMIT").required(false).asInt(),
   GARDEN_GE_SCHEDULED: env.get("GARDEN_GE_SCHEDULED").required(false).asBool(),
   GARDEN_GIT_SCAN_MODE: env
     .get("GARDEN_GIT_SCAN_MODE")
@@ -99,6 +100,7 @@ export const gardenEnv = {
   GARDEN_SERVER_PORT: env.get("GARDEN_SERVER_PORT").required(false).asPortNumber(),
   GARDEN_SERVER_HOSTNAME: env.get("GARDEN_SERVER_HOSTNAME").required(false).asUrlString(),
   GARDEN_SKIP_TESTS: env.get("GARDEN_SKIP_TESTS").required(false).default("").asString(),
+  GARDEN_STATUS_CONCURRENCY_LIMIT: env.get("GARDEN_STATUS_CONCURRENCY_LIMIT").required(false).asInt(),
   GARDEN_HARD_CONCURRENCY_LIMIT: env.get("GARDEN_HARD_CONCURRENCY_LIMIT").required(false).default(50).asInt(),
   GARDEN_WORKFLOW_RUN_UID: env.get("GARDEN_WORKFLOW_RUN_UID").required(false).asString(),
   GARDEN_CLOUD_DOMAIN: env.get("GARDEN_CLOUD_DOMAIN").required(false).asUrlString(),

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -37,6 +37,7 @@ import {
 import { styles } from "../logger/styles.js"
 import type { ActionRuntime } from "../plugin/base.js"
 import { deline } from "../util/string.js"
+import { gardenEnv } from "../constants.js"
 
 export function makeBaseKey(type: string, name: string) {
   return `${type}.${name}`
@@ -659,11 +660,19 @@ export abstract class ExecuteActionTask<
   protected defaultStatusConcurrencyLimit = 10
 
   override get executeConcurrencyLimit(): number {
-    return this.action.executeConcurrencyLimit || this.defaultExecuteConcurrencyLimit
+    return (
+      gardenEnv.GARDEN_EXECUTE_CONCURRENCY_LIMIT ||
+      this.action.executeConcurrencyLimit ||
+      this.defaultExecuteConcurrencyLimit
+    )
   }
 
   override get statusConcurrencyLimit(): number {
-    return this.action.statusConcurrencyLimit || this.defaultStatusConcurrencyLimit
+    return (
+      gardenEnv.GARDEN_STATUS_CONCURRENCY_LIMIT ||
+      this.action.statusConcurrencyLimit ||
+      this.defaultStatusConcurrencyLimit
+    )
   }
 
   abstract override readonly type: Lowercase<T["kind"]>


### PR DESCRIPTION
**What this PR does / why we need it**:

When testing on a multi-node cluster I noticed garden limits deploys to ~5 deploys at a time. Did some investigation and found that this value is hardcoded. This PR addresses this issue.

Adds two environment variables — `GARDEN_EXECUTE_CONCURRENCY_LIMIT` and `GARDEN_STATUS_CONCURRENCY_LIMIT` — that override the per-action concurrency limits used by `ExecuteActionTask`. When set, the env var takes precedence over the action-defined limit, which still falls back to the default of 10.

This lets operators tune task throughput in CI or constrained environments without requiring code changes to actions.

