### PR TITLE
chore(security): rebuild k8s utility images

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -48,14 +48,14 @@ function makeImagePath({
 
 export function getK8sUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sUtilImageName: DockerImageWithDigest =
-    "gardendev/k8s-util:0.6.6-2@sha256:851168cc038583932e5af3fa6b9965f54fb8df81d55884e4a4484d44001dc165"
+    "gardendev/k8s-util:0.6.6-3@sha256:4f5dff114b584a5ef8654b0e62dd1a1f9351245c1e178bf8f347d03c79e696a4"
 
   return makeImagePath({ imageName: k8sUtilImageName, registryDomain })
 }
 
 export function getK8sSyncUtilImagePath(registryDomain: string): DockerImageWithDigest {
   const k8sSyncUtilImageName: DockerImageWithDigest =
-    "gardendev/k8s-sync:0.2.6-2@sha256:95e361564c2593483c3866436f36b7b2cecd8568fd6790a70e66023f780560e2"
+    "gardendev/k8s-sync:0.2.6-3@sha256:0917f6f248ea8c41243933400726ae4da0305a14e364b50dee67511c773b22a9"
 
   return makeImagePath({ imageName: k8sSyncUtilImageName, registryDomain })
 }


### PR DESCRIPTION
## Summary
Re-pins the Kubernetes utility images to the OS-patched rebuild that CircleCI just pushed (`apk upgrade` of Alpine packages). The auto-PR step of the rebuild workflow failed (GitHub Actions is not permitted to create PRs in this repo), so this PR is opened from the branch that job already pushed.

| Image | Before | After |
|-------|--------|-------|
| `gardendev/k8s-util` | `0.6.6-2@sha256:851168cc...` | `0.6.6-3@sha256:4f5dff11...` |
| `gardendev/k8s-sync` | `0.2.6-2@sha256:95e36156...` | `0.2.6-3@sha256:0917f6f2...` |

Clears residual Alpine CVEs on the June `0.6.6-2` image (OpenSSL 3.5.6 → 3.5.7, including Critical CVE-2026-34182; p11-kit 0.25.5 → 0.26.2). No functional/behavioral change; mutagen is unchanged.

Triggered by workflow run https://github.com/garden-io/garden/actions/runs/32698406277 (tag suffix `3`, k8s only, not dry-run). Digests confirmed against Docker Hub manifest lists.

## Test plan
- [ ] Confirm tags `gardendev/k8s-util:0.6.6-3` and `gardendev/k8s-sync:0.2.6-3` exist on Docker Hub
- [ ] Confirm digest pins match the Hub index digests
- [ ] Follow-up: backport the same pins to `0.13` and ship as `0.13.65` (do **not** mark that GitHub release as latest)
