### PR TITLE
fix(ci): make npm ci resilient to buf.build idle timeouts

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -143,7 +143,27 @@ commands:
               exit 1
             fi
 
-      - run: npm ci --prefer-offline --cache ~/.npm --no-audit
+      - run:
+          name: npm ci
+          # The @buf/* deps resolve from buf.build, whose large packument
+          # endpoint intermittently stalls and trips npm's idle timeout
+          # (EIDLETIMEOUT). Raise fetch retries/timeouts and retry the whole
+          # install a few times so a single slow response doesn't fail the job.
+          command: |
+            npm config set fetch-retries 5
+            npm config set fetch-retry-factor 2
+            npm config set fetch-retry-mintimeout 20000
+            npm config set fetch-retry-maxtimeout 120000
+            npm config set fetch-timeout 600000
+            n=0
+            until [ "$n" -ge 3 ]; do
+              npm ci --prefer-offline --cache ~/.npm --no-audit && exit 0
+              n=$((n + 1))
+              echo "npm ci failed (attempt ${n}/3); retrying in 15s..."
+              sleep 15
+            done
+            echo "npm ci failed after ${n} attempts"
+            exit 1
 
       - save_cache:
           key: npm-v7-<<parameters.context>>-{{ checksum "package-lock.json" }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1453,6 +1453,7 @@
     "core/node_modules/@buf/garden_grow-platform.bufbuild_es": {
       "version": "2.8.0-20251119201656-897f960f13d3.1",
       "resolved": "https://buf.build/gen/npm/v1/@buf/garden_grow-platform.bufbuild_es/-/garden_grow-platform.bufbuild_es-2.8.0-20251119201656-897f960f13d3.1.tgz",
+      "integrity": "sha512-lsingE/qni88DVrMI9VGr4D+RVzj60JICGYl3B2pxM524Y/EyyU3dwBA39SchJa0ZOivOF0T7zjWMcfopwpF8A==",
       "dependencies": {
         "@buf/bufbuild_protovalidate.bufbuild_es": "2.8.0-20250613105001-9f2d3c737feb.1"
       },
@@ -1462,6 +1463,8 @@
     },
     "core/node_modules/@buf/garden_grow-platform.bufbuild_es/node_modules/@buf/bufbuild_protovalidate.bufbuild_es": {
       "version": "2.8.0-20250613105001-9f2d3c737feb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.8.0-20250613105001-9f2d3c737feb.1.tgz",
+      "integrity": "sha512-obS5XopdZVyQ9UgN7L4gZzXjXrA+tzv6mrorvWGB0MX8oVFOCZZTCbxBs3+jemL4FepuM1xHw9iGOBDZJvOxww==",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.8.0"
       }


### PR DESCRIPTION
## Problem

`npm ci` fails intermittently across CI (the `build`/`commit` workflow), and it is currently failing **repo-wide, including on `main`**, with:

```
npm error code EIDLETIMEOUT
Invalid response body while trying to fetch
https://buf.build/gen/npm/v1/@buf%2fbufbuild_protovalidate.bufbuild_es:
Idle timeout reached for host `buf.build:443`
```

## Root cause

The `@buf/*` packages resolve from buf.build's BSR npm registry (see `.npmrc`). The lockfile was missing `resolved`/`integrity` for `@buf/garden_grow-platform.bufbuild_es` and its transitive `@buf/bufbuild_protovalidate.bufbuild_es`. Without those fields, `npm ci` cannot satisfy them from the CI cache and must fetch buf.build's **package metadata (packument) on every run**.

Measured from a dev machine:
- protovalidate **tarball**: HTTP 200, 32 KB, ~0.76s (fast)
- protovalidate **packument** (what npm hits): HTTP 200, **~1.6 MB**, ~1.3s

That large metadata transfer intermittently stalls under CI network/concurrency and trips npm's idle-socket timeout, failing the whole install. It's non-deterministic, so plain re-runs don't reliably clear it.

## Fix

1. **`package-lock.json`** — add `resolved` + `integrity` (computed from the published tarballs) for both `@buf` entries. npm can now install them directly from cache/tarball and skip the flaky packument lookup entirely.
2. **`.circleci/continue-config.yml`** — in the shared `npm_install` command, raise npm fetch retries/timeouts and retry `npm ci` up to 3× so a single slow response doesn't fail the job.

## Test plan

- [ ] `ci/circleci: build` is green on this PR.
- [ ] Confirm `npm ci` logs no longer hit the buf.build packument endpoint (served from cache via the new `integrity`).
- [ ] Unblocks other red PRs (e.g. #8080) once merged + rebased.
