### PR TITLE
fix(examples): bump kustomize ldap image to osixia/openldap:1.5.0 (1.1.11 deleted from Docker Hub)

### DIFF
--- a/examples/kustomize/ldap/base/deployment.yaml
+++ b/examples/kustomize/ldap/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ldap
-          image: osixia/openldap:1.1.11
+          image: osixia/openldap:1.5.0
           args: ["--copy-service"]
           volumeMounts:
             - name: ldap-data


### PR DESCRIPTION
## Problem

The `ci/circleci: e2e-kustomize` suite fails repo-wide (on `main` and every PR) because the kustomize example's LDAP Deployment can't pull its image:

```
Failed to pull image "osixia/openldap:1.1.11":
docker.io/osixia/openldap:1.1.11: not found
Error: ImagePullBackOff
```

The `osixia/openldap:1.1.11` tag was **deleted from Docker Hub**. The repo still exists (last updated 2026-04-27), but that specific tag now returns 404, so the pod never becomes ready and the e2e deploy fails.

## Fix

Bump `examples/kustomize/ldap/base/deployment.yaml` to `osixia/openldap:1.5.0` — the latest still-available `1.x` release. It keeps the same osixia/openldap config conventions this example relies on (`--copy-service`, the `/container/...` mount paths, `env.startup.txt` configmap), so no other changes are needed. (The `2.x` line changed its env/config conventions and would require rewriting the example.)

Available tags at time of writing: `2.6.10-alpha`, `latest`, `stable`, `1.5.0`, `1.4.0`, `1.3.0`, `1.2.5`, `1.2.4` — `1.1.11` is gone.

## Test plan

- [ ] `ci/circleci: e2e-kustomize` goes green (LDAP pod pulls `1.5.0` and becomes ready).
- [ ] Unblocks the `e2e-kustomize` gate for other PRs (e.g. #8080).
