### PR TITLE
chore(ci): add workflow to rebuild k8s utility images

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -680,6 +680,161 @@ jobs:
             docker buildx bake --push --progress=plain -f support/docker-bake.hcl all
       - fail_fast
 
+  # Security refresh for the digest-pinned Kubernetes utility images.
+  # Triggered by a `rebuild-utility-images-*` tag pushed by the GitHub
+  # "Rebuild utility images" workflow, which records the requested inputs in
+  # .circleci/rebuild-request.json on the tagged commit. This job builds +
+  # pushes the images multi-arch, then sends the resulting digests back to
+  # GitHub (repository_dispatch) so a PR updating constants.ts is opened there.
+  rebuild-utility-images:
+    machine:
+      <<: *ubuntu-vm-runner
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Read rebuild request
+          command: |
+            set -euo pipefail
+            REQ=.circleci/rebuild-request.json
+            if [ ! -f "$REQ" ]; then
+              echo "Missing $REQ on the tagged commit"; exit 1
+            fi
+            cat "$REQ"
+            {
+              echo "export REBUILD_K8S=$(jq -r '.rebuild_k8s' "$REQ")"
+              echo "export REBUILD_BUILDKIT=$(jq -r '.rebuild_buildkit' "$REQ")"
+              echo "export TAG_SUFFIX=$(jq -r '.tag_suffix // ""' "$REQ")"
+              echo "export BUILDKIT_BASE=$(jq -r '.buildkit_base // ""' "$REQ")"
+              echo "export DRY_RUN=$(jq -r '.dry_run' "$REQ")"
+              echo "export TRIGGER_ACTOR=$(jq -r '.actor // ""' "$REQ")"
+            } >> "$BASH_ENV"
+      - run:
+          name: Compute new image tags
+          command: |
+            set -euo pipefail
+            read_tag() {
+              grep -E 'release-tag:' "$1" \
+                | sed -E 's/.*release-tag:[[:space:]]*([^[:space:]#]+).*/\1/'
+            }
+            # Increment the trailing numeric suffix, or append "-1" when there is
+            # none. A non-empty TAG_SUFFIX overrides the number.
+            next_tag() {
+              local cur="$1"
+              local last="${cur##*-}"
+              local base newnum
+              if [[ "$last" =~ ^[0-9]+$ ]]; then
+                base="${cur%-*}"
+                newnum=$((last + 1))
+              else
+                base="$cur"
+                newnum=1
+              fi
+              if [ -n "${TAG_SUFFIX}" ]; then
+                newnum="${TAG_SUFFIX}"
+              fi
+              printf '%s-%s' "$base" "$newnum"
+            }
+            sync_cur="$(read_tag images/k8s-sync/garden.yml | head -1)"
+            util_cur="$(read_tag images/k8s-util/garden.yml | head -1)"
+            bk_cur="$(read_tag images/buildkit/garden.yml | grep -v -- '-rootless' | head -1)"
+            bkr_cur="$(read_tag images/buildkit/garden.yml | grep -- '-rootless' | head -1)"
+            {
+              echo "export SYNC_CUR=${sync_cur}"
+              echo "export SYNC_NEW=$(next_tag "$sync_cur")"
+              echo "export UTIL_NEW=$(next_tag "$util_cur")"
+              echo "export BK_NEW=$(next_tag "$bk_cur")"
+              echo "export BKR_NEW=$(next_tag "$bkr_cur")"
+            } >> "$BASH_ENV"
+      - run:
+          name: Override buildkit base image
+          command: |
+            set -euo pipefail
+            if [ "${REBUILD_BUILDKIT}" != "true" ] || [ -z "${BUILDKIT_BASE}" ]; then
+              echo "No buildkit base override."; exit 0
+            fi
+            ver="${BUILDKIT_BASE#moby/buildkit:}"
+            ver="${ver%@*}"
+            sed -i -E "s#^FROM moby/buildkit:[^ ]+ as buildkit\$#FROM ${BUILDKIT_BASE} as buildkit#" images/buildkit/Dockerfile
+            sed -i -E "s#^FROM moby/buildkit:[^ ]+ as buildkit-rootless\$#FROM moby/buildkit:${ver}-rootless as buildkit-rootless#" images/buildkit/Dockerfile
+            grep -E '^FROM moby/buildkit' images/buildkit/Dockerfile
+      - update_buildx
+      - run:
+          name: Enable multi-arch builds
+          command: |
+            set -euo pipefail
+            docker run --privileged --rm tonistiigi/binfmt --install all
+            docker buildx create --name garden-rebuild --driver docker-container --use
+            docker buildx inspect --bootstrap
+      - run:
+          name: Build and push utility images
+          command: |
+            set -euo pipefail
+            PUSH_FLAG="--push"
+            if [ "${DRY_RUN}" = "true" ]; then
+              PUSH_FLAG=""
+            else
+              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            fi
+
+            build() { # <dir> <tag> <metadata-file> [extra buildx args...]
+              local dir="$1" tag="$2" meta="$3"; shift 3
+              docker buildx build --platform linux/amd64,linux/arm64 ${PUSH_FLAG} \
+                --metadata-file "$meta" -f "$dir/Dockerfile" -t "$tag" "$@" "$dir"
+            }
+            digest() { jq -r '.["containerimage.digest"]' "$1"; }
+
+            if [ "${REBUILD_K8S}" = "true" ]; then
+              build images/k8s-sync "docker.io/gardendev/k8s-sync:${SYNC_NEW}" /tmp/sync.json
+              if [ "${DRY_RUN}" = "true" ]; then
+                BASE="docker.io/gardendev/k8s-sync:${SYNC_CUR}"
+              else
+                BASE="docker.io/gardendev/k8s-sync:${SYNC_NEW}@$(digest /tmp/sync.json)"
+              fi
+              build images/k8s-util "docker.io/gardendev/k8s-util:${UTIL_NEW}" /tmp/util.json \
+                --build-arg "BASE_IMAGE=${BASE}"
+            fi
+            if [ "${REBUILD_BUILDKIT}" = "true" ]; then
+              build images/buildkit "docker.io/gardendev/buildkit:${BK_NEW}" /tmp/bk.json --target buildkit
+              build images/buildkit "docker.io/gardendev/buildkit:${BKR_NEW}" /tmp/bkr.json --target buildkit-rootless
+            fi
+      - run:
+          name: Dispatch digests to GitHub
+          command: |
+            set -euo pipefail
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "Dry run; built without pushing. Skipping GitHub dispatch."
+              exit 0
+            fi
+            digest() { jq -r '.["containerimage.digest"]' "$1"; }
+            refs='{}'
+            if [ "${REBUILD_K8S}" = "true" ]; then
+              refs="$(jq -n --argjson r "$refs" \
+                --arg sync "gardendev/k8s-sync:${SYNC_NEW}@$(digest /tmp/sync.json)" \
+                --arg util "gardendev/k8s-util:${UTIL_NEW}@$(digest /tmp/util.json)" \
+                '$r + {"k8s-sync": $sync, "k8s-util": $util}')"
+            fi
+            if [ "${REBUILD_BUILDKIT}" = "true" ]; then
+              refs="$(jq -n --argjson r "$refs" \
+                --arg bk "gardendev/buildkit:${BK_NEW}@$(digest /tmp/bk.json)" \
+                --arg bkr "gardendev/buildkit:${BKR_NEW}@$(digest /tmp/bkr.json)" \
+                '$r + {"buildkit": $bk, "buildkit-rootless": $bkr}')"
+            fi
+            payload="$(jq -n \
+              --argjson refs "$refs" \
+              --arg bkbase "${BUILDKIT_BASE}" \
+              --arg actor "${TRIGGER_ACTOR}" \
+              --arg k8s "${REBUILD_K8S}" \
+              --arg buildkit "${REBUILD_BUILDKIT}" \
+              '{event_type: "util-images-rebuilt", client_payload: {refs: $refs, buildkit_base: $bkbase, actor: $actor, rebuild_k8s: $k8s, rebuild_buildkit: $buildkit}}')"
+            curl -sSf -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/dispatches" \
+              -d "$payload"
+            echo "Dispatched util-images-rebuilt to GitHub; a PR will be opened there."
+      - fail_fast
+
   test-docker-aws:
     docker:
       # We do not use a specific digest here on purpose, to use the latest build from the previous job
@@ -1559,3 +1714,18 @@ workflows:
       - github-release-tag:
           <<: *only-tags
           requires: [build-dist-macos, build-dist-linux-windows, sign-windows-binary]
+
+  # On-demand security rebuild of the digest-pinned utility images. Triggered by
+  # the GitHub "Rebuild utility images" workflow, which pushes a throwaway
+  # `rebuild-utility-images-<run_id>` tag carrying the inputs. The non-semver tag
+  # pattern means this is the only workflow that runs for these tags (the
+  # commit/main/tags workflows do not match), so no normal CI is wasted.
+  rebuild-utility-images:
+    jobs:
+      - rebuild-utility-images:
+          context: docker
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^rebuild-utility-images-.*/

--- a/.github/workflows/rebuild-utility-images.yml
+++ b/.github/workflows/rebuild-utility-images.yml
@@ -1,9 +1,20 @@
 name: Rebuild utility images
 
 # Manually-triggered security refresh for the digest-pinned Kubernetes utility
-# images that Garden injects into clusters. It rebuilds the images multi-arch,
-# pushes them to Docker Hub, and opens a PR that updates the pinned
-# tag@sha256 references in core/src/plugins/kubernetes/constants.ts.
+# images that Garden injects into clusters.
+#
+# Hybrid CI/CD: the actual multi-arch build + push to Docker Hub runs on
+# CircleCI (where the Docker Hub credentials and bot PAT already live). This
+# workflow is the human entry point and the PR opener:
+#
+#   1. workflow_dispatch (the "trigger" job): records the requested inputs in
+#      .circleci/rebuild-request.json and pushes a throwaway tag
+#      (rebuild-utility-images-<run_id>). That tag starts the CircleCI
+#      "rebuild-utility-images" job, which builds + pushes the images and then
+#      sends a repository_dispatch back here with the freshly pushed digests.
+#   2. repository_dispatch / util-images-rebuilt (the "open-pr" job): rewrites
+#      the pinned tag@sha256 references in
+#      core/src/plugins/kubernetes/constants.ts and opens a PR.
 #
 # A human only needs to review/merge the PR; the new digests then ship with the
 # next normal Garden release. No local tooling required.
@@ -36,9 +47,11 @@ on:
         required: false
         default: ""
       dry_run:
-        description: "Build only (no push, no PR)"
+        description: "Build only on CircleCI (no push, no PR)"
         type: boolean
         default: false
+  repository_dispatch:
+    types: [util-images-rebuilt]
 
 permissions:
   contents: write
@@ -49,7 +62,69 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-pr:
+  # Phase 1: hand the request off to CircleCI by pushing a throwaway tag that
+  # carries the inputs in .circleci/rebuild-request.json.
+  trigger:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Write rebuild request
+        env:
+          REBUILD_K8S: ${{ inputs.rebuild_k8s }}
+          REBUILD_BUILDKIT: ${{ inputs.rebuild_buildkit }}
+          TAG_SUFFIX: ${{ inputs.tag_suffix }}
+          BUILDKIT_BASE: ${{ inputs.buildkit_base }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --argjson k8s "${REBUILD_K8S}" \
+            --argjson bk "${REBUILD_BUILDKIT}" \
+            --arg suffix "${TAG_SUFFIX}" \
+            --arg bkbase "${BUILDKIT_BASE}" \
+            --argjson dry "${DRY_RUN}" \
+            --arg actor "${ACTOR}" \
+            '{rebuild_k8s: $k8s, rebuild_buildkit: $bk, tag_suffix: $suffix, buildkit_base: $bkbase, dry_run: $dry, actor: $actor}' \
+            > .circleci/rebuild-request.json
+          echo "Rebuild request:"
+          cat .circleci/rebuild-request.json
+
+      - name: Push trigger tag for CircleCI
+        env:
+          TRIGGER_TAG: rebuild-utility-images-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          git config user.name "garden-ci"
+          git config user.email "garden-ci@users.noreply.github.com"
+          git add .circleci/rebuild-request.json
+          git commit -m "ci: rebuild utility images request (${TRIGGER_TAG})"
+          git tag "${TRIGGER_TAG}"
+          # Push only the tag; the commit is reachable via the tag and is not
+          # added to any branch. CircleCI runs its rebuild job on this tag.
+          git push origin "refs/tags/${TRIGGER_TAG}"
+          {
+            echo "## Utility-image rebuild dispatched to CircleCI"
+            echo ""
+            echo "- trigger tag: \`${TRIGGER_TAG}\`"
+            echo "- dry run: \`${{ inputs.dry_run }}\`"
+            echo ""
+            echo "Watch the CircleCI \`rebuild-utility-images\` workflow for the build."
+            echo "On success (non dry-run) it sends the digests back here and a PR is opened automatically."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Phase 2: CircleCI finished the build/push and sent us the new digests.
+  # Rewrite the pinned references and open the PR.
+  open-pr:
+    if: ${{ github.event_name == 'repository_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -65,54 +140,10 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Compute new image tags
-        id: tags
-        env:
-          TAG_SUFFIX: ${{ inputs.tag_suffix }}
-        run: |
-          set -euo pipefail
-
-          read_tag() {
-            grep -E 'release-tag:' "$1" \
-              | sed -E 's/.*release-tag:[[:space:]]*([^[:space:]#]+).*/\1/'
-          }
-
-          # Increment the trailing numeric suffix, or append "-1" when there is
-          # none. A non-empty TAG_SUFFIX overrides the number.
-          next_tag() {
-            local cur="$1"
-            local last="${cur##*-}"
-            local base newnum
-            if [[ "$last" =~ ^[0-9]+$ ]]; then
-              base="${cur%-*}"
-              newnum=$((last + 1))
-            else
-              base="$cur"
-              newnum=1
-            fi
-            if [ -n "${TAG_SUFFIX}" ]; then
-              newnum="${TAG_SUFFIX}"
-            fi
-            printf '%s-%s' "$base" "$newnum"
-          }
-
-          sync_cur="$(read_tag images/k8s-sync/garden.yml | head -1)"
-          util_cur="$(read_tag images/k8s-util/garden.yml | head -1)"
-          bk_cur="$(read_tag images/buildkit/garden.yml | grep -v -- '-rootless' | head -1)"
-          bkr_cur="$(read_tag images/buildkit/garden.yml | grep -- '-rootless' | head -1)"
-
-          {
-            echo "sync_cur=${sync_cur}"
-            echo "sync_new=$(next_tag "$sync_cur")"
-            echo "util_new=$(next_tag "$util_cur")"
-            echo "bk_new=$(next_tag "$bk_cur")"
-            echo "bkr_new=$(next_tag "$bkr_cur")"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Override buildkit base image
-        if: ${{ inputs.rebuild_buildkit && inputs.buildkit_base != '' }}
+        if: ${{ github.event.client_payload.buildkit_base != '' }}
         env:
-          BUILDKIT_BASE: ${{ inputs.buildkit_base }}
+          BUILDKIT_BASE: ${{ github.event.client_payload.buildkit_base }}
         run: |
           set -euo pipefail
           ver="${BUILDKIT_BASE#moby/buildkit:}"
@@ -123,112 +154,22 @@ jobs:
           grep -E '^FROM moby/buildkit' images/buildkit/Dockerfile
           echo "NOTE: the rootless base is pinned by tag only (no digest); review before merge."
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        if: ${{ !inputs.dry_run }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push k8s-sync
-        id: sync
-        if: ${{ inputs.rebuild_k8s }}
-        uses: docker/build-push-action@v6
-        with:
-          context: images/k8s-sync
-          file: images/k8s-sync/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ !inputs.dry_run }}
-          tags: docker.io/gardendev/k8s-sync:${{ steps.tags.outputs.sync_new }}
-
-      - name: Resolve k8s-util base image
-        id: base
-        if: ${{ inputs.rebuild_k8s }}
-        env:
-          DRY_RUN: ${{ inputs.dry_run }}
-          SYNC_NEW: ${{ steps.tags.outputs.sync_new }}
-          SYNC_CUR: ${{ steps.tags.outputs.sync_cur }}
-          SYNC_DIGEST: ${{ steps.sync.outputs.digest }}
-        run: |
-          set -euo pipefail
-          if [ "${DRY_RUN}" = "true" ]; then
-            # No image was pushed; validate the util build against the current base.
-            echo "base=docker.io/gardendev/k8s-sync:${SYNC_CUR}" >> "$GITHUB_OUTPUT"
-          else
-            echo "base=docker.io/gardendev/k8s-sync:${SYNC_NEW}@${SYNC_DIGEST}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build and push k8s-util
-        id: util
-        if: ${{ inputs.rebuild_k8s }}
-        uses: docker/build-push-action@v6
-        with:
-          context: images/k8s-util
-          file: images/k8s-util/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ !inputs.dry_run }}
-          build-args: |
-            BASE_IMAGE=${{ steps.base.outputs.base }}
-          tags: docker.io/gardendev/k8s-util:${{ steps.tags.outputs.util_new }}
-
-      - name: Build and push buildkit
-        id: bk
-        if: ${{ inputs.rebuild_buildkit }}
-        uses: docker/build-push-action@v6
-        with:
-          context: images/buildkit
-          file: images/buildkit/Dockerfile
-          target: buildkit
-          platforms: linux/amd64,linux/arm64
-          push: ${{ !inputs.dry_run }}
-          tags: docker.io/gardendev/buildkit:${{ steps.tags.outputs.bk_new }}
-
-      - name: Build and push buildkit-rootless
-        id: bkr
-        if: ${{ inputs.rebuild_buildkit }}
-        uses: docker/build-push-action@v6
-        with:
-          context: images/buildkit
-          file: images/buildkit/Dockerfile
-          target: buildkit-rootless
-          platforms: linux/amd64,linux/arm64
-          push: ${{ !inputs.dry_run }}
-          tags: docker.io/gardendev/buildkit:${{ steps.tags.outputs.bkr_new }}
-
       - name: Update pinned digests in constants.ts
-        if: ${{ !inputs.dry_run }}
         env:
-          REBUILD_K8S: ${{ inputs.rebuild_k8s }}
-          REBUILD_BUILDKIT: ${{ inputs.rebuild_buildkit }}
-          SYNC_NEW: ${{ steps.tags.outputs.sync_new }}
-          UTIL_NEW: ${{ steps.tags.outputs.util_new }}
-          BK_NEW: ${{ steps.tags.outputs.bk_new }}
-          BKR_NEW: ${{ steps.tags.outputs.bkr_new }}
-          SYNC_DIGEST: ${{ steps.sync.outputs.digest }}
-          UTIL_DIGEST: ${{ steps.util.outputs.digest }}
-          BK_DIGEST: ${{ steps.bk.outputs.digest }}
-          BKR_DIGEST: ${{ steps.bkr.outputs.digest }}
+          REFS_JSON: ${{ toJSON(github.event.client_payload.refs) }}
         run: |
           set -euo pipefail
           args=()
-          if [ "${REBUILD_K8S}" = "true" ]; then
-            args+=("k8s-sync=gardendev/k8s-sync:${SYNC_NEW}@${SYNC_DIGEST}")
-            args+=("k8s-util=gardendev/k8s-util:${UTIL_NEW}@${UTIL_DIGEST}")
-          fi
-          if [ "${REBUILD_BUILDKIT}" = "true" ]; then
-            args+=("buildkit=gardendev/buildkit:${BK_NEW}@${BK_DIGEST}")
-            args+=("buildkit-rootless=gardendev/buildkit:${BKR_NEW}@${BKR_DIGEST}")
+          while IFS= read -r line; do
+            [ -n "$line" ] && args+=("$line")
+          done < <(jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "$REFS_JSON")
+          if [ "${#args[@]}" -eq 0 ]; then
+            echo "No image references in dispatch payload; nothing to update."
+            exit 1
           fi
           node support/update-util-image-digests.mjs "${args[@]}"
 
       - name: Open pull request
-        if: ${{ !inputs.dry_run }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -243,33 +184,14 @@ jobs:
           body: |
             Automated security rebuild of the Kubernetes utility images.
 
-            This PR updates the pinned `tag@sha256` references in
-            `core/src/plugins/kubernetes/constants.ts` to the freshly built and
-            pushed images. Review the digests, then merge to ship them with the
-            next release.
+            The images were rebuilt and pushed by CircleCI; this PR updates the
+            pinned `tag@sha256` references in
+            `core/src/plugins/kubernetes/constants.ts`. Review the digests, then
+            merge to ship them with the next release.
 
-            - k8s rebuilt: ${{ inputs.rebuild_k8s }}
-            - buildkit rebuilt: ${{ inputs.rebuild_buildkit }}
-            - triggered by: @${{ github.actor }}
+            - k8s rebuilt: ${{ github.event.client_payload.rebuild_k8s }}
+            - buildkit rebuilt: ${{ github.event.client_payload.rebuild_buildkit }}
+            - triggered by: @${{ github.event.client_payload.actor }}
 
             Note: the `release-tag` values in `images/*/garden.yml` are not bumped
             by this workflow and may lag the published tags.
-
-      - name: Dry-run summary
-        if: ${{ inputs.dry_run }}
-        env:
-          SYNC_NEW: ${{ steps.tags.outputs.sync_new }}
-          UTIL_NEW: ${{ steps.tags.outputs.util_new }}
-          BK_NEW: ${{ steps.tags.outputs.bk_new }}
-          BKR_NEW: ${{ steps.tags.outputs.bkr_new }}
-        run: |
-          set -euo pipefail
-          {
-            echo "## Dry run (no push, no PR)"
-            echo ""
-            echo "Computed tags:"
-            echo "- k8s-sync: \`${SYNC_NEW}\`"
-            echo "- k8s-util: \`${UTIL_NEW}\`"
-            echo "- buildkit: \`${BK_NEW}\`"
-            echo "- buildkit-rootless: \`${BKR_NEW}\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rebuild-utility-images.yml
+++ b/.github/workflows/rebuild-utility-images.yml
@@ -1,0 +1,275 @@
+name: Rebuild utility images
+
+# Manually-triggered security refresh for the digest-pinned Kubernetes utility
+# images that Garden injects into clusters. It rebuilds the images multi-arch,
+# pushes them to Docker Hub, and opens a PR that updates the pinned
+# tag@sha256 references in core/src/plugins/kubernetes/constants.ts.
+#
+# A human only needs to review/merge the PR; the new digests then ship with the
+# next normal Garden release. No local tooling required.
+#
+# Notes:
+# - k8s-util is built FROM the freshly pushed k8s-sync image (BASE_IMAGE arg).
+# - buildkit tracks the upstream moby/buildkit base, so a plain rebuild does not
+#   patch OS CVEs on its own; use the `buildkit_base` input to bump the pin.
+# - default-backend has no Dockerfile in this repo and cannot be rebuilt here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      rebuild_k8s:
+        description: "Rebuild k8s-sync + k8s-util"
+        type: boolean
+        default: true
+      rebuild_buildkit:
+        description: "Rebuild buildkit + buildkit-rootless"
+        type: boolean
+        default: false
+      tag_suffix:
+        description: "Override the numeric tag suffix (e.g. '2' -> 0.2.6-2). Default: auto-increment."
+        type: string
+        required: false
+        default: ""
+      buildkit_base:
+        description: "Optional new moby/buildkit base ref to bump the upstream pin, e.g. moby/buildkit:v0.24.0@sha256:..."
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: "Build only (no push, no PR)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: rebuild-utility-images
+  cancel-in-progress: false
+
+jobs:
+  build-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Compute new image tags
+        id: tags
+        env:
+          TAG_SUFFIX: ${{ inputs.tag_suffix }}
+        run: |
+          set -euo pipefail
+
+          read_tag() {
+            grep -E 'release-tag:' "$1" \
+              | sed -E 's/.*release-tag:[[:space:]]*([^[:space:]#]+).*/\1/'
+          }
+
+          # Increment the trailing numeric suffix, or append "-1" when there is
+          # none. A non-empty TAG_SUFFIX overrides the number.
+          next_tag() {
+            local cur="$1"
+            local last="${cur##*-}"
+            local base newnum
+            if [[ "$last" =~ ^[0-9]+$ ]]; then
+              base="${cur%-*}"
+              newnum=$((last + 1))
+            else
+              base="$cur"
+              newnum=1
+            fi
+            if [ -n "${TAG_SUFFIX}" ]; then
+              newnum="${TAG_SUFFIX}"
+            fi
+            printf '%s-%s' "$base" "$newnum"
+          }
+
+          sync_cur="$(read_tag images/k8s-sync/garden.yml | head -1)"
+          util_cur="$(read_tag images/k8s-util/garden.yml | head -1)"
+          bk_cur="$(read_tag images/buildkit/garden.yml | grep -v -- '-rootless' | head -1)"
+          bkr_cur="$(read_tag images/buildkit/garden.yml | grep -- '-rootless' | head -1)"
+
+          {
+            echo "sync_cur=${sync_cur}"
+            echo "sync_new=$(next_tag "$sync_cur")"
+            echo "util_new=$(next_tag "$util_cur")"
+            echo "bk_new=$(next_tag "$bk_cur")"
+            echo "bkr_new=$(next_tag "$bkr_cur")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Override buildkit base image
+        if: ${{ inputs.rebuild_buildkit && inputs.buildkit_base != '' }}
+        env:
+          BUILDKIT_BASE: ${{ inputs.buildkit_base }}
+        run: |
+          set -euo pipefail
+          ver="${BUILDKIT_BASE#moby/buildkit:}"
+          ver="${ver%@*}"
+          sed -i -E "s#^FROM moby/buildkit:[^ ]+ as buildkit\$#FROM ${BUILDKIT_BASE} as buildkit#" images/buildkit/Dockerfile
+          sed -i -E "s#^FROM moby/buildkit:[^ ]+ as buildkit-rootless\$#FROM moby/buildkit:${ver}-rootless as buildkit-rootless#" images/buildkit/Dockerfile
+          echo "Updated images/buildkit/Dockerfile base images:"
+          grep -E '^FROM moby/buildkit' images/buildkit/Dockerfile
+          echo "NOTE: the rootless base is pinned by tag only (no digest); review before merge."
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push k8s-sync
+        id: sync
+        if: ${{ inputs.rebuild_k8s }}
+        uses: docker/build-push-action@v6
+        with:
+          context: images/k8s-sync
+          file: images/k8s-sync/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ !inputs.dry_run }}
+          tags: docker.io/gardendev/k8s-sync:${{ steps.tags.outputs.sync_new }}
+
+      - name: Resolve k8s-util base image
+        id: base
+        if: ${{ inputs.rebuild_k8s }}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          SYNC_NEW: ${{ steps.tags.outputs.sync_new }}
+          SYNC_CUR: ${{ steps.tags.outputs.sync_cur }}
+          SYNC_DIGEST: ${{ steps.sync.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN}" = "true" ]; then
+            # No image was pushed; validate the util build against the current base.
+            echo "base=docker.io/gardendev/k8s-sync:${SYNC_CUR}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=docker.io/gardendev/k8s-sync:${SYNC_NEW}@${SYNC_DIGEST}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push k8s-util
+        id: util
+        if: ${{ inputs.rebuild_k8s }}
+        uses: docker/build-push-action@v6
+        with:
+          context: images/k8s-util
+          file: images/k8s-util/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ !inputs.dry_run }}
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.base }}
+          tags: docker.io/gardendev/k8s-util:${{ steps.tags.outputs.util_new }}
+
+      - name: Build and push buildkit
+        id: bk
+        if: ${{ inputs.rebuild_buildkit }}
+        uses: docker/build-push-action@v6
+        with:
+          context: images/buildkit
+          file: images/buildkit/Dockerfile
+          target: buildkit
+          platforms: linux/amd64,linux/arm64
+          push: ${{ !inputs.dry_run }}
+          tags: docker.io/gardendev/buildkit:${{ steps.tags.outputs.bk_new }}
+
+      - name: Build and push buildkit-rootless
+        id: bkr
+        if: ${{ inputs.rebuild_buildkit }}
+        uses: docker/build-push-action@v6
+        with:
+          context: images/buildkit
+          file: images/buildkit/Dockerfile
+          target: buildkit-rootless
+          platforms: linux/amd64,linux/arm64
+          push: ${{ !inputs.dry_run }}
+          tags: docker.io/gardendev/buildkit:${{ steps.tags.outputs.bkr_new }}
+
+      - name: Update pinned digests in constants.ts
+        if: ${{ !inputs.dry_run }}
+        env:
+          REBUILD_K8S: ${{ inputs.rebuild_k8s }}
+          REBUILD_BUILDKIT: ${{ inputs.rebuild_buildkit }}
+          SYNC_NEW: ${{ steps.tags.outputs.sync_new }}
+          UTIL_NEW: ${{ steps.tags.outputs.util_new }}
+          BK_NEW: ${{ steps.tags.outputs.bk_new }}
+          BKR_NEW: ${{ steps.tags.outputs.bkr_new }}
+          SYNC_DIGEST: ${{ steps.sync.outputs.digest }}
+          UTIL_DIGEST: ${{ steps.util.outputs.digest }}
+          BK_DIGEST: ${{ steps.bk.outputs.digest }}
+          BKR_DIGEST: ${{ steps.bkr.outputs.digest }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "${REBUILD_K8S}" = "true" ]; then
+            args+=("k8s-sync=gardendev/k8s-sync:${SYNC_NEW}@${SYNC_DIGEST}")
+            args+=("k8s-util=gardendev/k8s-util:${UTIL_NEW}@${UTIL_DIGEST}")
+          fi
+          if [ "${REBUILD_BUILDKIT}" = "true" ]; then
+            args+=("buildkit=gardendev/buildkit:${BK_NEW}@${BK_DIGEST}")
+            args+=("buildkit-rootless=gardendev/buildkit:${BKR_NEW}@${BKR_DIGEST}")
+          fi
+          node support/update-util-image-digests.mjs "${args[@]}"
+
+      - name: Open pull request
+        if: ${{ !inputs.dry_run }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: security/util-image-rebuild-${{ github.run_id }}
+          base: main
+          delete-branch: true
+          add-paths: |
+            core/src/plugins/kubernetes/constants.ts
+            images/buildkit/Dockerfile
+          commit-message: "chore(security): rebuild k8s utility images"
+          title: "chore(security): rebuild k8s utility images"
+          body: |
+            Automated security rebuild of the Kubernetes utility images.
+
+            This PR updates the pinned `tag@sha256` references in
+            `core/src/plugins/kubernetes/constants.ts` to the freshly built and
+            pushed images. Review the digests, then merge to ship them with the
+            next release.
+
+            - k8s rebuilt: ${{ inputs.rebuild_k8s }}
+            - buildkit rebuilt: ${{ inputs.rebuild_buildkit }}
+            - triggered by: @${{ github.actor }}
+
+            Note: the `release-tag` values in `images/*/garden.yml` are not bumped
+            by this workflow and may lag the published tags.
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        env:
+          SYNC_NEW: ${{ steps.tags.outputs.sync_new }}
+          UTIL_NEW: ${{ steps.tags.outputs.util_new }}
+          BK_NEW: ${{ steps.tags.outputs.bk_new }}
+          BKR_NEW: ${{ steps.tags.outputs.bkr_new }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dry run (no push, no PR)"
+            echo ""
+            echo "Computed tags:"
+            echo "- k8s-sync: \`${SYNC_NEW}\`"
+            echo "- k8s-util: \`${UTIL_NEW}\`"
+            echo "- buildkit: \`${BK_NEW}\`"
+            echo "- buildkit-rootless: \`${BKR_NEW}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/support/update-util-image-digests.mjs
+++ b/support/update-util-image-digests.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/*
+ * Rewrites the pinned gardendev utility-image references (tag@sha256 digest) in
+ * core/src/plugins/kubernetes/constants.ts.
+ *
+ * Invoked by the rebuild-utility-images workflow with one or more "name=ref"
+ * pairs. Supported names: k8s-sync, k8s-util, buildkit, buildkit-rootless.
+ *
+ *   node support/update-util-image-digests.mjs \
+ *     k8s-sync=gardendev/k8s-sync:0.2.6-2@sha256:<digest> \
+ *     k8s-util=gardendev/k8s-util:0.6.6-2@sha256:<digest>
+ *
+ * Each reference must keep the `<repo>:<tag>@sha256:<digest>` shape so the
+ * `DockerImageWithDigest` template-literal type in core/src/util/string.ts stays
+ * satisfied.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, resolve } from "node:path"
+
+const CONSTANTS_REL = "../core/src/plugins/kubernetes/constants.ts"
+
+// Per-image matchers for the existing `gardendev/<repo>:<tag>@sha256:<digest>`
+// literals. The buildkit matchers use the presence/absence of "rootless" in the
+// tag to disambiguate the two `gardendev/buildkit:` entries.
+const MATCHERS = {
+  "k8s-sync": /gardendev\/k8s-sync:[^"@\s]+@sha256:[0-9a-f]{64}/g,
+  "k8s-util": /gardendev\/k8s-util:[^"@\s]+@sha256:[0-9a-f]{64}/g,
+  "buildkit-rootless": /gardendev\/buildkit:[^"@\s]*rootless[^"@\s]*@sha256:[0-9a-f]{64}/g,
+  "buildkit": /gardendev\/buildkit:(?![^"@\s]*rootless)[^"@\s]+@sha256:[0-9a-f]{64}/g,
+}
+
+const REF_RE = /^gardendev\/[^:\s]+:[^@\s]+@sha256:[0-9a-f]{64}$/
+
+/**
+ * Apply the given { name: ref } replacements to the constants file content.
+ * Throws if a name is unknown, a ref is malformed, or a matcher finds nothing.
+ */
+export function updateConstants(content, pairs) {
+  // Apply the rootless buildkit entry before the non-rootless one for clarity;
+  // the matchers are mutually exclusive regardless of order.
+  const order = ["k8s-sync", "k8s-util", "buildkit-rootless", "buildkit"]
+  const names = order.filter((name) => name in pairs)
+
+  for (const name of names) {
+    const matcher = MATCHERS[name]
+    if (!matcher) {
+      throw new Error(`Unknown image name "${name}". Known: ${Object.keys(MATCHERS).join(", ")}`)
+    }
+
+    const ref = pairs[name].replace(/^docker\.io\//, "")
+    if (!REF_RE.test(ref)) {
+      throw new Error(`Invalid image reference for "${name}": "${ref}"`)
+    }
+
+    let count = 0
+    content = content.replace(matcher, () => {
+      count++
+      return ref
+    })
+    if (count === 0) {
+      throw new Error(`No existing reference found for "${name}" in constants.ts`)
+    }
+    console.log(`Updated ${name}: ${count} occurrence(s) -> ${ref}`)
+  }
+
+  return content
+}
+
+function parsePairs(argv) {
+  const pairs = {}
+  for (const arg of argv) {
+    const idx = arg.indexOf("=")
+    if (idx === -1) {
+      throw new Error(`Expected "name=ref" but got: "${arg}"`)
+    }
+    pairs[arg.slice(0, idx)] = arg.slice(idx + 1)
+  }
+  return pairs
+}
+
+function main() {
+  const argv = process.argv.slice(2)
+  if (argv.length === 0) {
+    console.error("Usage: node support/update-util-image-digests.mjs <name=ref> [<name=ref> ...]")
+    process.exit(1)
+  }
+
+  const pairs = parsePairs(argv)
+  const file = resolve(dirname(fileURLToPath(import.meta.url)), CONSTANTS_REL)
+  const original = readFileSync(file, "utf8")
+  const updated = updateConstants(original, pairs)
+
+  if (updated !== original) {
+    writeFileSync(file, updated)
+    console.log(`Wrote ${file}`)
+  } else {
+    console.log("No changes to write.")
+  }
+}
+
+// Only run main() when executed directly, so the module can be imported in tests.
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : ""
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main()
+}


### PR DESCRIPTION
﻿## Summary

Manually-triggerable security refresh for the digest-pinned Kubernetes utility images Garden injects into clusters (`k8s-sync`, `k8s-util`, `buildkit`, `buildkit-rootless`). Rebuilds them multi-arch, pushes to Docker Hub, and opens a PR updating the pinned `tag@sha256` references in `core/src/plugins/kubernetes/constants.ts`.

**Hybrid CI/CD** so the build reuses CircleCI's existing Docker Hub credentials (`docker` context) and the `gordon-garden-bot` PAT instead of provisioning new GitHub secrets:

- **GitHub Actions (`.github/workflows/rebuild-utility-images.yml`)** is the human entry point and the PR opener.
  - `workflow_dispatch` (`trigger` job): records inputs in `.circleci/rebuild-request.json` and pushes a throwaway `rebuild-utility-images-<run_id>` tag.
  - `repository_dispatch` / `util-images-rebuilt` (`open-pr` job): rewrites the pinned digests via `support/update-util-image-digests.mjs` and opens the PR.
- **CircleCI (`.circleci/continue-config.yml`)** is the build/push worker.
  - New `rebuild-utility-images` job + workflow, gated to the non-semver `rebuild-utility-images-*` tag (so the normal commit/main/tags workflows do **not** run — no wasted CI).
  - Sets up QEMU + a `docker-container` buildx builder, builds/pushes each image multi-arch, captures the index digests, and `repository_dispatch`es them back to GitHub.

### Inputs (`workflow_dispatch`)
- `rebuild_k8s` (default true) — rebuild `k8s-sync` + `k8s-util` (`k8s-util` is built `FROM` the freshly pushed `k8s-sync`).
- `rebuild_buildkit` (default false) — rebuild `buildkit` + `buildkit-rootless`.
- `tag_suffix` — override the numeric tag suffix (default: auto-increment).
- `buildkit_base` — optional new `moby/buildkit` base ref to bump the upstream pin (applied on both the CircleCI build and the PR's Dockerfile).
- `dry_run` (default false) — build only on CircleCI, no push / no PR.

## Notes / limitations
- A plain `buildkit` rebuild does not patch OS CVEs on its own (it tracks the upstream `moby/buildkit` base); use `buildkit_base` to bump the pin.
- `default-backend` has no Dockerfile in this repo and is out of scope.
- `release-tag` values in `images/*/garden.yml` are not bumped automatically.
- Trigger tags (`rebuild-utility-images-*`) accumulate and can be pruned periodically.

## Prerequisites
- Relies on the existing CircleCI project env var `GITHUB_TOKEN` (gordon-garden-bot PAT, already used by `github-release-tag`) and the `docker` context (`DOCKER_USER`/`DOCKER_PASS`). No new GitHub secrets needed.

## Test plan
- [x] Both YAML files parse (`js-yaml`).
- [x] `update-util-image-digests.mjs` rewrites all four pinned refs in `constants.ts`.
- [ ] One `dry_run` end-to-end: confirm CircleCI builds multi-arch and (for a real run) the digest dispatch opens a PR.
