### PR TITLE
fix(k8s): backport OS-patched k8s-util/k8s-sync 0.6.6-3 images to 0.13

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -48,14 +48,14 @@ function makeImagePath({
 
 export function getK8sUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sUtilImageName: DockerImageWithDigest =
-    "gardendev/k8s-util:0.6.6-2@sha256:851168cc038583932e5af3fa6b9965f54fb8df81d55884e4a4484d44001dc165"
+    "gardendev/k8s-util:0.6.6-3@sha256:4f5dff114b584a5ef8654b0e62dd1a1f9351245c1e178bf8f347d03c79e696a4"
 
   return makeImagePath({ imageName: k8sUtilImageName, registryDomain })
 }
 
 export function getK8sSyncUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sSyncUtilImageName: DockerImageWithDigest =
-    "gardendev/k8s-sync:0.2.6-2@sha256:95e361564c2593483c3866436f36b7b2cecd8568fd6790a70e66023f780560e2"
+    "gardendev/k8s-sync:0.2.6-3@sha256:0917f6f248ea8c41243933400726ae4da0305a14e364b50dee67511c773b22a9"
 
   return makeImagePath({ imageName: k8sSyncUtilImageName, registryDomain })
 }


### PR DESCRIPTION
## Summary
Backports the OS security image rebuild to the **0.13 (Bonsai)** line for the on-prem Garden Enterprise customer currently on Garden Core `0.13.64`.

Re-pins the utility images to the already-published, OS-patched digests:

| Image | Before | After |
|-------|--------|-------|
| `gardendev/k8s-util` | `0.6.6-2@sha256:851168cc...` | `0.6.6-3@sha256:4f5dff11...` |
| `gardendev/k8s-sync` | `0.2.6-2@sha256:95e36156...` | `0.2.6-3@sha256:0917f6f2...` |

These are the same image tags the 0.13 line already uses (from `0.13.64`), rebuilt with `apk upgrade` so Alpine packages pick up OpenSSL 3.5.7-r0 (Critical CVE-2026-34182 and related Highs) and p11-kit 0.26.2-r0 (CVE-2026-2100). Mutagen is unchanged.

## Release
Intended to ship as Garden Core **`0.13.65`** via the Start Release workflow (base branch `0.13`). When publishing the GitHub release, it must **not** be marked as latest (`--latest=false`) so the installer keeps pointing at 0.14.x.

## Test plan
- [ ] Confirm `gardendev/k8s-util:0.6.6-3` and `gardendev/k8s-sync:0.2.6-3` exist on Docker Hub
- [ ] Confirm digest pins match Hub manifest-list digests
- [ ] After merge: Start Release (patch, base `0.13`), then publish the draft with `--latest=false`
