### PR TITLE
ci(0.13): support --yes flag in release.ts for CI

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -43,7 +43,7 @@ const rootPackageJsonPath = resolve(gardenRoot, "package.json")
  * 9. If we're making a minor release, update links to examples and re-push the tag.
  * 10. If this is not a pre-release, pushes the release branch to Github.
  *
- * Usage: ./scripts/release.ts <minor | patch | preminor | prepatch | prerelease> [--force] [--dry-run]
+ * Usage: ./scripts/release.ts <minor | patch | preminor | prepatch | prerelease> [--force] [--dry-run] [--yes]
  */
 async function release() {
   // Parse arguments
@@ -51,6 +51,7 @@ async function release() {
   const releaseType = <ReleaseType>argv._[0]
   const force = !!argv.force
   const dryRun = !!argv["dry-run"]
+  const skipPrompt = !!argv.yes || !!argv.y
 
   // Check if branch is clean
   try {
@@ -119,11 +120,15 @@ async function release() {
     }
   }
 
-  // Check if user wants to continue
-  const proceed = await prompt(version)
-  if (!proceed) {
-    await rollBack()
-    return
+  // Check if user wants to continue (skipped with --yes/-y for CI usage)
+  if (!skipPrompt) {
+    const proceed = await prompt(version)
+    if (!proceed) {
+      await rollBack()
+      return
+    }
+  } else {
+    console.log(`Skipping confirmation prompt (--yes flag set). Releasing ${version}...`)
   }
 
   // Pull remote tags


### PR DESCRIPTION
## Summary

The shared **Start Release** workflow runs `release.ts <type> --yes` non-interactively, but the `0.13` copy of `release.ts` never supported `--yes` and always called the interactive `confirm()` prompt. In CI this aborts with `ExitPromptError: User force closed the prompt`, which is why the `0.13.64` release run failed before tagging.

Backports the `--yes`/`-y` skip-prompt handling from `main` so `0.13` patch releases can be cut via the Start Release workflow. No behavior change for interactive use.

## Test plan
- [x] Lint clean
- [ ] Re-run Start Release (patch, base `0.13`) and confirm it tags `0.13.64`