### PR TITLE
fix(k8s): backport OS-patched k8s-util/k8s-sync images to 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.2.0
+  path-filtering: circleci/path-filtering@2.0.2
 
 # We are using a setup workflow here to filter based on the path of changed resources
 # and then continue the workflow with continue-config.yml based on the filters.
@@ -14,11 +14,6 @@ workflows:
       - path-filtering/filter:
           base-revision: "0.13"
           config-path: .circleci/continue-config.yml
-          # Set Python as 3.9 instead of default 3.8.
-          # Otherwise, this job fails with an error:
-          # ERROR: This script does not work on Python 3.8. The minimum supported Python version is 3.9. Please use https://bootstrap.pypa.io/pip/3.8/get-pip.py instead.
-          # See https://app.circleci.com/pipelines/github/garden-io/garden/30557/workflows/604a6d0e-fa95-499f-9326-4913225b7314/jobs/645108
-          tag: '3.9'
           mapping: |
             support/.* run-test-dockerhub true
             .circleci/.* run-test-dockerhub true

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -435,8 +435,8 @@ jobs:
 
   build-dist-macos:
     macos:
-      xcode: 15.0.0
-    resource_class: macos.m1.medium.gen1
+      xcode: "16.4.0"
+    resource_class: m4pro.medium
     parameters:
       version:
         description: The version tag/name to set
@@ -1108,9 +1108,9 @@ jobs:
 
   test-macos-x86-rosetta:
     macos:
-      xcode: "15.4.0"
+      xcode: "16.4.0"
     # We are testing x86 binaries under rosetta because CircleCI stopped supporting x86 macs.
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
     steps:
       # We are testing x86 binaries under rosetta because CircleCI stopped supporting x86 macs.
       - macos/install-rosetta
@@ -1170,8 +1170,8 @@ jobs:
 
   test-macos-arm:
     macos:
-      xcode: "15.4.0"
-    resource_class: macos.m1.medium.gen1
+      xcode: "16.4.0"
+    resource_class: m4pro.medium
     steps:
       - checkout
       - *attach-workspace

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -48,14 +48,14 @@ function makeImagePath({
 
 export function getK8sUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sUtilImageName: DockerImageWithDigest =
-    "gardendev/k8s-util:0.6.6-1@sha256:25bbd209a48fe01d8d8dd0b6d960c35f094f68db24c5148a1a69dc0a53162ce3"
+    "gardendev/k8s-util:0.6.6-2@sha256:851168cc038583932e5af3fa6b9965f54fb8df81d55884e4a4484d44001dc165"
 
   return makeImagePath({ imageName: k8sUtilImageName, registryDomain })
 }
 
 export function getK8sSyncUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sSyncUtilImageName: DockerImageWithDigest =
-    "gardendev/k8s-sync:0.2.6-1@sha256:ceca2b878a98ec2e6f2e959c50d5a789cfc159a3a74b46ce12d410a4f376567e"
+    "gardendev/k8s-sync:0.2.6-2@sha256:95e361564c2593483c3866436f36b7b2cecd8568fd6790a70e66023f780560e2"
 
   return makeImagePath({ imageName: k8sSyncUtilImageName, registryDomain })
 }

--- a/e2e/projects/vote-modules/result/Dockerfile
+++ b/e2e/projects/vote-modules/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.6-alpine
+FROM node:18-alpine
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/examples/kustomize/ldap/base/deployment.yaml
+++ b/examples/kustomize/ldap/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ldap
-          image: osixia/openldap:1.1.11
+          image: osixia/openldap:1.5.0
           args: ["--copy-service"]
           volumeMounts:
             - name: ldap-data

--- a/examples/vote/result/Dockerfile
+++ b/examples/vote/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.6-alpine
+FROM node:18-alpine
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
## Summary  Backports the OS security image rebuild from #8080 to the **0.13 (Bonsai)** line for an on-prem Garden Enterprise customer on Garden Core `0.13.62`.  Re-pins the utility images to the already-published, OS-patched digests:  | Image | Before | After | |-------|--------|-------| | `gardendev/k8s-util` | `0.6.6-1@sha256:25bbd209...` | `0.6.6-2@sha256:851168cc...` | | `gardendev/k8s-sync` | `0.2.6-1@sha256:ceca2b87...` | `0.2.6-2@sha256:95e36156...` |  These are the **same image tags the 0.13 line already uses** (introduced in `0.13.63`), rebuilt with `apk upgrade` for OS-level CVE fixes. The `-2` artifacts are identical to what ships on `main` today.  ## Why this is safe on 0.13  - **mutagen unchanged (`0.18.1`)** in `k8s-sync` across 0.13 and main, so dev-sync client/agent compatibility is preserved. - Remaining drift vs the old digests is non-Core-coupled and forward (alpine `3.21.3`╬ô├Ñ├å`3.22.1`, newer ECR/GCR cred helpers). - `k8s-reverse-proxy` and `buildkit` are intentionally left unchanged for this minimal security patch.  ## Release  Intended to ship as Garden Core **`0.13.64`** via the Start Release workflow (base branch `0.13`). Customer upgrades `0.13.62` ╬ô├Ñ├å `0.13.64` within the Bonsai line (no breaking changes).   ---  ### Also includes a required CI fix  The `0.13` CircleCI setup pinned Python `3.9` for the `path-filtering` orb, but `get-pip.py` now requires Python `3.10+`, which broke the `setup-workflow` for **all** `0.13` branches and tags (not just this PR). Bumped the orb `1.2.0` ├óΓÇáΓÇÖ `2.0.2` and dropped the version pin, matching `main`. This is also required for the `0.13.64` release tag to build. 

### Also fixes pre-existing 0.13 e2e rot (backported from main)

Unrelated to the digest re-pin, but required for a green pipeline / clean release:
- **e2e-kustomize**: `osixia/openldap` `1.1.11` → `1.5.0` (old tag was deleted from Docker Hub).
- **e2e-vote / e2e-vote-modules**: vote `result` example base `node:12.22.6-alpine` → `node:18-alpine` (node 12 can't parse modern JS shipped by the service's deps).

All four release-critical jobs (`build-dist-macos`, `build-dist-linux-windows`, `test-macos-arm`, `test-macos-x86-rosetta`) pass with the CI fixes above.