### PR TITLE
fix(k8s): retry on Konnectivity tunnel "error dialing backend" errors

### DIFF
--- a/core/src/plugins/kubernetes/retry.ts
+++ b/core/src/plugins/kubernetes/retry.ts
@@ -213,4 +213,12 @@ const errorMessageRegexesForRetry = [
 
   // We get WebsocketError without HTTP status code on some API operations, e.g. exec in a pod
   /WebsocketError/,
+
+  // Seen on GKE (and other providers using a Konnectivity-style apiserver<->node proxy tunnel):
+  // the tunnel silently drops long-idle exec/portForward/watch connections, e.g. because of an
+  // intermediate load balancer's idle-connection timeout. The client only finds out on the next
+  // request over the same (now-dead) tunnel, which fails immediately with this error and no
+  // retry today, even though a fresh request over a new tunnel succeeds right away.
+  // See https://github.com/kubernetes/kubernetes/issues/110225
+  /error dialing backend/,
 ]

--- a/core/test/unit/src/plugins/kubernetes/retry.ts
+++ b/core/test/unit/src/plugins/kubernetes/retry.ts
@@ -21,6 +21,7 @@ const websocketError: ErrorEvent = {
 }
 const plainError = new Error("failed to refresh token")
 const syntaxError = new SyntaxError("invalid syntax")
+const dialBackendError = new Error("error dialing backend: dial tcp 10.0.0.5:10250: i/o timeout")
 
 describe("toKubernetesError", () => {
   it("should handle WebsocketError", () => {
@@ -61,5 +62,9 @@ describe("toKubernetesError", () => {
 describe("shouldRetry", () => {
   it("should retry WebsocketError", () => {
     expect(shouldRetry(websocketError, testKubeOp)).to.be.true
+  })
+
+  it("should retry Konnectivity tunnel 'error dialing backend' errors", () => {
+    expect(shouldRetry(dialBackendError, testKubeOp)).to.be.true
   })
 })


### PR DESCRIPTION
## What this PR does

Adds `error dialing backend` to the retryable error message patterns in `shouldRetry` (`core/src/plugins/kubernetes/retry.ts`), plus a unit test.

## Why

We run Garden against a GKE cluster, and developers regularly hit a confusing failure a few times a day: `garden deploy` (or `exec`/`portForward`) fails outright with something like:

```
Error while performing Kubernetes API operation readNamespace: Error

error dialing backend: dial tcp 10.x.x.x:10250: i/o timeout
```

with no retry attempted, and `garden.log`/`.garden/error.log` showing nothing useful because the failure never reaches application-level logging.

Root cause: on GKE (and other providers fronting the apiserver<->kubelet connection with a Konnectivity-style proxy tunnel), long-idle `exec`/`portForward`/watch connections get silently dropped once an intermediate load balancer's idle-connection timeout fires (GCP's is 10 minutes — see [kubernetes/kubernetes#110225](https://github.com/kubernetes/kubernetes/issues/110225) for the same symptom reported against the Konnectivity agent itself). The client only discovers this on the next request over the now-dead tunnel, which fails with `error dialing backend`.

Since every Kubernetes API call already goes through `requestWithRetry` (via the `wrapApi` proxy in `api.ts`), this is a one-line fix: `shouldRetry` just doesn't recognize this error text yet, so it throws on the very first attempt instead of retrying. A fresh request over a newly-established tunnel succeeds immediately — this is exactly the "some errors occur because of network issues, intermittent timeouts etc. and should be retried automatically" case the module's own doc comment describes, same class as the existing `ECONNRESET`/`socket hang up`/`WebsocketError` patterns.

Today, the practical workaround for users hitting this is to just re-run `garden deploy`, which works because it starts a fresh process/connection — this PR makes Garden do that retry internally instead.

## Testing

- Added a unit test in `core/test/unit/src/plugins/kubernetes/retry.ts` asserting `shouldRetry` returns `true` for an `error dialing backend` error, following the existing test pattern for `WebsocketError`.
- Verified the updated regex list against representative real-world error strings (including the exact `readNamespace` message shape from `toKubernetesError`) in isolation, confirming the new pattern matches while the existing "should not retry" case (`failed to refresh token`) is unaffected.
- Did not run the full monorepo test suite locally (this sandbox doesn't have the pinned Node 22.17.1 toolchain available); relying on CI to run the full unit test suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)